### PR TITLE
Feature: SASL Auth (PLAIN and SCRAM)

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ $ docker exec -it lensesio bash
 (inside container)$ kafka-topics --create --topic xk6_kafka_json_topic --bootstrap-server localhost:9092
 ```
 
+If you want to test SASL authentication, have a look at (this commmit message)[https://github.com/mostafa/xk6-kafka/pull/3/commits/216ee0cd4f69864cb259445819541ef34fe2f2dd], where I describe how to run a test environment.
+
 ### k6 Test
 
 The following k6 test script is used to test this extension and Apache Kafka in turn. The script is available as `test_<format>.js` with more code and commented sections. The scripts have 4 parts:

--- a/auth.go
+++ b/auth.go
@@ -1,0 +1,64 @@
+package kafka
+
+import (
+	"encoding/json"
+	"time"
+
+	kafkago "github.com/segmentio/kafka-go"
+	"github.com/segmentio/kafka-go/sasl/plain"
+	"github.com/segmentio/kafka-go/sasl/scram"
+)
+
+const (
+	Plain  = "plain"
+	SHA256 = "sha256"
+	SHA512 = "sha512"
+)
+
+type Credentials struct {
+	Username  string `json:"username"`
+	Password  string `json:"password"`
+	Algorithm string `json:"algorithm"`
+}
+
+func unmarshalCredentials(auth string) (creds *Credentials, err error) {
+	creds = &Credentials{
+		Algorithm: Plain,
+	}
+
+	err = json.Unmarshal([]byte(auth), &creds)
+
+	return
+}
+
+func getDialer(creds *Credentials) (dialer *kafkago.Dialer) {
+	dialer = &kafkago.Dialer{
+		Timeout:   10 * time.Second,
+		DualStack: true,
+	}
+
+	if creds.Algorithm == Plain {
+		mechanism := plain.Mechanism{
+			Username: creds.Username,
+			Password: creds.Password,
+		}
+		dialer.SASLMechanism = mechanism
+		return
+	} else {
+		hashes := make(map[string]scram.Algorithm)
+		hashes["sha256"] = scram.SHA256
+		hashes["sha512"] = scram.SHA512
+
+		mechanism, err := scram.Mechanism(
+			hashes[creds.Algorithm],
+			creds.Username,
+			creds.Password,
+		)
+		if err != nil {
+			ReportError(err, "authentication failed")
+			return nil
+		}
+		dialer.SASLMechanism = mechanism
+		return
+	}
+}

--- a/consumer.go
+++ b/consumer.go
@@ -6,10 +6,10 @@ import (
 	"io"
 	"time"
 
+	kafkago "github.com/segmentio/kafka-go"
 	"go.k6.io/k6/js/modules"
 	"go.k6.io/k6/lib"
 	"go.k6.io/k6/stats"
-	kafkago "github.com/segmentio/kafka-go"
 )
 
 func init() {
@@ -19,22 +19,31 @@ func init() {
 type Kafka struct{}
 
 func (*Kafka) Reader(
-	brokers []string, topic string, partition int,
-	minBytes int, maxBytes int, offset int64) *kafkago.Reader {
+	brokers []string, topic string, partition int, offset int64, auth string) *kafkago.Reader {
+	var dialer *kafkago.Dialer
 
-	if maxBytes == 0 {
-		maxBytes = 10e6 // 10MB
+	if auth != "" {
+		creds, err := unmarshalCredentials(auth)
+		if err != nil {
+			ReportError(err, "Unable to unmarshal credentials")
+			return nil
+		}
+
+		dialer = getDialer(creds)
+		if dialer == nil {
+			ReportError(nil, "Dialer cannot authenticate")
+			return nil
+		}
 	}
 
 	reader := kafkago.NewReader(kafkago.ReaderConfig{
 		Brokers:          brokers,
 		Topic:            topic,
 		Partition:        partition,
-		MinBytes:         minBytes,
-		MaxBytes:         maxBytes,
 		MaxWait:          time.Millisecond * 200,
 		RebalanceTimeout: time.Second * 5,
 		QueueCapacity:    1,
+		Dialer:           dialer,
 	})
 
 	if offset > 0 {
@@ -102,7 +111,7 @@ func (*Kafka) Consume(
 
 func ReportReaderStats(ctx context.Context, currentStats kafkago.ReaderStats) error {
 	state := lib.GetState(ctx)
-	err := errors.New("State is nil")
+	err := errors.New("state is nil")
 
 	if state == nil {
 		ReportError(err, "Cannot determine state")

--- a/producer.go
+++ b/producer.go
@@ -10,12 +10,30 @@ import (
 	"go.k6.io/k6/stats"
 )
 
-func (*Kafka) Writer(brokers []string, topic string) *kafkago.Writer {
+func (*Kafka) Writer(brokers []string, topic string, auth string) *kafkago.Writer {
+	var dialer *kafkago.Dialer
+
+	if auth != "" {
+		creds, err := unmarshalCredentials(auth)
+		if err != nil {
+			ReportError(err, "Unable to unmarshal credentials")
+			return nil
+		}
+
+		dialer = getDialer(creds)
+		if dialer == nil {
+			ReportError(nil, "Dialer cannot authenticate")
+			return nil
+		}
+	}
+
 	return kafkago.NewWriter(kafkago.WriterConfig{
 		Brokers:   brokers,
 		Topic:     topic,
 		Balancer:  &kafkago.LeastBytes{},
 		BatchSize: 1,
+		Dialer:    dialer,
+		Async:     false,
 	})
 }
 
@@ -23,7 +41,7 @@ func (*Kafka) Produce(
 	ctx context.Context, writer *kafkago.Writer, messages []map[string]string,
 	keySchema string, valueSchema string) error {
 	state := lib.GetState(ctx)
-	err := errors.New("State is nil")
+	err := errors.New("state is nil")
 
 	if state == nil {
 		ReportError(err, "Cannot determine state")
@@ -66,7 +84,7 @@ func (*Kafka) Produce(
 
 func ReportWriterStats(ctx context.Context, currentStats kafkago.WriterStats) error {
 	state := lib.GetState(ctx)
-	err := errors.New("State is nil")
+	err := errors.New("state is nil")
 
 	if state == nil {
 		ReportError(err, "Cannot determine state")

--- a/test_avro.js
+++ b/test_avro.js
@@ -1,7 +1,7 @@
 /*
 
 This is a k6 test script that imports the xk6-kafka and
-tests Kafka with a 100 Avro messages per iteration.
+tests Kafka with a 200 Avro messages per iteration.
 
 */
 
@@ -36,60 +36,60 @@ const valueSchema = JSON.stringify({
     "name": "Value",
     "namespace": "dev.mostafa.xk6.kafka",
     "fields": [{
-            "name": "name",
-            "type": "string"
-        },
-        {
-            "name": "version",
-            "type": "string"
-        },
-        {
-            "name": "author",
-            "type": "string"
-        },
-        {
-            "name": "description",
-            "type": "string"
-        },
-        {
-            "name": "url",
-            "type": "string"
-        },
-        {
-            "name": "index",
-            "type": "int"
-        }
+        "name": "name",
+        "type": "string"
+    },
+    {
+        "name": "version",
+        "type": "string"
+    },
+    {
+        "name": "author",
+        "type": "string"
+    },
+    {
+        "name": "description",
+        "type": "string"
+    },
+    {
+        "name": "url",
+        "type": "string"
+    },
+    {
+        "name": "index",
+        "type": "int"
+    }
     ]
 });
 
 export default function () {
     for (let index = 0; index < 100; index++) {
         let messages = [{
-                key: JSON.stringify({
-                    "correlationId": "test-id-abc-" + index
-                }),
-                value: JSON.stringify({
-                    "name": "xk6-kafka",
-                    "version": "0.2.1",
-                    "author": "Mostafa Moradian",
-                    "description": "k6 extension to load test Apache Kafka with support for Avro messages",
-                    "url": "https://mostafa.dev",
-                    "index": index
-                })
-            },
-            {
-                key: JSON.stringify({
-                    "correlationId": "test-id-def-" + index
-                }),
-                value: JSON.stringify({
-                    "name": "xk6-kafka",
-                    "version": "0.2.1",
-                    "author": "Mostafa Moradian",
-                    "description": "k6 extension to load test Apache Kafka with support for Avro messages",
-                    "url": "https://mostafa.dev",
-                    "index": index
-                })
-            }
+            key: JSON.stringify({
+                "correlationId": "test-id-abc-" + index
+            }),
+            value: JSON.stringify({
+                "name": "xk6-kafka",
+                "version": "0.2.1",
+                "author": "Mostafa Moradian",
+                "description": "k6 extension to load test Apache Kafka with support for Avro messages",
+                "url": "https://mostafa.dev",
+                "index": index
+            })
+        },
+        {
+            key: JSON.stringify({
+                "correlationId": "test-id-def-" + index
+            }),
+            value: JSON.stringify({
+                "name": "xk6-kafka",
+                "version": "0.2.1",
+                "author": "Mostafa Moradian",
+                "description": "k6 extension to load test Apache Kafka with support for Avro messages",
+                "url": "https://mostafa.dev",
+                "index": index
+            })
+        }
         ]
         let error = produce(producer, messages, keySchema, valueSchema);
         check(error, {

--- a/test_sasl_auth.js
+++ b/test_sasl_auth.js
@@ -1,7 +1,8 @@
 /*
 
 This is a k6 test script that imports the xk6-kafka and
-tests Kafka with a 200 JSON messages per iteration.
+tests Kafka with a 200 JSON messages per iteration. It
+also uses SASL authentication.
 
 */
 
@@ -17,9 +18,19 @@ import {
 
 const bootstrapServers = ["localhost:9092"];
 const kafkaTopic = "xk6_kafka_json_topic";
+const auth = JSON.stringify({
+    username: "client",
+    password: "client-secret",
+    // Possible values for the algorithm is:
+    // SASL Plain: "plain" (default if omitted)
+    // SASL SCRAM: "sha256", "sha512"
+    algorithm: "sha256"
+})
+const offset = 0;
+const partition = 1;
 
-const producer = writer(bootstrapServers, kafkaTopic);
-const consumer = reader(bootstrapServers, kafkaTopic);
+const producer = writer(bootstrapServers, kafkaTopic, auth);
+const consumer = reader(bootstrapServers, kafkaTopic, offset, partition, auth);
 
 export default function () {
     for (let index = 0; index < 100; index++) {


### PR DESCRIPTION
**Description:**
This PR adds support for SASL Auth, both `PLAIN` and `SCRAM`.

**Tests:**
~I bumped into this [issue](https://github.com/edenhill/librdkafka/issues/1584) while testing the current implementation, which might be a configuration issue on Kafka/Zookeeper. Till then, it needs more testing.~
I was able to test this feature after some fixes and a proper test environment. I added a `test_sasl_auth.js` file that shows how to configure reader and writer for SASL authentication. Refer to https://github.com/mostafa/xk6-kafka/issues/2#issuecomment-851002005.

**Issue:**
https://github.com/mostafa/xk6-kafka/issues/2