### PR TITLE
Experimental support for Confluent Cloud

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@
 # Dependency directories (remove the comment below to include it)
 vendor/
 k6
+.idea

--- a/consumer.go
+++ b/consumer.go
@@ -78,6 +78,7 @@ func (*Kafka) Consume(
 		}
 
 		message := make(map[string]interface{})
+        msg.Key = msg.Key[5:len(msg.Key)]
 		if len(msg.Key) > 0 {
 			message["key"] = string(msg.Key)
 			if keySchema != "" {
@@ -85,6 +86,7 @@ func (*Kafka) Consume(
 			}
 		}
 
+        msg.Value = msg.Value[5:len(msg.Value)]
 		if len(msg.Value) > 0 {
 			message["value"] = string(msg.Value)
 			if valueSchema != "" {

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.14
 
 require (
 	github.com/dustin/go-humanize v1.0.1-0.20200219035652-afde56e7acac // indirect
+	github.com/k6io/xk6 v0.4.1 // indirect
 	github.com/linkedin/goavro/v2 v2.9.8
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/segmentio/kafka-go v0.3.6

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/BurntSushi/xgb v0.0.0-20160522181843-27f122750802/go.mod h1:IVnqGOEym
 github.com/DataDog/datadog-go v0.0.0-20180330214955-e67964b4021a/go.mod h1:LButxg5PwREeZtORoXG3tL4fMGNddJ+vMq1mwgfaqoQ=
 github.com/GeertJohan/go.rice v0.0.0-20170420135705-c02ca9a983da h1:UVU3a9pRUyLdnBtn60WjRl0s4SEyJc2ChCY56OAR6wI=
 github.com/GeertJohan/go.rice v0.0.0-20170420135705-c02ca9a983da/go.mod h1:DgrzXonpdQbfN3uYaGz1EG4Sbhyum/MMIn6Cphlh2bw=
+github.com/Masterminds/semver/v3 v3.1.0 h1:Y2lUDsFKVRSYGojLJ1yLxSXdMmMYTYls0rCvoqmMUQk=
+github.com/Masterminds/semver/v3 v3.1.0/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=
 github.com/PuerkitoBio/goquery v1.3.0/go.mod h1:T9ezsOHcCrDCgA8aF1Cqr3sSYbO/xgdy8/R/XiIMAhA=
 github.com/PuerkitoBio/goquery v1.6.1 h1:FgjbQZKl5HTmcn4sKBgvx8vv63nhyhIpv7lJpFGCWpk=
@@ -181,6 +183,8 @@ github.com/jstemmer/go-junit-report v0.0.0-20190106144839-af01ea7f8024/go.mod h1
 github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
 github.com/julienschmidt/httprouter v1.1.1-0.20180222160526-d18983907793/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
 github.com/julienschmidt/httprouter v1.2.0/go.mod h1:SYymIcj16QtmaHHD7aYtjjsJG7VTCxuUUipMqKk8s4w=
+github.com/k6io/xk6 v0.4.1 h1:O0O1raTV6XrkD+WvLj/qXrstEG+wOpu3vpalzuJOGZI=
+github.com/k6io/xk6 v0.4.1/go.mod h1:QS8YtgA0CTJId5eYwHE41n25y4cnhXbxHXTwWQC8Heg=
 github.com/k6io/xk6-output-kafka v0.1.1/go.mod h1:FEnBddwavknsQ3/tGFW0CP9ABAVMyimlJdLgyT1BDPE=
 github.com/k6io/xk6-output-kafka v0.1.2-0.20210510135110-a159d7c8c171/go.mod h1:fgsOfxm/erON/jKuOBL8/TceTnAZPQ1OS8A7cPhrso8=
 github.com/k6io/xk6-output-kafka v0.2.0/go.mod h1:yoiecpPwfa3F/UVl8k2scJ0xkZqRYu6Ht1XqohXnlXA=

--- a/producer.go
+++ b/producer.go
@@ -43,8 +43,8 @@ func (*Kafka) Produce(
 		}
 
 		kafkaMessages[i] = kafkago.Message{
-			Key:   key,
-			Value: value,
+			Key:   append([]byte{ 0, 0, 0, 0, 3 }, key...),
+			Value: append([]byte{ 0, 0, 0, 0, 4 }, value...),
 		}
 	}
 

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,5 @@
+```
+$ xk6 build v0.32.0 --with github.com/mostafa/xk6-kafka="."
+$ ./k6 run --vus 1 --duration 1s test/test.js
+```
+

--- a/test/schema/key.avro
+++ b/test/schema/key.avro
@@ -1,0 +1,11 @@
+{
+  "name": "KeySchema",
+  "type": "record",
+  "namespace": "com.example",
+  "fields": [
+    {
+      "name": "ssn",
+      "type": "string"
+    }
+  ]
+}

--- a/test/schema/value.avro
+++ b/test/schema/value.avro
@@ -1,0 +1,15 @@
+{
+  "name": "ValueSchema",
+  "type": "record",
+  "namespace": "com.example",
+  "fields": [
+    {
+      "name": "firstname",
+      "type": "string"
+    },
+    {
+      "name": "lastname",
+      "type": "string"
+    }
+  ]
+}

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,54 @@
+/*
+This is a k6 test script that imports the xk6-kafka and
+tests Kafka with a 100 Avro messages per iteration.
+*/
+
+import {
+    check
+} from 'k6';
+import {
+    writer,
+    produce,
+    reader,
+    consume
+} from 'k6/x/kafka'; // import kafka extension
+
+const bootstrapServers = ["localhost:9092"];
+const topic = "com.example.person";
+
+const producer = writer(bootstrapServers, topic);
+const consumer = reader(bootstrapServers, topic);
+
+const keySchema = open('schema/key.avro');
+const valueSchema = open('schema/value.avro');
+
+export default function () {
+    for (let index = 0; index < 1; index++) {
+        let messages = [{
+            key: JSON.stringify({
+                "ssn": "ssn-" + index,
+            }),
+            value: JSON.stringify({
+                    "firstname": "firstname-" + index,
+                    "lastname": "lastname-" + index,
+            }),
+        }]
+        let error = produce(producer, messages, keySchema, valueSchema);
+        check(error, {
+            "is sent": err => err == undefined
+        });
+    }
+
+    //Read 10 messages only
+    let messages = consume(consumer, 1, keySchema, valueSchema);
+    console.log('messages ', JSON.stringify(messages))
+    check(messages, {
+        "10 messages returned": msgs => msgs.length == 1
+    })
+
+}
+
+export function teardown(data) {
+    producer.close();
+    consumer.close();
+}


### PR DESCRIPTION
Confluent Platform uses serializers/deserializers that add/expect a custom 5-byte prefix before the Avro payload: https://docs.confluent.io/platform/current/schema-registry/serdes-develop/index.html#wire-format

This is currently not supported by your extension. 

I have drafted a PR that shows how to fix that:

- add 5-byte prefix in the producer
- remove 5-byte prefix in the consumer

I've also added a test case:
- spin up a local instance of Confluent Platform
- create the topic `com.example.person`
- register the key and value schema
- adjust the schema id in `producer#Produce` according to the IDs that have been assigned to the registered schemas
- run `./k6 run --vus 1 --duration 1s test/test.js`

The PR can't be merged as is (e.g., I have hard-coded the schema IDs). I would like to start a conversation whether you want to add support for Confluent Platform. I'm happy to contribute a "polished PR" if you are open to the idea. 
