### PR TITLE
Allow producing messages without specifying a Key

### DIFF
--- a/producer.go
+++ b/producer.go
@@ -106,6 +106,8 @@ func ProduceInternal(
 			}
 
 			kafkaMessages[i].Key = keyData
+		} else {
+			kafkaMessages[i].Key = nil
 		}
 
 		// Then add then message

--- a/producer.go
+++ b/producer.go
@@ -106,8 +106,6 @@ func ProduceInternal(
 			}
 
 			kafkaMessages[i].Key = keyData
-		} else {
-			kafkaMessages[i].Key = nil
 		}
 
 		// Then add then message

--- a/scripts/test_avro_no_key.js
+++ b/scripts/test_avro_no_key.js
@@ -81,10 +81,14 @@ export default function () {
     }
 
     // Read 10 messages only
-    let messages = consume(consumer, 10, null, valueSchema);
-    check(messages, {
+    let rx_messages = consume(consumer, 10, null, valueSchema);
+    check(rx_messages, {
         "10 messages returned": (msgs) => msgs.length == 10,
     });
+
+    for (let index = 0; index < rx_messages.length; index++) {
+        console.debug('Received Message: ' + JSON.stringify(rx_messages[index]));
+    }
 }
 
 export function teardown(data) {

--- a/scripts/test_avro_no_key.js
+++ b/scripts/test_avro_no_key.js
@@ -1,0 +1,93 @@
+/*
+
+This is a k6 test script that imports the xk6-kafka and
+tests Kafka by sending 200 Avro messages per iteration
+without any associated key.
+*/
+
+import { check } from "k6";
+import { writer, produce, reader, consume, createTopic } from "k6/x/kafka"; // import kafka extension
+
+const bootstrapServers = ["localhost:9092"];
+const kafkaTopic = "xk6_kafka_avro_topic";
+
+const producer = writer(bootstrapServers, kafkaTopic);
+const consumer = reader(bootstrapServers, kafkaTopic);
+
+const valueSchema = JSON.stringify({
+    type: "record",
+    name: "Value",
+    namespace: "dev.mostafa.xk6.kafka",
+    fields: [
+        {
+            name: "name",
+            type: "string",
+        },
+        {
+            name: "version",
+            type: "string",
+        },
+        {
+            name: "author",
+            type: "string",
+        },
+        {
+            name: "description",
+            type: "string",
+        },
+        {
+            name: "url",
+            type: "string",
+        },
+        {
+            name: "index",
+            type: "int",
+        },
+    ],
+});
+
+createTopic(bootstrapServers[0], kafkaTopic);
+
+export default function () {
+    for (let index = 0; index < 100; index++) {
+        let messages = [
+            {
+                value: JSON.stringify({
+                    name: "xk6-kafka",
+                    version: "0.2.1",
+                    author: "Mostafa Moradian",
+                    description:
+                        "k6 extension to load test Apache Kafka with support for Avro messages",
+                    url: "https://mostafa.dev",
+                    index: index,
+                }),
+            },
+            {
+                value: JSON.stringify({
+                    name: "xk6-kafka",
+                    version: "0.2.1",
+                    author: "Mostafa Moradian",
+                    description:
+                        "k6 extension to load test Apache Kafka with support for Avro messages",
+                    url: "https://mostafa.dev",
+                    index: index,
+                }),
+            },
+        ];
+        let error = produce(producer, messages, null, valueSchema);
+        check(error, {
+            "is sent": (err) => err == undefined,
+        });
+    }
+
+    // Read 10 messages only
+    let messages = consume(consumer, 10, null, valueSchema);
+    check(messages, {
+        "10 messages returned": (msgs) => msgs.length == 10,
+    });
+}
+
+export function teardown(data) {
+    producer.close();
+    consumer.close();
+}

--- a/scripts/test_avro_with_schema_registry_no_key.js
+++ b/scripts/test_avro_with_schema_registry_no_key.js
@@ -73,16 +73,20 @@ export default function () {
         });
     }
 
-    let messages = consumeWithConfiguration(
+    let rx_messages = consumeWithConfiguration(
         consumer,
         20,
         configuration,
         null,
         valueSchema
     );
-    check(messages, {
+    check(rx_messages, {
         "20 message returned": (msgs) => msgs.length == 20,
     });
+
+    for (let index = 0; index < rx_messages.length; index++) {
+        console.debug('Received Message: ' + JSON.stringify(rx_messages[index]));
+    }
 }
 
 export function teardown(data) {

--- a/scripts/test_avro_with_schema_registry_no_key.js
+++ b/scripts/test_avro_with_schema_registry_no_key.js
@@ -1,0 +1,91 @@
+/*
+This is a k6 test script that imports the xk6-kafka and
+tests Kafka with a 100 Avro messages per iteration.
+*/
+
+import { check } from "k6";
+import {
+    writer,
+    reader,
+    consumeWithConfiguration,
+    produceWithConfiguration,
+    createTopic,
+} from "k6/x/kafka"; // import kafka extension
+
+const bootstrapServers = ["localhost:9092"];
+const topic = "com.example.person";
+
+const producer = writer(bootstrapServers, topic, null);
+const consumer = reader(bootstrapServers, topic, null, "", null, null);
+
+const valueSchema = `{
+  "name": "ValueSchema",
+  "type": "record",
+  "namespace": "com.example",
+  "fields": [
+    {
+      "name": "firstname",
+      "type": "string"
+    },
+    {
+      "name": "lastname",
+      "type": "string"
+    }
+  ]
+}`;
+
+var configuration = JSON.stringify({
+    consumer: {
+        keyDeserializer: "",
+        valueDeserializer:
+            "io.confluent.kafka.serializers.KafkaAvroDeserializer",
+    },
+    producer: {
+        keySerializer: "",
+        valueSerializer: "io.confluent.kafka.serializers.KafkaAvroSerializer",
+    },
+    schemaRegistry: {
+        url: "http://localhost:8081",
+    },
+});
+
+createTopic(bootstrapServers[0], topic);
+
+export default function () {
+    for (let index = 0; index < 100; index++) {
+        let messages = [
+            {
+                value: JSON.stringify({
+                    firstname: "firstname-" + index,
+                    lastname: "lastname-" + index,
+                }),
+            },
+        ];
+        let error = produceWithConfiguration(
+            producer,
+            messages,
+            configuration,
+            null,
+            valueSchema
+        );
+        check(error, {
+            "is sent": (err) => err == undefined,
+        });
+    }
+
+    let messages = consumeWithConfiguration(
+        consumer,
+        20,
+        configuration,
+        null,
+        valueSchema
+    );
+    check(messages, {
+        "20 message returned": (msgs) => msgs.length == 20,
+    });
+}
+
+export function teardown(data) {
+    producer.close();
+    consumer.close();
+}


### PR DESCRIPTION
According to [1], Keys are optional. With this change, by not setting a
key for a message it will be considered null.

Example:
~~~
        let messages = [
            {
                value: JSON.stringify({
                    firstname: "firstname-" + index,
                    lastname: "lastname-" + index,
                }),
                // Only value is set. The key field is not set.
            },
        ];
        let error = produceWithConfiguration(
            producer,
            messages,
            configuration,
            null, //!< Null for key schema, not used
            valueSchema
        );
~~~

[1]
https://cwiki.apache.org/confluence/display/KAFKA/A+Guide+To+The+Kafka+Protocol#AGuideToTheKafkaProtocol-Messagesets