### PR TITLE
Add CI workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,54 @@
+name: Build and publish xk6-kafka
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build:
+    name: Build xk6-kafka
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Build 🏗️
+        id: build
+        uses: szkiba/xk6bundler@v0
+        with:
+          platform: linux/amd64 windows/amd64 darwin/amd64
+          with: |
+            github.com/mostafa/xk6-kafka@latest
+
+      - name: Create Release 📦
+        uses: softprops/action-gh-release@v1
+        with:
+          files: dist/*.tar.gz
+
+      - name: Docker meta 📝
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          images: ${{ secrets.DOCKERHUB_USERNAME }}/${{ steps.build.outputs.name }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+
+      - name: Login to DockerHub 🔒
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Docker build and push ☁️
+        if: startsWith(github.ref, 'refs/tags/')
+        uses: docker/build-push-action@v2
+        with:
+          push: true
+          context: ./${{ steps.build.outputs.dockerdir }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
In this PR, I add CI workflow for:
1. Building k6 binaries with xk6-kafka extension using the awesome [xk6bundler](https://github.com/szkiba/xk6bundler) action by @szkiba. 👏 🙏 
2. Creating a GitHub release based on the pushed tag.
3. Building and pushing a Docker image.

This PR also partially addresses #32. I'll create another PR for testing the extension.