### PR TITLE
Find and fix deprecated APIs in k6

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,32 +244,34 @@ And here's the test result output:
            * default: 50 looping VUs for 1m0s (gracefulStop: 30s)
 
 
-running (1m00.4s), 00/50 VUs, 6554 complete and 0 interrupted iterations
+running (1m00.1s), 00/50 VUs, 13598 complete and 0 interrupted iterations
 default ✓ [======================================] 50 VUs  1m0s
 
-    ✓ is sent
-    ✓ 10 messages returned
+     ✓ is sent
+     ✓ 10 messages returned
 
-    checks.........................: 100.00% ✓ 661954 ✗ 0
-    data_received..................: 0 B     0 B/s
-    data_sent......................: 0 B     0 B/s
-    iteration_duration.............: avg=459.31ms min=188.19ms med=456.26ms max=733.67ms p(90)=543.22ms p(95)=572.76ms
-    iterations.....................: 6554    108.563093/s
-    kafka.reader.dial.count........: 6554    108.563093/s
-    kafka.reader.error.count.......: 0       0/s
-    kafka.reader.fetches.count.....: 6554    108.563093/s
-    kafka.reader.message.bytes.....: 6.4 MB  106 kB/s
-    kafka.reader.message.count.....: 77825   1289.124612/s
-    kafka.reader.rebalance.count...: 0       0/s
-    kafka.reader.timeouts.count....: 0       0/s
-    kafka.writer.dial.count........: 6554    108.563093/s
-    kafka.writer.error.count.......: 0       0/s
-    kafka.writer.message.bytes.....: 54 MB   890 kB/s
-    kafka.writer.message.count.....: 655400  10856.309293/s
-    kafka.writer.rebalance.count...: 6554    108.563093/s
-    kafka.writer.write.count.......: 655400  10856.309293/s
-    vus............................: 50      min=50   max=50
-    vus_max........................: 50      min=50   max=50
+     █ teardown
+
+     checks.........................: 100.00% ✓ 1373398      ✗ 0
+     data_received..................: 0 B     0 B/s
+     data_sent......................: 0 B     0 B/s
+     iteration_duration.............: avg=220.82ms min=28.5µs med=215.94ms max=987.93ms p(90)=248.22ms p(95)=258.71ms
+     iterations.....................: 13598   226.195625/s
+     kafka.reader.dial.count........: 50      0.831724/s
+     kafka.reader.error.count.......: 0       0/s
+     kafka.reader.fetches.count.....: 50      0.831724/s
+     kafka.reader.message.bytes.....: 27 MB   444 kB/s
+     kafka.reader.message.count.....: 136030  2262.787977/s
+     kafka.reader.rebalance.count...: 0       0/s
+     kafka.reader.timeouts.count....: 0       0/s
+     kafka.writer.dial.count........: 132     2.195751/s
+     kafka.writer.error.count.......: 0       0/s
+     kafka.writer.message.bytes.....: 595 MB  9.9 MB/s
+     kafka.writer.message.count.....: 2719600 45239.125059/s
+     kafka.writer.rebalance.count...: 0       0/s
+     kafka.writer.write.count.......: 2719600 45239.125059/s
+     vus............................: 50      min=50         max=50
+     vus_max........................: 50      min=50         max=50
 ```
 
 ### Troubleshooting

--- a/module.go
+++ b/module.go
@@ -1,0 +1,34 @@
+package kafka
+
+import "go.k6.io/k6/js/modules"
+
+func init() {
+	modules.Register("k6/x/kafka", New())
+}
+
+type (
+	Kafka struct {
+		vu modules.VU
+	}
+	RootModule  struct{}
+	KafkaModule struct {
+		*Kafka
+	}
+)
+
+var (
+	_ modules.Instance = &KafkaModule{}
+	_ modules.Module   = &RootModule{}
+)
+
+func New() *RootModule {
+	return &RootModule{}
+}
+
+func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
+	return &KafkaModule{Kafka: &Kafka{vu: vu}}
+}
+
+func (c *KafkaModule) Exports() modules.Exports {
+	return modules.Exports{Default: c.Kafka}
+}

--- a/producer.go
+++ b/producer.go
@@ -1,13 +1,11 @@
 package kafka
 
 import (
-	"context"
 	"errors"
 	"time"
 
 	kafkago "github.com/segmentio/kafka-go"
 	"github.com/segmentio/kafka-go/compress"
-	"go.k6.io/k6/lib"
 	"go.k6.io/k6/stats"
 )
 
@@ -53,14 +51,14 @@ func (*Kafka) Writer(brokers []string, topic string, auth string, compression st
 	return kafkago.NewWriter(writerConfig)
 }
 
-func (*Kafka) Produce(
-	ctx context.Context, writer *kafkago.Writer, messages []map[string]interface{},
+func (k *Kafka) Produce(
+	writer *kafkago.Writer, messages []map[string]interface{},
 	keySchema string, valueSchema string) error {
-	return ProduceInternal(ctx, writer, messages, Configuration{}, keySchema, valueSchema)
+	return k.produceInternal(writer, messages, Configuration{}, keySchema, valueSchema)
 }
 
-func (*Kafka) ProduceWithConfiguration(
-	ctx context.Context, writer *kafkago.Writer, messages []map[string]interface{},
+func (k *Kafka) ProduceWithConfiguration(
+	writer *kafkago.Writer, messages []map[string]interface{},
 	configurationJson string, keySchema string, valueSchema string) error {
 	configuration, err := unmarshalConfiguration(configurationJson)
 	if err != nil {
@@ -68,13 +66,13 @@ func (*Kafka) ProduceWithConfiguration(
 		return nil
 	}
 
-	return ProduceInternal(ctx, writer, messages, configuration, keySchema, valueSchema)
+	return k.produceInternal(writer, messages, configuration, keySchema, valueSchema)
 }
 
-func ProduceInternal(
-	ctx context.Context, writer *kafkago.Writer, messages []map[string]interface{},
+func (k *Kafka) produceInternal(
+	writer *kafkago.Writer, messages []map[string]interface{},
 	configuration Configuration, keySchema string, valueSchema string) error {
-	state := lib.GetState(ctx)
+	state := k.vu.State()
 	err := errors.New("state is nil")
 
 	err = validateConfiguration(configuration)
@@ -85,6 +83,14 @@ func ProduceInternal(
 
 	if state == nil {
 		ReportError(err, "Cannot determine state")
+		return err
+	}
+
+	ctx := k.vu.Context()
+	err = errors.New("context is nil")
+
+	if ctx == nil {
+		ReportError(err, "Cannot determine context")
 		return err
 	}
 
@@ -120,25 +126,32 @@ func ProduceInternal(
 	err = writer.WriteMessages(ctx, kafkaMessages...)
 	if err == ctx.Err() {
 		// context is cancelled, so stop
-		ReportWriterStats(ctx, writer.Stats())
+		k.reportWriterStats(writer.Stats())
 		return nil
 	}
 
 	if err != nil {
 		ReportError(err, "Failed to write message")
-		ReportWriterStats(ctx, writer.Stats())
+		k.reportWriterStats(writer.Stats())
 		return err
 	}
 
 	return nil
 }
 
-func ReportWriterStats(ctx context.Context, currentStats kafkago.WriterStats) error {
-	state := lib.GetState(ctx)
+func (k *Kafka) reportWriterStats(currentStats kafkago.WriterStats) error {
+	state := k.vu.State()
 	err := errors.New("state is nil")
 
 	if state == nil {
 		ReportError(err, "Cannot determine state")
+		return err
+	}
+
+	ctx := k.vu.Context()
+	err = errors.New("context is nil")
+	if ctx == nil {
+		ReportError(err, "Cannot determine context")
 		return err
 	}
 


### PR DESCRIPTION
This PR fixes deprecated APIs errors while running k6 (#38) and replaces them with the new APIs from k6 modules. The only issue with the changes is that SASL PLAIN/SCRAM doesn't seem to work. I'll fix this issue, and then I'll merge this PR.

I retested with the old API, and I noticed no difference or improvements in performance overall. It could be that the evolution of the [kafka-go](https://github.com/segmentio/kafka-go) library and updating the [k6](https://github.com/grafana/k6) caused this massive speedup (expand and see below) compared to the original test in the README.

<details>
<summary>xk6-kafka is faster now? 🤔 </summary>

The new changes made the extension more than 3x faster on [fast-data-dev](https://github.com/lensesio/fast-data-dev) containers:
```bash

          /\      |‾‾| /‾‾/   /‾‾/
     /\  /  \     |  |/  /   /  /
    /  \/    \    |     (   /   ‾‾\
   /          \   |  |\  \ |  (‾)  |
  / __________ \  |__| \__\ \_____/ .io

  execution: local
     script: scripts/test_json.js
     output: -

  scenarios: (100.00%) 1 scenario, 50 max VUs, 1m30s max duration (incl. graceful stop):
           * default: 50 looping VUs for 1m0s (gracefulStop: 30s)


running (1m00.2s), 00/50 VUs, 9653 complete and 0 interrupted iterations
default ✓ [======================================] 50 VUs  1m0s

     ✓ is sent
     ✓ 10 messages returned

     █ teardown

     checks.........................: 100.00% ✓ 974953       ✗ 0
     data_received..................: 0 B     0 B/s
     data_sent......................: 0 B     0 B/s
     iteration_duration.............: avg=311.24ms min=33.87µs med=301.12ms max=767.25ms p(90)=354.48ms p(95)=385.52ms
     iterations.....................: 9653    160.396792/s
     kafka.reader.dial.count........: 50      0.830813/s
     kafka.reader.error.count.......: 0       0/s
     kafka.reader.fetches.count.....: 50      0.830813/s
     kafka.reader.message.bytes.....: 19 MB   315 kB/s
     kafka.reader.message.count.....: 96580   1604.798737/s
     kafka.reader.rebalance.count...: 0       0/s
     kafka.reader.timeouts.count....: 0       0/s
     kafka.writer.dial.count........: 150     2.49244/s
     kafka.writer.error.count.......: 0       0/s
     kafka.writer.message.bytes.....: 422 MB  7.0 MB/s
     kafka.writer.message.count.....: 1930600 32079.358475/s
     kafka.writer.rebalance.count...: 0       0/s
     kafka.writer.write.count.......: 1930600 32079.358475/s
     vus............................: 50      min=50         max=50
     vus_max........................: 50      min=50         max=50
```
and 4x faster on a bare Zookeeperless instance of Apache Kafka (v3.1.0 on Scala v2.13), compared to the [previous results](https://github.com/mostafa/xk6-kafka#k6-test-script):
```bash

          /\      |‾‾| /‾‾/   /‾‾/
     /\  /  \     |  |/  /   /  /
    /  \/    \    |     (   /   ‾‾\
   /          \   |  |\  \ |  (‾)  |
  / __________ \  |__| \__\ \_____/ .io

  execution: local
     script: scripts/test_json.js
     output: -

  scenarios: (100.00%) 1 scenario, 50 max VUs, 1m30s max duration (incl. graceful stop):
           * default: 50 looping VUs for 1m0s (gracefulStop: 30s)


running (1m00.1s), 00/50 VUs, 13598 complete and 0 interrupted iterations
default ✓ [======================================] 50 VUs  1m0s

     ✓ is sent
     ✓ 10 messages returned

     █ teardown

     checks.........................: 100.00% ✓ 1373398      ✗ 0
     data_received..................: 0 B     0 B/s
     data_sent......................: 0 B     0 B/s
     iteration_duration.............: avg=220.82ms min=28.5µs med=215.94ms max=987.93ms p(90)=248.22ms p(95)=258.71ms
     iterations.....................: 13598   226.195625/s
     kafka.reader.dial.count........: 50      0.831724/s
     kafka.reader.error.count.......: 0       0/s
     kafka.reader.fetches.count.....: 50      0.831724/s
     kafka.reader.message.bytes.....: 27 MB   444 kB/s
     kafka.reader.message.count.....: 136030  2262.787977/s
     kafka.reader.rebalance.count...: 0       0/s
     kafka.reader.timeouts.count....: 0       0/s
     kafka.writer.dial.count........: 132     2.195751/s
     kafka.writer.error.count.......: 0       0/s
     kafka.writer.message.bytes.....: 595 MB  9.9 MB/s
     kafka.writer.message.count.....: 2719600 45239.125059/s
     kafka.writer.rebalance.count...: 0       0/s
     kafka.writer.write.count.......: 2719600 45239.125059/s
     vus............................: 50      min=50         max=50
     vus_max........................: 50      min=50         max=50
```
</details>

**Update:**
I couldn't figure out how to test SASL (no SSL), and I need someone to test it against a working instance of Kafka with SASL PLAIN/SCRAM enabled. I'll merge this, but won't release it until I fully test it. This means that you can test the feature by compiling with the latest commits on the `main` branch, but it won't be available as binary and a Docker image yet.