### PR TITLE
Add linters and CycloneDX SBOM generation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,6 +15,11 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install Go 🧑‍💻
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.18'
+
       - name: Build 🏗️
         id: build
         uses: szkiba/xk6bundler@v0
@@ -22,6 +27,20 @@ jobs:
           platform: linux/amd64 windows/amd64 darwin/amd64
           with: |
             github.com/mostafa/xk6-kafka@latest
+
+      - name: Generate CycloneDX SBOM artifacts 📃
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        run: |
+          go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@latest
+          cyclonedx-gomod mod -json -licenses -output cyclonedx-xk6-kafka-${{ github.ref_name }}.json
+
+      - name: Upload CycloneDX SBOM artifact for go.mod 💾
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: actions/upload-artifact@v3
+        with:
+          name: cyclonedx-xk6-kafka-${{ github.ref_name }}.json
+          path:
+            cyclonedx-xk6-kafka-${{ github.ref_name }}.json
 
       - name: Create Release 📦
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,11 +15,6 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Install Go 🧑‍💻
-        uses: actions/setup-go@v3
-        with:
-          go-version: '1.18'
-
       - name: Build 🏗️
         id: build
         uses: szkiba/xk6bundler@v0
@@ -27,6 +22,12 @@ jobs:
           platform: linux/amd64 windows/amd64 darwin/amd64
           with: |
             github.com/mostafa/xk6-kafka@latest
+
+      - name: Install Go 🧑‍💻
+        if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+        uses: actions/setup-go@v3
+        with:
+          go-version: '1.18'
 
       - name: Generate CycloneDX SBOM artifacts 📃
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,6 +23,16 @@ jobs:
         with:
           go-version: '1.18'
 
+      - name: Lint code issues 🚨
+        run: |
+          go install github.com/golangci/golangci-lint/cmd/golangci-lint@latest
+          golangci-lint run
+
+      - name: Lint security issues 🔒
+        run: |
+          go install github.com/securego/gosec/v2/cmd/gosec@latest
+          gosec .
+
       - name: Install xk6 and build xk6-kafka 🏗️
         run: |
           go install go.k6.io/xk6/cmd/xk6@latest


### PR DESCRIPTION
As part of #41 and #38, this PR adds two linters: [golangci-lint](https://github.com/golangci/golangci-lint) and [gosec](https://github.com/securego/gosec). CycloneDX SBOM artifacts are also generated using [cyclonedx-gomod](https://github.com/CycloneDX/cyclonedx-gomod) on release.