### PR TITLE
Add headers to produced and consumed messages

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -125,7 +125,7 @@ func (k *Kafka) consumeInternal(
 		message["topic"] = msg.Topic
 		message["partition"] = msg.Partition
 		message["offset"] = msg.Offset
-		message["time"] = msg.Time.UnixNano() / int64(time.Millisecond)
+		message["time"] = time.Unix(msg.Time.Unix(), 0).Format(time.RFC3339)
 		message["highWaterMark"] = msg.HighWaterMark
 		message["headers"] = msg.Headers
 

--- a/consumer.go
+++ b/consumer.go
@@ -121,6 +121,14 @@ func (k *Kafka) consumeInternal(
 			message["value"] = valueDeserializer(configuration, msg.Value, "value", valueSchema)
 		}
 
+		// Rest of the fields of a given message
+		message["topic"] = msg.Topic
+		message["partition"] = msg.Partition
+		message["offset"] = msg.Offset
+		message["time"] = msg.Time.UnixNano() / int64(time.Millisecond)
+		message["highWaterMark"] = msg.HighWaterMark
+		message["headers"] = msg.Headers
+
 		messages = append(messages, message)
 	}
 

--- a/producer.go
+++ b/producer.go
@@ -104,10 +104,6 @@ func (k *Kafka) produceInternal(
 			kafkaMessages[i].Offset = message["offset"].(int64)
 		}
 
-		if _, has_highwatermark := message["highWaterMark"]; has_highwatermark {
-			kafkaMessages[i].HighWaterMark = message["highWaterMark"].(int64)
-		}
-
 		// If time is set, use it to set the time on the message,
 		// otherwise use the current time.
 		if _, has_time := message["time"]; has_time {

--- a/scripts/test_json.js
+++ b/scripts/test_json.js
@@ -93,6 +93,8 @@ export default function () {
             String.fromCharCode(...msg.headers[0]["value"]) == "myvalue",
         "Time is past": (msg) => new Date(msg["time"]) < new Date(),
         "Partition is zero": (msg) => msg["partition"] == 0,
+        "Offset is gte zero": (msg) => msg["offset"] >= 0,
+        "High watermark is gte zero": (msg) => msg["highWaterMark"] >= 0,
     });
 }
 

--- a/scripts/test_json.js
+++ b/scripts/test_json.js
@@ -44,6 +44,9 @@ export default function () {
                 headers: {
                     mykey: "myvalue",
                 },
+                offset: index,
+                partition: 0,
+                time: new Date().getTime(), // timestamp
             },
             {
                 key: JSON.stringify({

--- a/scripts/test_json.js
+++ b/scripts/test_json.js
@@ -35,12 +35,15 @@ export default function () {
                 }),
                 value: JSON.stringify({
                     name: "xk6-kafka",
-                    version: "0.2.1",
+                    version: "0.9.0",
                     author: "Mostafa Moradian",
                     description:
                         "k6 extension to load test Apache Kafka with support for Avro messages",
                     index: index,
                 }),
+                headers: {
+                    mykey: "myvalue",
+                },
             },
             {
                 key: JSON.stringify({
@@ -48,25 +51,48 @@ export default function () {
                 }),
                 value: JSON.stringify({
                     name: "xk6-kafka",
-                    version: "0.2.1",
+                    version: "0.9.0",
                     author: "Mostafa Moradian",
                     description:
                         "k6 extension to load test Apache Kafka with support for Avro messages",
                     index: index,
                 }),
+                headers: {
+                    mykey: "myvalue",
+                },
             },
         ];
 
         let error = produce(producer, messages);
         check(error, {
-            "is sent": (err) => err == undefined,
+            "Messages are sent": (err) => err == undefined,
         });
     }
 
     // Read 10 messages only
     let messages = consume(consumer, 10);
     check(messages, {
-        "10 messages returned": (msgs) => msgs.length == 10,
+        "10 messages are received": (messages) => messages.length == 10,
+    });
+
+    check(messages[0], {
+        "Topic equals xk6_kafka_json_topic": (msg) => msg["topic"] == kafkaTopic,
+        "Key is correct": (msg) => msg["key"] == JSON.stringify({ correlationId: "test-id-abc-0" }),
+        "Value is correct": (msg) =>
+            msg["value"] ==
+            JSON.stringify({
+                name: "xk6-kafka",
+                version: "0.9.0",
+                author: "Mostafa Moradian",
+                description:
+                    "k6 extension to load test Apache Kafka with support for Avro messages",
+                index: 0,
+            }),
+        "Header equals {mykey: 'myvalue'}": (msg) =>
+            msg.headers[0]["key"] == "mykey" &&
+            String.fromCharCode(...msg.headers[0]["value"]) == "myvalue",
+        "Time is past": (msg) => new Date(msg["time"]) < new Date(),
+        "Partition is zero": (msg) => msg["partition"] == 0,
     });
 }
 


### PR DESCRIPTION
This PR partially addresses #17 by adding headers to the produced message and exporting various fields on the consumed message. 

The `produce` function can now accept a list of messages, each containing `key`, `value`, `topic`, `offset`, `highWaterMark`, `time`, and `headers`, as shown below in the below pseudo-JS code:
```js
let messages = [
  {
    key: string,
    value: string, // mandatory
    topic: string,
    offset: integer,
    time: timestamp,
    headers: {
      key: string / bytearray,
    },
  },
];
let error = produce(producer, message);
```
And the messages consumed by the consumer will have `topic`, `partition`, `offset`, `time`, `highWaterMark` and `headers` in addition to the previous `key` and `value`, as shown below in the below pseudo-JS code:
```js
let messages = consume(consumer, 1);
messages ==
  [
    {
      key: string,
      value: string,
      topic: string,
      partition: number,
      offset: number,
      time: timestamp,
      highWaterMark: number,
      headers: {
        key: string / bytearray,
      },
    },
  ];
```

As a sie note, the tests might look flaky (work sometimes and fails other times), but the actual reason is that I introduced thresholds on custom Kafka metrics and also added checks to verify produced and consumed messages. So, this behavior is expected. I am going to fix the test later in #48.