### PR TITLE
Revamp logging and error reporting

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -46,8 +46,10 @@ func unmarshalCredentials(auth string) (*Credentials, *Xk6KafkaError) {
 }
 
 func getDialerFromCreds(creds *Credentials) (*kafkago.Dialer, *Xk6KafkaError) {
-	// TODO: handle error
-	tlsConfig, _ := tlsConfig(creds)
+	tlsConfig, err := tlsConfig(creds)
+	if err != nil && err.Unwrap() != nil {
+		return nil, err
+	}
 
 	dialer := &kafkago.Dialer{
 		Timeout:   10 * time.Second,

--- a/auth.go
+++ b/auth.go
@@ -4,8 +4,8 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
-	"log"
 	"os"
 	"time"
 
@@ -30,21 +30,29 @@ type Credentials struct {
 	ServerCaPem   string `json:"serverCaPem"`
 }
 
-func unmarshalCredentials(auth string) (creds *Credentials, err error) {
-	creds = &Credentials{
+func unmarshalCredentials(auth string) (*Credentials, *Xk6KafkaError) {
+	creds := &Credentials{
 		Algorithm: None,
 	}
 
-	err = json.Unmarshal([]byte(auth), &creds)
+	err := json.Unmarshal([]byte(auth), &creds)
 
-	return
+	if err != nil {
+		return nil, NewXk6KafkaError(
+			failedUnmarshalCreds, "Unable to unmarshal credentials", err)
+	} else {
+		return creds, nil
+	}
 }
 
-func getDialerFromCreds(creds *Credentials) (dialer *kafkago.Dialer) {
-	dialer = &kafkago.Dialer{
+func getDialerFromCreds(creds *Credentials) (*kafkago.Dialer, *Xk6KafkaError) {
+	// TODO: handle error
+	tlsConfig, _ := tlsConfig(creds)
+
+	dialer := &kafkago.Dialer{
 		Timeout:   10 * time.Second,
 		DualStack: true,
-		TLS:       tlsConfig(creds),
+		TLS:       tlsConfig,
 	}
 
 	if creds.Algorithm == Plain {
@@ -53,7 +61,7 @@ func getDialerFromCreds(creds *Credentials) (dialer *kafkago.Dialer) {
 			Password: creds.Password,
 		}
 		dialer.SASLMechanism = mechanism
-		return
+		return dialer, nil
 	} else if creds.Algorithm == SHA256 || creds.Algorithm == SHA512 {
 		hashes := make(map[string]scram.Algorithm)
 		hashes["sha256"] = scram.SHA256
@@ -65,41 +73,34 @@ func getDialerFromCreds(creds *Credentials) (dialer *kafkago.Dialer) {
 			creds.Password,
 		)
 		if err != nil {
-			ReportError(err, "authentication failed")
-			return nil
+			return nil, NewXk6KafkaError(
+				failedCreateDialerWithScram, "Unable to create SCRAM mechanism", err)
 		}
 		dialer.SASLMechanism = mechanism
-		return
+		return dialer, nil
 	}
-	return
+	return dialer, nil
 }
 
-func getDialerFromAuth(auth string) (dialer *kafkago.Dialer) {
+func getDialerFromAuth(auth string) (*kafkago.Dialer, *Xk6KafkaError) {
 	if auth != "" {
 		// Parse the auth string
 		creds, err := unmarshalCredentials(auth)
 		if err != nil {
-			ReportError(err, "Unable to unmarshal credentials")
-			return nil
+			return nil, err
 		}
 
 		// Try to create an authenticated dialer from the credentials
 		// with TLS enabled if the credentials specify a client cert
 		// and key.
-		dialer = getDialerFromCreds(creds)
-		if dialer == nil {
-			ReportError(nil, "Dialer cannot authenticate")
-			return nil
-		}
+		return getDialerFromCreds(creds)
 	} else {
 		// Create a normal (unauthenticated) dialer
-		dialer = &kafkago.Dialer{
+		return &kafkago.Dialer{
 			Timeout:   10 * time.Second,
 			DualStack: false,
-		}
+		}, nil
 	}
-
-	return
 }
 
 func fileExists(filename string) bool {
@@ -107,33 +108,36 @@ func fileExists(filename string) bool {
 	return err == nil
 }
 
-func tlsConfig(creds *Credentials) *tls.Config {
+func tlsConfig(creds *Credentials) (*tls.Config, *Xk6KafkaError) {
 	var clientCertFile = &creds.ClientCertPem
 	if !fileExists(*clientCertFile) {
-		ReportError(nil, "client certificate file not found")
-		return nil
+		return nil, NewXk6KafkaError(fileNotFound, "Client certificate file not found.", nil)
 	}
 
 	var clientKeyFile = &creds.ClientKeyPem
 	if !fileExists(*clientKeyFile) {
-		ReportError(nil, "client key file not found")
-		return nil
+		return nil, NewXk6KafkaError(fileNotFound, "Client key file not found.", nil)
 	}
 
 	var cert, err = tls.LoadX509KeyPair(*clientCertFile, *clientKeyFile)
 	if err != nil {
-		log.Fatalf("Error creating x509 keypair from client cert file %s and client key file %s", *clientCertFile, *clientKeyFile)
+		return nil, NewXk6KafkaError(
+			failedLoadX509KeyPair,
+			fmt.Sprintf("Error creating x509 keypair from client cert file %s and client key file %s", *clientCertFile, *clientKeyFile),
+			err)
 	}
 
 	var caCertFile = &creds.ServerCaPem
 	if !fileExists(*caCertFile) {
-		ReportError(nil, "CA certificate file not found")
-		return nil
+		return nil, NewXk6KafkaError(fileNotFound, "CA certificate file not found.", nil)
 	}
 
 	caCert, err := ioutil.ReadFile(*caCertFile)
 	if err != nil {
-		log.Fatalf("Error opening cert file %s, Error: %s", *caCertFile, err)
+		return nil, NewXk6KafkaError(
+			failedReadCaCertFile,
+			fmt.Sprintf("Error reading CA certificate file %s", *caCertFile),
+			err)
 	}
 	caCertPool := x509.NewCertPool()
 	caCertPool.AppendCertsFromPEM(caCert)
@@ -142,5 +146,5 @@ func tlsConfig(creds *Credentials) *tls.Config {
 		Certificates: []tls.Certificate{cert},
 		RootCAs:      caCertPool,
 		MinVersion:   tls.VersionTLS12,
-	}
+	}, nil
 }

--- a/avro.go
+++ b/avro.go
@@ -4,54 +4,66 @@ import (
 	"github.com/linkedin/goavro/v2"
 )
 
-func SerializeAvro(configuration Configuration, topic string, data interface{}, element Element, schema string, version int) ([]byte, error) {
+func SerializeAvro(configuration Configuration, topic string, data interface{}, element Element, schema string, version int) ([]byte, *Xk6KafkaError) {
 	bytesData := []byte(data.(string))
 	if schema != "" {
 		codec, err := goavro.NewCodec(schema)
 		if err != nil {
-			ReportError(err, "Failed to create codec for encoding Avro")
+			return nil, NewXk6KafkaError(failedCreateAvroCodec,
+				"Failed to create codec for encoding Avro",
+				err)
 		}
 
 		avroEncodedData, _, err := codec.NativeFromTextual(bytesData)
 		if err != nil {
-			ReportError(err, "Failed to encode data into Avro")
+			return nil, NewXk6KafkaError(failedEncodeToAvro,
+				"Failed to encode data into Avro",
+				err)
 		}
 
 		bytesData, err = codec.BinaryFromNative(nil, avroEncodedData)
 		if err != nil {
-			ReportError(err, "Failed to encode Avro data into binary")
+			return nil, NewXk6KafkaError(failedEncodeAvroToBinary,
+				"Failed to encode Avro data into binary",
+				err)
 		}
 	}
 
 	byteData, err := encodeWireFormat(configuration, bytesData, topic, element, schema, version)
 	if err != nil {
-		ReportError(err, "Failed to add wire format to the binary data")
-		return nil, err
+		return nil, NewXk6KafkaError(failedEncodeToWireFormat,
+			"Failed to encode data into wire format",
+			err)
 	}
 
 	return byteData, nil
 }
 
-func DeserializeAvro(configuration Configuration, data []byte, element Element, schema string, version int) interface{} {
+func DeserializeAvro(configuration Configuration, data []byte, element Element, schema string, version int) (interface{}, *Xk6KafkaError) {
 	bytesDecodedData, err := decodeWireFormat(configuration, data, element)
 	if err != nil {
-		ReportError(err, "Failed to remove wire format from the binary data")
-		return nil
+		return nil, NewXk6KafkaError(failedDecodeFromWireFormat,
+			"Failed to remove wire format from the binary data",
+			err)
 	}
 
 	if schema != "" {
 		codec, err := goavro.NewCodec(schema)
 		if err != nil {
-			ReportError(err, "Failed to create codec for decoding Avro")
+			return nil, NewXk6KafkaError(failedCreateAvroCodec,
+				"Failed to create codec for decoding Avro",
+				err)
 		}
 
 		avroDecodedData, _, err := codec.NativeFromBinary(bytesDecodedData)
 		if err != nil {
-			ReportError(err, "Failed to decode data from Avro")
+			return nil, NewXk6KafkaError(failedDecodeAvroFromBinary,
+				"Failed to decode data from Avro",
+				err)
 		}
 
-		return avroDecodedData
+		return avroDecodedData, nil
 	}
 
-	return bytesDecodedData
+	return bytesDecodedData, nil
 }

--- a/bytearray.go
+++ b/bytearray.go
@@ -1,8 +1,8 @@
 package kafka
 
-import "errors"
+import "fmt"
 
-func SerializeByteArray(configuration Configuration, topic string, data interface{}, element Element, schema string, version int) ([]byte, error) {
+func SerializeByteArray(configuration Configuration, topic string, data interface{}, element Element, schema string, version int) ([]byte, *Xk6KafkaError) {
 	switch data.(type) {
 	case []interface{}:
 		bArray := data.([]interface{})
@@ -12,10 +12,13 @@ func SerializeByteArray(configuration Configuration, topic string, data interfac
 		}
 		return arr, nil
 	default:
-		return nil, errors.New("Invalid data type provided for byte array serializer (requires []byte)")
+		return nil, NewXk6KafkaError(
+			invalidDataType,
+			"Invalid data type provided for byte array serializer (requires []byte)",
+			fmt.Errorf("Expected: []byte, got: %T", data))
 	}
 }
 
-func DeserializeByteArray(configuration Configuration, data []byte, element Element, schema string, version int) interface{} {
-	return data
+func DeserializeByteArray(configuration Configuration, data []byte, element Element, schema string, version int) (interface{}, *Xk6KafkaError) {
+	return data, nil
 }

--- a/configuration.go
+++ b/configuration.go
@@ -2,7 +2,6 @@ package kafka
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"reflect"
 )
@@ -23,13 +22,14 @@ type Configuration struct {
 	SchemaRegistry SchemaRegistryConfiguration `json:"schemaRegistry"`
 }
 
-func UnmarshalConfiguration(jsonConfiguration string) (Configuration, error) {
+func UnmarshalConfiguration(jsonConfiguration string) (Configuration, *Xk6KafkaError) {
 	var configuration Configuration
 	err := json.Unmarshal([]byte(jsonConfiguration), &configuration)
-	return configuration, err
+	return configuration, NewXk6KafkaError(
+		configurationError, "Cannot unmarshal configuration.", err)
 }
 
-func ValidateConfiguration(configuration Configuration) error {
+func ValidateConfiguration(configuration Configuration) *Xk6KafkaError {
 	if (Configuration{}) == configuration {
 		// No configuration, fallback to default
 		return nil
@@ -37,8 +37,10 @@ func ValidateConfiguration(configuration Configuration) error {
 
 	if useSerializer(configuration, Key) || useSerializer(configuration, Value) {
 		if (SchemaRegistryConfiguration{}) == configuration.SchemaRegistry {
-			return errors.New("You must provide a value for the \"SchemaRegistry\" configuration property to use a serializer " +
-				"of either of these types " + fmt.Sprintf("%q", reflect.ValueOf(Serializers).MapKeys()))
+			return NewXk6KafkaError(
+				configurationError,
+				fmt.Sprintf("You must provide a value for the \"SchemaRegistry\" configuration property to use a serializer of either of these types %q", reflect.ValueOf(Serializers).MapKeys()),
+				nil)
 		}
 	}
 	return nil

--- a/error_codes.go
+++ b/error_codes.go
@@ -1,0 +1,78 @@
+package kafka
+
+type errCode uint32
+
+const (
+	// non specific
+	kafkaForbiddenInInitContext errCode = 1000
+	configurationError          errCode = 1001
+	contextCancelled            errCode = 1002
+	cannotReportStats           errCode = 1003
+	fileNotFound                errCode = 1004
+	dialerError                 errCode = 1005
+
+	// serdes errors
+	invalidDataType             errCode = 2000
+	failedEncodeToWireFormat    errCode = 2001
+	failedDecodeFromWireFormat  errCode = 2002
+	failedCreateAvroCodec       errCode = 2003
+	failedEncodeToAvro          errCode = 2004
+	failedEncodeAvroToBinary    errCode = 2005
+	failedDecodeAvroFromBinary  errCode = 2006
+	failedCreateJsonSchemaCodec errCode = 2007
+	failedUnmarshalJsonSchema   errCode = 2008
+	failedValidateJsonSchema    errCode = 2009
+
+	// producer
+	failedWriteMessage errCode = 3000
+
+	// consumer
+	failedSetOffset   errCode = 4000
+	failedReadMessage errCode = 4001
+	noMoreMessages    errCode = 4002
+
+	// authentication
+	failedCreateDialerWithScram errCode = 5000
+	failedUnmarshalCreds        errCode = 5001
+	failedLoadX509KeyPair       errCode = 5002
+	failedReadCaCertFile        errCode = 5003
+
+	// schema registry
+	messageTooShort      errCode = 6000
+	schemaCreationFailed errCode = 6001
+
+	// topics
+	failedCreateTopic    errCode = 7000
+	failedDeleteTopic    errCode = 7001
+	failedReadPartitions errCode = 7002
+)
+
+var (
+	// ErrorForbiddenInInitContext is used when a Kafka producer was used in the init context
+	ErrorForbiddenInInitContext = NewXk6KafkaError(
+		kafkaForbiddenInInitContext,
+		"Producing Kafka messages in the init context is not supported",
+		nil)
+)
+
+type Xk6KafkaError struct {
+	Code          errCode
+	Message       string
+	OriginalError error
+}
+
+// NewXk6KafkaError is the constructor for Xk6KafkaError
+func NewXk6KafkaError(code errCode, msg string, originalErr error) *Xk6KafkaError {
+	return &Xk6KafkaError{Code: code, Message: msg, OriginalError: originalErr}
+}
+
+// Error implements the `error` interface, so Xk6KafkaError are normal Go errors.
+func (e Xk6KafkaError) Error() string {
+	return e.Message
+}
+
+// Unwrap implements the `xerrors.Wrapper` interface, so Xk6KafkaError are a bit
+// future-proof Go 2 errors.
+func (e Xk6KafkaError) Unwrap() error {
+	return e.OriginalError
+}

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/riferrei/srclient v0.5.2
 	github.com/santhosh-tekuri/jsonschema/v5 v5.0.0
 	github.com/segmentio/kafka-go v0.4.31
+	github.com/sirupsen/logrus v1.8.1
 	go.k6.io/k6 v0.38.0
 )
 
@@ -24,7 +25,6 @@ require (
 	github.com/oxtoacart/bpool v0.0.0-20190530202638-03653db5a59c // indirect
 	github.com/pierrec/lz4/v4 v4.1.14 // indirect
 	github.com/serenize/snaker v0.0.0-20201027110005-a7ad2135616e // indirect
-	github.com/sirupsen/logrus v1.8.1 // indirect
 	github.com/spf13/afero v1.1.2 // indirect
 	github.com/xdg/scram v0.0.0-20180814205039-7eeb5667e42c // indirect
 	github.com/xdg/stringprep v1.0.0 // indirect

--- a/module.go
+++ b/module.go
@@ -1,6 +1,7 @@
 package kafka
 
 import (
+	"github.com/sirupsen/logrus"
 	"go.k6.io/k6/js/common"
 	"go.k6.io/k6/js/modules"
 )
@@ -13,6 +14,7 @@ type (
 	Kafka struct {
 		vu      modules.VU
 		metrics kafkaMetrics
+		logger  *logrus.Logger
 	}
 	RootModule  struct{}
 	KafkaModule struct {
@@ -35,7 +37,7 @@ func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 		common.Throw(vu.Runtime(), err)
 	}
 
-	return &KafkaModule{Kafka: &Kafka{vu: vu, metrics: m}}
+	return &KafkaModule{Kafka: &Kafka{vu: vu, metrics: m, logger: logrus.New()}}
 }
 
 func (c *KafkaModule) Exports() modules.Exports {

--- a/scripts/test_avro.js
+++ b/scripts/test_avro.js
@@ -11,8 +11,8 @@ import { writer, produce, reader, consume, createTopic, deleteTopic } from "k6/x
 const bootstrapServers = ["localhost:9092"];
 const kafkaTopic = "xk6_kafka_avro_topic";
 
-const producer = writer(bootstrapServers, kafkaTopic);
-const consumer = reader(bootstrapServers, kafkaTopic);
+const [producer, _writerError] = writer(bootstrapServers, kafkaTopic);
+const [consumer, _readerError] = reader(bootstrapServers, kafkaTopic);
 
 const keySchema = JSON.stringify({
     type: "record",
@@ -101,7 +101,7 @@ export default function () {
     }
 
     // Read 10 messages only
-    let messages = consume(consumer, 10, keySchema, valueSchema);
+    let [messages, _consumeError] = consume(consumer, 10, keySchema, valueSchema);
     check(messages, {
         "10 messages returned": (msgs) => msgs.length == 10,
     });

--- a/scripts/test_avro_no_key.js
+++ b/scripts/test_avro_no_key.js
@@ -11,8 +11,8 @@ import { writer, produce, reader, consume, createTopic, deleteTopic } from "k6/x
 const bootstrapServers = ["localhost:9092"];
 const kafkaTopic = "xk6_kafka_avro_topic";
 
-const producer = writer(bootstrapServers, kafkaTopic);
-const consumer = reader(bootstrapServers, kafkaTopic);
+const [producer, _writerError] = writer(bootstrapServers, kafkaTopic);
+const [consumer, _readerError] = reader(bootstrapServers, kafkaTopic);
 
 const valueSchema = JSON.stringify({
     type: "record",
@@ -83,13 +83,13 @@ export default function () {
     }
 
     // Read 10 messages only
-    let rx_messages = consume(consumer, 10, null, valueSchema);
-    check(rx_messages, {
+    let [messages, _consumeError] = consume(consumer, 10, null, valueSchema);
+    check(messages, {
         "10 messages returned": (msgs) => msgs.length == 10,
     });
 
-    for (let index = 0; index < rx_messages.length; index++) {
-        console.debug("Received Message: " + JSON.stringify(rx_messages[index]));
+    for (let index = 0; index < messages.length; index++) {
+        console.debug("Received Message: " + JSON.stringify(messages[index]));
     }
 }
 

--- a/scripts/test_avro_with_schema_registry.js
+++ b/scripts/test_avro_with_schema_registry.js
@@ -16,8 +16,8 @@ import {
 const bootstrapServers = ["localhost:9092"];
 const kafkaTopic = "com.example.person";
 
-const producer = writer(bootstrapServers, kafkaTopic);
-const consumer = reader(bootstrapServers, kafkaTopic, null, "", null);
+const [producer, _writerError] = writer(bootstrapServers, kafkaTopic);
+const [consumer, _readerError] = reader(bootstrapServers, kafkaTopic, null, "", null);
 
 const keySchema = `{
   "name": "KeySchema",
@@ -90,7 +90,13 @@ export default function () {
         });
     }
 
-    let messages = consumeWithConfiguration(consumer, 20, configuration, keySchema, valueSchema);
+    let [messages, _consumeError] = consumeWithConfiguration(
+        consumer,
+        20,
+        configuration,
+        keySchema,
+        valueSchema
+    );
     check(messages, {
         "20 message returned": (msgs) => msgs.length == 20,
     });

--- a/scripts/test_avro_with_schema_registry_no_key.js
+++ b/scripts/test_avro_with_schema_registry_no_key.js
@@ -16,8 +16,8 @@ import {
 const bootstrapServers = ["localhost:9092"];
 const kafkaTopic = "com.example.person";
 
-const producer = writer(bootstrapServers, kafkaTopic, null);
-const consumer = reader(bootstrapServers, kafkaTopic, null, "", null, null);
+const [producer, _writerError] = writer(bootstrapServers, kafkaTopic, null);
+const [consumer, _readerError] = reader(bootstrapServers, kafkaTopic, null, "", null, null);
 
 const valueSchema = `{
   "name": "ValueSchema",
@@ -69,13 +69,19 @@ export default function () {
         });
     }
 
-    let rx_messages = consumeWithConfiguration(consumer, 20, configuration, null, valueSchema);
-    check(rx_messages, {
+    let [messages, _consumeError] = consumeWithConfiguration(
+        consumer,
+        20,
+        configuration,
+        null,
+        valueSchema
+    );
+    check(messages, {
         "20 message returned": (msgs) => msgs.length == 20,
     });
 
-    for (let index = 0; index < rx_messages.length; index++) {
-        console.debug("Received Message: " + JSON.stringify(rx_messages[index]));
+    for (let index = 0; index < messages.length; index++) {
+        console.debug("Received Message: " + JSON.stringify(messages[index]));
     }
 }
 

--- a/scripts/test_bytes.js
+++ b/scripts/test_bytes.js
@@ -18,8 +18,8 @@ import {
 const bootstrapServers = ["localhost:9092"];
 const kafkaTopic = "xk6_kafka_byte_array_topic";
 
-const producer = writer(bootstrapServers, kafkaTopic);
-const consumer = reader(bootstrapServers, kafkaTopic);
+const [producer, _writerError] = writer(bootstrapServers, kafkaTopic);
+const [consumer, _readerError] = reader(bootstrapServers, kafkaTopic);
 
 if (__VU == 1) {
     createTopic(bootstrapServers[0], kafkaTopic);
@@ -58,7 +58,7 @@ export default function () {
     }
 
     // Read 10 messages only
-    let messages = consumeWithConfiguration(consumer, 10, configuration);
+    let [messages, _consumeError] = consumeWithConfiguration(consumer, 10, configuration);
     check(messages, {
         "10 messages returned": (msgs) => msgs.length == 10,
         "key starts with 'test-id-' string": (msgs) => msgs[0].key.startsWith("test-id-"),

--- a/scripts/test_json.js
+++ b/scripts/test_json.js
@@ -11,8 +11,8 @@ import { writer, produce, reader, consume, createTopic, deleteTopic } from "k6/x
 const bootstrapServers = ["localhost:9092"];
 const kafkaTopic = "xk6_kafka_json_topic";
 
-const producer = writer(bootstrapServers, kafkaTopic);
-const consumer = reader(bootstrapServers, kafkaTopic);
+const [producer, _writerError] = writer(bootstrapServers, kafkaTopic);
+const [consumer, _readerError] = reader(bootstrapServers, kafkaTopic);
 
 if (__VU == 1) {
     createTopic(bootstrapServers[0], kafkaTopic);
@@ -73,7 +73,8 @@ export default function () {
     }
 
     // Read 10 messages only
-    let messages = consume(consumer, 10);
+    let [messages, _consumeError] = consume(consumer, 10);
+
     check(messages, {
         "10 messages are received": (messages) => messages.length == 10,
     });

--- a/scripts/test_json_with_snappy_compression.js
+++ b/scripts/test_json_with_snappy_compression.js
@@ -21,8 +21,8 @@ Supported compression codecs:
 */
 const compression = "Snappy";
 
-const producer = writer(bootstrapServers, kafkaTopic, no_auth, compression);
-const consumer = reader(bootstrapServers, kafkaTopic);
+const [producer, _writerError] = writer(bootstrapServers, kafkaTopic, no_auth, compression);
+const [consumer, _readerError] = reader(bootstrapServers, kafkaTopic);
 
 const replicationFactor = 1;
 const partitions = 1;
@@ -70,7 +70,7 @@ export default function () {
     }
 
     // Read 10 messages only
-    let messages = consume(consumer, 10);
+    let [messages, _consumeError] = consume(consumer, 10);
     check(messages, {
         "10 messages returned": (msgs) => msgs.length == 10,
     });

--- a/scripts/test_jsonschema_with_schema_registry.js
+++ b/scripts/test_jsonschema_with_schema_registry.js
@@ -16,8 +16,8 @@ import {
 const bootstrapServers = ["localhost:9092"];
 const kafkaTopic = "xk6_jsonschema_test";
 
-const producer = writer(bootstrapServers, kafkaTopic, null);
-const consumer = reader(bootstrapServers, kafkaTopic, null, "", null, null);
+const [producer, _writerError] = writer(bootstrapServers, kafkaTopic, null);
+const [consumer, _readerError] = reader(bootstrapServers, kafkaTopic, null, "", null, null);
 
 const keySchema = JSON.stringify({
     title: "Key",
@@ -88,12 +88,18 @@ export default function () {
         });
     }
 
-    let rx_messages = consumeWithConfiguration(consumer, 20, configuration, keySchema, valueSchema);
-    check(rx_messages, {
+    let [messages, _consumeError] = consumeWithConfiguration(
+        consumer,
+        20,
+        configuration,
+        keySchema,
+        valueSchema
+    );
+    check(messages, {
         "20 message returned": (msgs) => msgs.length == 20,
     });
 
-    check(rx_messages[0], {
+    check(messages[0], {
         "Topic equals to xk6_jsonschema_test": (msg) => msg.topic == kafkaTopic,
         "Key is correct": (msg) => msg.key.key == "key0",
         "Value is correct": (msg) =>

--- a/scripts/test_sasl_auth.js
+++ b/scripts/test_sasl_auth.js
@@ -27,8 +27,15 @@ const partitions = 1;
 const replicationFactor = 1;
 const compression = "";
 
-const producer = writer(bootstrapServers, kafkaTopic, auth);
-const consumer = reader(bootstrapServers, kafkaTopic, partition, groupID, offset, auth);
+const [producer, _writerError] = writer(bootstrapServers, kafkaTopic, auth);
+const [consumer, _readerError] = reader(
+    bootstrapServers,
+    kafkaTopic,
+    partition,
+    groupID,
+    offset,
+    auth
+);
 
 if (__VU == 1) {
     createTopic(bootstrapServers[0], kafkaTopic, partitions, replicationFactor, compression, auth);
@@ -73,7 +80,7 @@ export default function () {
     }
 
     // Read 10 messages only
-    let messages = consume(consumer, 10);
+    let [messages, _consumeError] = consume(consumer, 10);
     check(messages, {
         "10 messages returned": (msgs) => msgs.length == 10,
     });

--- a/serde.go
+++ b/serde.go
@@ -4,8 +4,8 @@ import (
 	"github.com/riferrei/srclient"
 )
 
-type Serializer func(configuration Configuration, topic string, data interface{}, element Element, schema string, version int) ([]byte, error)
-type Deserializer func(configuration Configuration, data []byte, element Element, schema string, version int) interface{}
+type Serializer func(configuration Configuration, topic string, data interface{}, element Element, schema string, version int) ([]byte, *Xk6KafkaError)
+type Deserializer func(configuration Configuration, data []byte, element Element, schema string, version int) (interface{}, *Xk6KafkaError)
 
 var (
 	// TODO: Find a better way to do this, like serde registry or something

--- a/string.go
+++ b/string.go
@@ -1,16 +1,19 @@
 package kafka
 
-import "errors"
+import "fmt"
 
-func SerializeString(configuration Configuration, topic string, data interface{}, element Element, schema string, version int) ([]byte, error) {
+func SerializeString(configuration Configuration, topic string, data interface{}, element Element, schema string, version int) ([]byte, *Xk6KafkaError) {
 	switch data := data.(type) {
 	case string:
 		return []byte(data), nil
 	default:
-		return nil, errors.New("Invalid data type provided for string serializer (requires string)")
+		return nil, NewXk6KafkaError(
+			invalidDataType,
+			"Invalid data type provided for string serializer (requires string)",
+			fmt.Errorf("Expected: string, got: %T", data))
 	}
 }
 
-func DeserializeString(configuration Configuration, data []byte, element Element, schema string, version int) interface{} {
-	return string(data)
+func DeserializeString(configuration Configuration, data []byte, element Element, schema string, version int) (interface{}, *Xk6KafkaError) {
+	return string(data), nil
 }


### PR DESCRIPTION
This PR addresses issue #49. As I mentioned in PR #60 (issue #58), the reason is testing. It's hard to write tests when you output the error via `stdout` using `fmt.Println`. Other than that, better logging and error reporting help better spot issues.

I'll merge this to `main` and then I will continue writing and adding tests to #60, including tests for errors. 🤞 