### PR TITLE
Add TLS configuration to Schema Registry client

### DIFF
--- a/avro.go
+++ b/avro.go
@@ -14,9 +14,7 @@ const (
 func SerializeAvro(configuration Configuration, topic string, data interface{}, element Element, schema string, version int) ([]byte, *Xk6KafkaError) {
 	bytesData := []byte(data.(string))
 
-	client := SchemaRegistryClient(configuration.SchemaRegistry.Url,
-		configuration.SchemaRegistry.BasicAuth.Username,
-		configuration.SchemaRegistry.BasicAuth.Password)
+	client := SchemaRegistryClientWithConfiguration(configuration.SchemaRegistry)
 	subject := topic + "-" + string(element)
 	var schemaInfo *srclient.Schema
 	schemaID := 0
@@ -85,9 +83,7 @@ func DeserializeAvro(configuration Configuration, topic string, data []byte, ele
 			err)
 	}
 
-	client := SchemaRegistryClient(configuration.SchemaRegistry.Url,
-		configuration.SchemaRegistry.BasicAuth.Username,
-		configuration.SchemaRegistry.BasicAuth.Password)
+	client := SchemaRegistryClientWithConfiguration(configuration.SchemaRegistry)
 	subject := topic + "-" + string(element)
 	var schemaInfo *srclient.Schema
 

--- a/error_codes.go
+++ b/error_codes.go
@@ -13,6 +13,7 @@ const (
 	cannotReportStats           errCode = 1004
 	fileNotFound                errCode = 1005
 	dialerError                 errCode = 1006
+	noTLSConfig                 errCode = 1007
 
 	// serdes errors
 	invalidDataType             errCode = 2000

--- a/jsonschema.go
+++ b/jsonschema.go
@@ -16,9 +16,7 @@ const (
 func SerializeJson(configuration Configuration, topic string, data interface{}, element Element, schema string, version int) ([]byte, *Xk6KafkaError) {
 	bytesData := []byte(data.(string))
 
-	client := SchemaRegistryClient(configuration.SchemaRegistry.Url,
-		configuration.SchemaRegistry.BasicAuth.Username,
-		configuration.SchemaRegistry.BasicAuth.Password)
+	client := SchemaRegistryClientWithConfiguration(configuration.SchemaRegistry)
 	subject := topic + "-" + string(element)
 	var schemaInfo *srclient.Schema
 	schemaID := 0
@@ -87,9 +85,7 @@ func DeserializeJson(configuration Configuration, topic string, data []byte, ele
 			err)
 	}
 
-	client := SchemaRegistryClient(configuration.SchemaRegistry.Url,
-		configuration.SchemaRegistry.BasicAuth.Username,
-		configuration.SchemaRegistry.BasicAuth.Password)
+	client := SchemaRegistryClientWithConfiguration(configuration.SchemaRegistry)
 	subject := topic + "-" + string(element)
 	var schemaInfo *srclient.Schema
 

--- a/schema_registry_test.go
+++ b/schema_registry_test.go
@@ -65,6 +65,21 @@ func TestSchemaRegistryClientWithTLSConfig(t *testing.T) {
 	assert.NotNil(t, srClient)
 }
 
+func TestGetLatestSchemaFails(t *testing.T) {
+	srConfig := SchemaRegistryConfiguration{
+		Url: "http://localhost:8081",
+		BasicAuth: BasicAuth{
+			Username: "username",
+			Password: "password",
+		},
+	}
+	srClient := SchemaRegistryClientWithConfiguration(srConfig)
+	schema, err := GetSchema(srClient, "test-subject", "test-schema", srclient.Avro, 0)
+	assert.Nil(t, schema)
+	assert.NotNil(t, err)
+	assert.Equal(t, "Failed to get schema from schema registry", err.Message)
+}
+
 func TestGetSchemaFails(t *testing.T) {
 	srConfig := SchemaRegistryConfiguration{
 		Url: "http://localhost:8081",

--- a/schema_registry_test.go
+++ b/schema_registry_test.go
@@ -37,12 +37,26 @@ func TestEncodeWireFormat(t *testing.T) {
 }
 
 func TestSchemaRegistryClient(t *testing.T) {
-	srClient := SchemaRegistryClient("http://localhost:8081", "username", "password")
+	srConfig := SchemaRegistryConfiguration{
+		Url: "http://localhost:8081",
+		BasicAuth: BasicAuth{
+			Username: "username",
+			Password: "password",
+		},
+	}
+	srClient := SchemaRegistryClientWithConfiguration(srConfig)
 	assert.NotNil(t, srClient)
 }
 
 func TestGetSchemaFails(t *testing.T) {
-	srClient := SchemaRegistryClient("http://localhost:8081", "username", "password")
+	srConfig := SchemaRegistryConfiguration{
+		Url: "http://localhost:8081",
+		BasicAuth: BasicAuth{
+			Username: "username",
+			Password: "password",
+		},
+	}
+	srClient := SchemaRegistryClientWithConfiguration(srConfig)
 	schema, err := GetSchema(srClient, "test-subject", "test-schema", srclient.Avro, 1)
 	assert.Nil(t, schema)
 	assert.NotNil(t, err)
@@ -50,7 +64,14 @@ func TestGetSchemaFails(t *testing.T) {
 }
 
 func TestCreateSchemaFails(t *testing.T) {
-	srClient := SchemaRegistryClient("http://localhost:8081", "username", "password")
+	srConfig := SchemaRegistryConfiguration{
+		Url: "http://localhost:8081",
+		BasicAuth: BasicAuth{
+			Username: "username",
+			Password: "password",
+		},
+	}
+	srClient := SchemaRegistryClientWithConfiguration(srConfig)
 	schema, err := CreateSchema(srClient, "test-subject", "test-schema", srclient.Avro)
 	assert.Nil(t, schema)
 	assert.NotNil(t, err)

--- a/schema_registry_test.go
+++ b/schema_registry_test.go
@@ -48,6 +48,23 @@ func TestSchemaRegistryClient(t *testing.T) {
 	assert.NotNil(t, srClient)
 }
 
+func TestSchemaRegistryClientWithTLSConfig(t *testing.T) {
+	srConfig := SchemaRegistryConfiguration{
+		Url: "http://localhost:8081",
+		BasicAuth: BasicAuth{
+			Username: "username",
+			Password: "password",
+		},
+		TLSConfig: &TLSConfig{
+			ClientCertPem: "fixtures/client.cer",
+			ClientKeyPem:  "fixtures/client.pem",
+			ServerCaPem:   "fixtures/caroot.cer",
+		},
+	}
+	srClient := SchemaRegistryClientWithConfiguration(srConfig)
+	assert.NotNil(t, srClient)
+}
+
 func TestGetSchemaFails(t *testing.T) {
 	srConfig := SchemaRegistryConfiguration{
 		Url: "http://localhost:8081",


### PR DESCRIPTION
This PR addresses the following issue. It also breaks backward compatibility with TLS configuration in `auth.go`, where the `TLSConfig` is now a separate field containing a certificate, key, and CA fields.
- #68 