### PR TITLE
Refactor logging

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -11,7 +11,6 @@ import (
 	"github.com/segmentio/kafka-go/sasl"
 	"github.com/segmentio/kafka-go/sasl/plain"
 	"github.com/segmentio/kafka-go/sasl/scram"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -44,7 +43,6 @@ type TLSConfig struct {
 
 // GetDialer creates a kafka dialer from the given auth string or an unauthenticated dialer if the auth string is empty
 func GetDialer(saslConfig SASLConfig, tlsConfig TLSConfig) (*kafkago.Dialer, *Xk6KafkaError) {
-	logger := logrus.New()
 	// Create a unauthenticated dialer with no TLS
 	dialer := &kafkago.Dialer{
 		Timeout:   10 * time.Second,

--- a/auth.go
+++ b/auth.go
@@ -146,6 +146,7 @@ func GetTLSConfig(tlsConfig TLSConfig) (*tls.Config, *Xk6KafkaError) {
 		}
 	} else {
 		// TLS is disabled, and we continue with a unauthenticated dialer
+		// FIXME: This is not an actual error, and we should return nil instead
 		return nil, NewXk6KafkaError(
 			noTLSConfig, "No TLS config provided. Continuing with TLS disabled.", nil)
 	}

--- a/avro.go
+++ b/avro.go
@@ -3,7 +3,6 @@ package kafka
 import (
 	"github.com/linkedin/goavro/v2"
 	"github.com/riferrei/srclient"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -40,7 +39,8 @@ func SerializeAvro(configuration Configuration, topic string, data interface{}, 
 	}
 
 	if xk6KafkaError != nil {
-		logrus.New().WithField("error", xk6KafkaError).Warn("Failed to create or get schema, manually encoding the data")
+		logger.WithField("error", xk6KafkaError).Warn(
+			"Failed to create or get schema, manually encoding the data")
 		codec, err := goavro.NewCodec(schema)
 		if err != nil {
 			return nil, NewXk6KafkaError(failedCreateAvroCodec,
@@ -126,7 +126,8 @@ func DeserializeAvro(configuration Configuration, topic string, data []byte, ele
 	}
 
 	if xk6KafkaError != nil {
-		logrus.New().WithField("error", xk6KafkaError).Warn("Failed to create or get schema, manually decoding the data")
+		logger.WithField("error", xk6KafkaError).Warn(
+			"Failed to create or get schema, manually decoding the data")
 		codec, err := goavro.NewCodec(schema)
 		if err != nil {
 			return nil, NewXk6KafkaError(failedCreateAvroCodec,

--- a/consumer.go
+++ b/consumer.go
@@ -21,7 +21,7 @@ func (k *Kafka) Reader(
 	dialer, err := GetDialer(saslConfig, tlsConfig)
 	if err != nil {
 		if err.Unwrap() != nil {
-			k.logger.WithField("error", err).Error(err)
+			logger.WithField("error", err).Error(err)
 		}
 		return nil, err
 	}
@@ -43,7 +43,7 @@ func (k *Kafka) Reader(
 			if err != nil {
 				wrappedError := NewXk6KafkaError(
 					failedSetOffset, "Unable to set offset, yet returning the reader.", err)
-				k.logger.WithField("error", wrappedError).Warn(wrappedError)
+				logger.WithField("error", wrappedError).Warn(wrappedError)
 				return reader, wrappedError
 			}
 		} else {
@@ -68,7 +68,7 @@ func (k *Kafka) ConsumeWithConfiguration(
 	configuration, err := UnmarshalConfiguration(configurationJson)
 	if err != nil {
 		if err.Unwrap() != nil {
-			k.logger.WithField("error", err).Error(err)
+			logger.WithField("error", err).Error(err)
 		}
 		return nil, err
 	}
@@ -89,14 +89,14 @@ func (k *Kafka) consumeInternal(
 	configuration Configuration, keySchema string, valueSchema string) ([]map[string]interface{}, *Xk6KafkaError) {
 	state := k.vu.State()
 	if state == nil {
-		k.logger.WithField("error", ErrorForbiddenInInitContext).Error(ErrorForbiddenInInitContext)
+		logger.WithField("error", ErrorForbiddenInInitContext).Error(ErrorForbiddenInInitContext)
 		return nil, ErrorForbiddenInInitContext
 	}
 
 	ctx := k.vu.Context()
 	if ctx == nil {
 		err := NewXk6KafkaError(noContextError, "No context.", nil)
-		k.logger.WithField("error", err).Info(err)
+		logger.WithField("error", err).Info(err)
 		return nil, err
 	}
 
@@ -123,13 +123,13 @@ func (k *Kafka) consumeInternal(
 			err := k.reportReaderStats(reader.Stats())
 			if err != nil {
 				if err.Unwrap() != nil {
-					k.logger.WithField("error", err).Error(err)
+					logger.WithField("error", err).Error(err)
 				}
 				return nil, err
 			}
 
 			err = NewXk6KafkaError(noMoreMessages, "No more messages.", nil)
-			k.logger.WithField("error", err).Info(err)
+			logger.WithField("error", err).Info(err)
 			return messages, err
 		}
 
@@ -137,12 +137,12 @@ func (k *Kafka) consumeInternal(
 			err := k.reportReaderStats(reader.Stats())
 			if err != nil {
 				if err.Unwrap() != nil {
-					k.logger.WithField("error", err).Error(err)
+					logger.WithField("error", err).Error(err)
 				}
 				return messages, err
 			}
 			err = NewXk6KafkaError(failedReadMessage, "Unable to read messages.", nil)
-			k.logger.WithField("error", err).Error(err)
+			logger.WithField("error", err).Error(err)
 			return messages, err
 		}
 
@@ -152,7 +152,7 @@ func (k *Kafka) consumeInternal(
 			message["key"], wrappedError = keyDeserializer(
 				configuration, reader.Config().Topic, msg.Key, Key, keySchema, 0)
 			if wrappedError != nil && wrappedError.Unwrap() != nil {
-				k.logger.WithField("error", wrappedError).Error(wrappedError)
+				logger.WithField("error", wrappedError).Error(wrappedError)
 			}
 		}
 
@@ -161,7 +161,7 @@ func (k *Kafka) consumeInternal(
 			message["value"], wrappedError = valueDeserializer(
 				configuration, reader.Config().Topic, msg.Value, "value", valueSchema, 0)
 			if wrappedError != nil && wrappedError.Unwrap() != nil {
-				k.logger.WithField("error", wrappedError).Error(wrappedError)
+				logger.WithField("error", wrappedError).Error(wrappedError)
 			}
 		}
 
@@ -179,7 +179,7 @@ func (k *Kafka) consumeInternal(
 	err = k.reportReaderStats(reader.Stats())
 	if err != nil {
 		if err.Unwrap() != nil {
-			k.logger.WithField("error", err).Error(err)
+			logger.WithField("error", err).Error(err)
 		}
 		return messages, err
 	}
@@ -191,14 +191,14 @@ func (k *Kafka) consumeInternal(
 func (k *Kafka) reportReaderStats(currentStats kafkago.ReaderStats) *Xk6KafkaError {
 	state := k.vu.State()
 	if state == nil {
-		k.logger.WithField("error", ErrorForbiddenInInitContext).Error(ErrorForbiddenInInitContext)
+		logger.WithField("error", ErrorForbiddenInInitContext).Error(ErrorForbiddenInInitContext)
 		return ErrorForbiddenInInitContext
 	}
 
 	ctx := k.vu.Context()
 	if ctx == nil {
 		err := NewXk6KafkaError(contextCancelled, "No context.", nil)
-		k.logger.WithField("error", err).Info(err)
+		logger.WithField("error", err).Info(err)
 		return err
 	}
 

--- a/jsonschema.go
+++ b/jsonschema.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/riferrei/srclient"
 	"github.com/santhosh-tekuri/jsonschema/v5"
-	"github.com/sirupsen/logrus"
 )
 
 const (
@@ -37,7 +36,8 @@ func SerializeJson(configuration Configuration, topic string, data interface{}, 
 	}
 
 	if xk6KafkaError != nil {
-		logrus.New().WithField("error", xk6KafkaError).Warn("Failed to create or get schema, manually encoding the data")
+		logger.WithField("error", xk6KafkaError).Warn(
+			"Failed to create or get schema, manually encoding the data")
 		codec, err := jsonschema.CompileString(subject, schema)
 		if err != nil {
 			return nil, NewXk6KafkaError(failedCreateJsonSchemaCodec,
@@ -110,7 +110,8 @@ func DeserializeJson(configuration Configuration, topic string, data []byte, ele
 	}
 
 	if xk6KafkaError != nil {
-		logrus.New().WithField("error", xk6KafkaError).Warn("Failed to create or get schema, manually decoding the data")
+		logger.WithField("error", xk6KafkaError).Warn(
+			"Failed to create or get schema, manually decoding the data")
 		codec, err := jsonschema.CompileString(string(element), schema)
 		if err != nil {
 			return nil, NewXk6KafkaError(failedCreateJsonSchemaCodec,

--- a/module.go
+++ b/module.go
@@ -7,8 +7,15 @@ import (
 	"go.k6.io/k6/js/modules"
 )
 
+// Global logger used by the Kafka module.
+var logger *logrus.Logger
+
 // init registers the xk6-kafka module as 'k6/x/kafka'
 func init() {
+	// Initialize the global logger
+	logger = logrus.New()
+
+	// Register the module namespace (aka. JS import path)
 	modules.Register("k6/x/kafka", New())
 }
 
@@ -16,7 +23,6 @@ type (
 	Kafka struct {
 		vu                   modules.VU
 		metrics              kafkaMetrics
-		logger               *logrus.Logger
 		serializerRegistry   *Serde[Serializer]
 		deserializerRegistry *Serde[Deserializer]
 	}
@@ -49,7 +55,6 @@ func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 	return &KafkaModule{Kafka: &Kafka{
 		vu:                   vu,
 		metrics:              m,
-		logger:               logrus.New(),
 		serializerRegistry:   NewSerializersRegistry(),
 		deserializerRegistry: NewDeserializersRegistry()},
 	}

--- a/producer.go
+++ b/producer.go
@@ -29,7 +29,7 @@ func (k *Kafka) Writer(brokers []string, topic string, saslConfig SASLConfig, tl
 	dialer, err := GetDialer(saslConfig, tlsConfig)
 	if err != nil {
 		if err.Unwrap() != nil {
-			k.logger.WithField("error", err).Error(err)
+			logger.WithField("error", err).Error(err)
 		}
 		return nil, err
 	}
@@ -70,7 +70,7 @@ func (k *Kafka) ProduceWithConfiguration(
 	configuration, err := UnmarshalConfiguration(configurationJson)
 	if err != nil {
 		if err.Unwrap() != nil {
-			k.logger.WithField("error", err).Error(err)
+			logger.WithField("error", err).Error(err)
 		}
 		return err
 	}
@@ -92,14 +92,14 @@ func (k *Kafka) produceInternal(
 	configuration Configuration, keySchema string, valueSchema string) *Xk6KafkaError {
 	state := k.vu.State()
 	if state == nil {
-		k.logger.WithField("error", ErrorForbiddenInInitContext).Error(ErrorForbiddenInInitContext)
+		logger.WithField("error", ErrorForbiddenInInitContext).Error(ErrorForbiddenInInitContext)
 		return ErrorForbiddenInInitContext
 	}
 
 	ctx := k.vu.Context()
 	if ctx == nil {
 		err := NewXk6KafkaError(noContextError, "No context.", nil)
-		k.logger.WithField("error", err).Info(err)
+		logger.WithField("error", err).Info(err)
 		return err
 	}
 
@@ -138,7 +138,7 @@ func (k *Kafka) produceInternal(
 			keyData, err := keySerializer(
 				configuration, writer.Stats().Topic, message["key"], "key", keySchema, 0)
 			if err != nil && err.Unwrap() != nil {
-				k.logger.WithField("error", err).Error(err)
+				logger.WithField("error", err).Error(err)
 			}
 
 			kafkaMessages[i].Key = keyData
@@ -147,7 +147,7 @@ func (k *Kafka) produceInternal(
 		// Then add the message
 		valueData, err := valueSerializer(configuration, writer.Stats().Topic, message["value"], "value", valueSchema, 0)
 		if err != nil && err.Unwrap() != nil {
-			k.logger.WithField("error", err).Error(err)
+			logger.WithField("error", err).Error(err)
 		}
 
 		kafkaMessages[i].Value = valueData
@@ -167,18 +167,18 @@ func (k *Kafka) produceInternal(
 
 	err = k.reportWriterStats(writer.Stats())
 	if err != nil {
-		k.logger.WithField("error", err).Error(err)
+		logger.WithField("error", err).Error(err)
 	}
 
 	if originalErr != nil {
 		if originalErr == k.vu.Context().Err() {
-			k.logger.WithField("error", k.vu.Context().Err()).Error(k.vu.Context().Err())
+			logger.WithField("error", k.vu.Context().Err()).Error(k.vu.Context().Err())
 			return NewXk6KafkaError(contextCancelled, "Context cancelled.", originalErr)
 		} else {
 			// TODO: fix this
 			// Ignore stats reporting errors here, because we can't return twice,
 			// and there is no way to wrap the error in another one.
-			k.logger.WithField("error", originalErr).Error(originalErr)
+			logger.WithField("error", originalErr).Error(originalErr)
 			return NewXk6KafkaError(failedWriteMessage, "Failed to write messages.", err)
 		}
 	}
@@ -190,14 +190,14 @@ func (k *Kafka) produceInternal(
 func (k *Kafka) reportWriterStats(currentStats kafkago.WriterStats) *Xk6KafkaError {
 	state := k.vu.State()
 	if state == nil {
-		k.logger.WithField("error", ErrorForbiddenInInitContext).Error(ErrorForbiddenInInitContext)
+		logger.WithField("error", ErrorForbiddenInInitContext).Error(ErrorForbiddenInInitContext)
 		return ErrorForbiddenInInitContext
 	}
 
 	ctx := k.vu.Context()
 	if ctx == nil {
 		err := NewXk6KafkaError(cannotReportStats, "Cannot report writer stats, no context.", nil)
-		k.logger.WithField("error", err).Info(err)
+		logger.WithField("error", err).Info(err)
 		return err
 	}
 

--- a/schema_registry.go
+++ b/schema_registry.go
@@ -4,9 +4,9 @@ import (
 	"encoding/binary"
 	"encoding/json"
 	"fmt"
-	"github.com/riferrei/srclient"
-	"github.com/sirupsen/logrus"
 	"net/http"
+
+	"github.com/riferrei/srclient"
 )
 
 type Element string
@@ -66,7 +66,7 @@ func SchemaRegistryClientWithConfiguration(configuration SchemaRegistryConfigura
 
 	tlsConfig, err := GetTLSConfig(configuration.TLSConfig)
 	if err != nil {
-		logrus.New().WithField("error", err).Warn("Failed to get TLS config. Continuing without TLS.")
+		logger.WithField("error", err).Warn("Failed to get TLS config. Continuing without TLS.")
 		srClient = srclient.CreateSchemaRegistryClient(configuration.Url)
 	}
 

--- a/topic.go
+++ b/topic.go
@@ -15,7 +15,7 @@ import (
 func (k *Kafka) GetKafkaControllerConnection(address string, saslConfig SASLConfig, tlsConfig TLSConfig) (*kafkago.Conn, *Xk6KafkaError) {
 	dialer, wrappedError := GetDialer(saslConfig, tlsConfig)
 	if wrappedError != nil {
-		k.logger.WithField("error", wrappedError).Error(wrappedError)
+		logger.WithField("error", wrappedError).Error(wrappedError)
 		if dialer == nil {
 			return nil, wrappedError
 		}
@@ -24,21 +24,21 @@ func (k *Kafka) GetKafkaControllerConnection(address string, saslConfig SASLConf
 	ctx := k.vu.Context()
 	if ctx == nil {
 		err := NewXk6KafkaError(noContextError, "No context.", nil)
-		k.logger.WithField("error", err).Info(err)
+		logger.WithField("error", err).Info(err)
 		return nil, err
 	}
 
 	conn, err := dialer.DialContext(ctx, "tcp", address)
 	if err != nil {
 		wrappedError := NewXk6KafkaError(dialerError, "Failed to create dialer.", err)
-		k.logger.WithField("error", wrappedError).Error(wrappedError)
+		logger.WithField("error", wrappedError).Error(wrappedError)
 		return nil, wrappedError
 	}
 
 	controller, err := conn.Controller()
 	if err != nil {
 		wrappedError := NewXk6KafkaError(failedGetController, "Failed to get controller.", err)
-		k.logger.WithField("error", wrappedError).Error(wrappedError)
+		logger.WithField("error", wrappedError).Error(wrappedError)
 		return nil, wrappedError
 	}
 
@@ -46,7 +46,7 @@ func (k *Kafka) GetKafkaControllerConnection(address string, saslConfig SASLConf
 		ctx, "tcp", net.JoinHostPort(controller.Host, strconv.Itoa(controller.Port)))
 	if err != nil {
 		wrappedError := NewXk6KafkaError(failedGetController, "Failed to get controller.", err)
-		k.logger.WithField("error", wrappedError).Error(wrappedError)
+		logger.WithField("error", wrappedError).Error(wrappedError)
 		return nil, wrappedError
 	}
 
@@ -87,7 +87,7 @@ func (k *Kafka) CreateTopic(address, topic string, partitions, replicationFactor
 	err := conn.CreateTopics([]kafkago.TopicConfig{topicConfig}...)
 	if err != nil {
 		wrappedError := NewXk6KafkaError(failedCreateTopic, "Failed to create topic.", err)
-		k.logger.WithField("error", wrappedError).Error(wrappedError)
+		logger.WithField("error", wrappedError).Error(wrappedError)
 		return wrappedError
 	}
 
@@ -125,7 +125,7 @@ func (k *Kafka) ListTopics(address string, saslConfig SASLConfig, tlsConfig TLSC
 	partitions, err := conn.ReadPartitions()
 	if err != nil {
 		wrappedError := NewXk6KafkaError(failedReadPartitions, "Failed to read partitions.", err)
-		k.logger.WithField("error", wrappedError).Error(wrappedError)
+		logger.WithField("error", wrappedError).Error(wrappedError)
 		return nil, wrappedError
 	}
 


### PR DESCRIPTION
This PR refactors logging (#81), as it was scattered all over the place. This change introduces a global logger that all functions can use. This change won't affect the API but how the logging works internally in the extension.