### PR TITLE
Export all constants to JS code

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -13,17 +13,17 @@ import (
 	"github.com/segmentio/kafka-go/sasl/scram"
 )
 
+var (
+	// TLSVersions is a map of TLS versions to their numeric values.
+	TLSVersions map[string]uint16
+)
+
 const (
-	None              = "none"
-	SASL_Plain        = "sasl_plain"
+	NONE              = "none"
+	SASL_PLAIN        = "sasl_plain"
 	SASL_SCRAM_SHA256 = "sasl_scram_sha256"
 	SASL_SCRAM_SHA512 = "sasl_scram_sha512"
 	SASL_SSL          = "sasl_ssl"
-
-	TLSv10 = "TLSv1.0"
-	TLSv11 = "TLSv1.1"
-	TLSv12 = "TLSv1.2"
-	TLSv13 = "TLSv1.3"
 )
 
 type SASLConfig struct {
@@ -77,13 +77,13 @@ func GetDialer(saslConfig SASLConfig, tlsConfig TLSConfig) (*kafkago.Dialer, *Xk
 // GetSASLMechanism returns a kafka SASL config from the given credentials
 func GetSASLMechanism(saslConfig SASLConfig) (sasl.Mechanism, *Xk6KafkaError) {
 	if saslConfig.Algorithm == "" {
-		saslConfig.Algorithm = None
+		saslConfig.Algorithm = NONE
 	}
 
 	switch saslConfig.Algorithm {
-	case None:
+	case NONE:
 		return nil, nil
-	case SASL_Plain, SASL_SSL:
+	case SASL_PLAIN, SASL_SSL:
 		mechanism := plain.Mechanism{
 			Username: saslConfig.Username,
 			Password: saslConfig.Password,
@@ -115,13 +115,6 @@ func GetTLSConfig(tlsConfig TLSConfig) (*tls.Config, *Xk6KafkaError) {
 	var tlsObject *tls.Config
 
 	if tlsConfig.EnableTLS {
-		// TODO: Export them as module level constants (flags)
-		TLSVersions := make(map[string]uint16)
-		TLSVersions[TLSv10] = tls.VersionTLS10
-		TLSVersions[TLSv11] = tls.VersionTLS11
-		TLSVersions[TLSv12] = tls.VersionTLS12
-		TLSVersions[TLSv13] = tls.VersionTLS13
-
 		// Create a TLS config with default settings
 		tlsObject = &tls.Config{
 			InsecureSkipVerify: tlsConfig.InsecureSkipTLSVerify,

--- a/auth_test.go
+++ b/auth_test.go
@@ -15,7 +15,7 @@ func TestGetDialerWithSASLPlainAndFullTLSConfig(t *testing.T) {
 	saslConfig := SASLConfig{
 		Username:  "test",
 		Password:  "test",
-		Algorithm: SASL_Plain,
+		Algorithm: SASL_PLAIN,
 	}
 	tlsConfig := TLSConfig{
 		EnableTLS:             true,
@@ -40,7 +40,7 @@ func TestGetDialerWithSASLPlainWithDefaultTLSConfig(t *testing.T) {
 	saslConfig := SASLConfig{
 		Username:  "test",
 		Password:  "test",
-		Algorithm: SASL_Plain,
+		Algorithm: SASL_PLAIN,
 	}
 	dialer, err := GetDialer(saslConfig, TLSConfig{EnableTLS: true})
 	assert.Nil(t, err)

--- a/consumer.go
+++ b/consumer.go
@@ -108,7 +108,7 @@ func (k *Kafka) consumeInternal(
 	if err != nil {
 		configuration.Consumer.KeyDeserializer = DefaultDeserializer
 		configuration.Consumer.ValueDeserializer = DefaultDeserializer
-		state.Logger.WithField("error", err).Warn("Using default string serializers")
+		logger.WithField("error", err).Warn("Using default string serializers")
 	}
 
 	keyDeserializer := k.GetDeserializer(configuration.Consumer.KeyDeserializer)

--- a/docs/README.md
+++ b/docs/README.md
@@ -4,6 +4,50 @@ This documentation refers to the development version of the xk6-kafka project, w
 
 ## Table of contents
 
+### Module-level constants
+
+The following constants are available on the module-level (and the default export) and you can use them for various purposes. The usage of these constants are available in the example [scripts](https://github.com/mostafa/xk6-kafka/blob/main/scripts/) directory.
+
+```json
+{
+    // TLS versions
+    "TLS_1_0": "tls1.0",
+    "TLS_1_1": "tls1.1",
+    "TLS_1_2": "tls1.2",
+    "TLS_1_3": "tls1.3",
+
+    // SASL mechanisms
+    "NONE": "none",
+    "SASL_PLAIN": "sasl_plain",
+    "SASL_SCRAM_SHA256": "sasl_scram_sha256",
+    "SASL_SCRAM_SHA512": "sasl_scram_sha512",
+    "SASL_SSL": "sasl_ssl",
+
+    // Compression codecs
+    "CODEC_GZIP": "gzip",
+    "CODEC_SNAPPY": "snappy",
+    "CODEC_LZ4": "lz4",
+    "CODEC_ZSTD": "zstd",
+
+    // Serde types
+    "STRING_SERIALIZER": "org.apache.kafka.common.serialization.StringSerializer",
+    "STRING_DESERIALIZER": "org.apache.kafka.common.serialization.StringDeserializer",
+    "BYTE_ARRAY_SERIALIZER": "org.apache.kafka.common.serialization.ByteArraySerializer",
+    "BYTE_ARRAY_DESERIALIZER": "org.apache.kafka.common.serialization.ByteArrayDeserializer",
+    "JSON_SCHEMA_SERIALIZER": "io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializer",
+    "JSON_SCHEMA_DESERIALIZER": "io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer",
+    "AVRO_SERIALIZER": "io.confluent.kafka.serializers.KafkaAvroSerializer",
+    "AVRO_DESERIALIZER": "io.confluent.kafka.serializers.KafkaAvroDeserializer",
+    "PROTOBUF_SERIALIZER": "io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer",
+    "PROTOBUF_DESERIALIZER": "io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializer",
+
+    // TopicNameStrategy types
+    "TOPIC_NAME_STRATEGY": "TopicNameStrategy",
+    "RECORD_NAME_STRATEGY": "RecordNameStrategy",
+    "TOPIC_RECORD_NAME_STRATEGY": "TopicRecordNameStrategy",
+}
+```
+
 ### Functions
 
 - [consume](README.md#consume)
@@ -28,12 +72,12 @@ Read a sequence of messages from Kafka.
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `reader` | `Object` | The reader object created with the reader constructor. |
-| `limit` | `Number` | How many messages should be read in one go, which blocks. Defaults to 1. |
-| `keySchema` | `String` | An optional Avro/JSONSchema schema for the key. |
-| `valueSchema` | `String` | An optional Avro/JSONSchema schema for the value. |
+| Name          | Type     | Description                                                              |
+| :------------ | :------- | :----------------------------------------------------------------------- |
+| `reader`      | `Object` | The reader object created with the reader constructor.                   |
+| `limit`       | `Number` | How many messages should be read in one go, which blocks. Defaults to 1. |
+| `keySchema`   | `String` | An optional Avro/JSONSchema schema for the key.                          |
+| `valueSchema` | `String` | An optional Avro/JSONSchema schema for the value.                        |
 
 #### Returns
 
@@ -53,13 +97,13 @@ Read a sequence of messages from Kafka.
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `reader` | `object` | The reader object created with the reader constructor. |
-| `limit` | `Number` | How many messages should be read in one go, which blocks. Defaults to 1. |
-| `configurationJson` | `String` | Serializer, deserializer and schemaRegistry configuration. |
-| `keySchema` | `String` | An optional Avro/JSONSchema schema for the key. |
-| `valueSchema` | `String` | An optional Avro/JSONSchema schema for the value. |
+| Name                | Type     | Description                                                              |
+| :------------------ | :------- | :----------------------------------------------------------------------- |
+| `reader`            | `object` | The reader object created with the reader constructor.                   |
+| `limit`             | `Number` | How many messages should be read in one go, which blocks. Defaults to 1. |
+| `configurationJson` | `String` | Serializer, deserializer and schemaRegistry configuration.               |
+| `keySchema`         | `String` | An optional Avro/JSONSchema schema for the key.                          |
+| `valueSchema`       | `String` | An optional Avro/JSONSchema schema for the value.                        |
 
 #### Returns
 
@@ -79,15 +123,15 @@ Create a topic in Kafka. It does nothing if the topic exists.
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `address` | `String` | The broker address. |
-| `topic` | `String` | The topic name. |
-| `partitions` | `Number` | The Number of partitions. |
+| Name                | Type     | Description                                  |
+| :------------------ | :------- | :------------------------------------------- |
+| `address`           | `String` | The broker address.                          |
+| `topic`             | `String` | The topic name.                              |
+| `partitions`        | `Number` | The Number of partitions.                    |
 | `replicationFactor` | `Number` | The replication factor in a clustered setup. |
-| `compression` | `String` | The compression algorithm. |
-| `saslConfig` | `object` | The SASL configuration. |
-| `tlsConfig` | `object` | The TLS configuration. |
+| `compression`       | `String` | The compression algorithm.                   |
+| `saslConfig`        | `object` | The SASL configuration.                      |
+| `tlsConfig`         | `object` | The TLS configuration.                       |
 
 #### Returns
 
@@ -107,12 +151,12 @@ Delete a topic from Kafka. It raises an error if the topic doesn't exist.
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `address` | `String` | The broker address. |
-| `topic` | `String` | The topic name. |
+| Name         | Type     | Description             |
+| :----------- | :------- | :---------------------- |
+| `address`    | `String` | The broker address.     |
+| `topic`      | `String` | The topic name.         |
 | `saslConfig` | `Object` | The SASL configuration. |
-| `tlsConfig` | `object` | The TLS configuration. |
+| `tlsConfig`  | `object` | The TLS configuration.  |
 
 #### Returns
 
@@ -132,11 +176,11 @@ List all topics in Kafka.
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `address` | `String` | The broker address. |
+| Name         | Type     | Description             |
+| :----------- | :------- | :---------------------- |
+| `address`    | `String` | The broker address.     |
 | `saslConfig` | `Object` | The SASL configuration. |
-| `tlsConfig` | `Object` | The TLS configuration. |
+| `tlsConfig`  | `Object` | The TLS configuration.  |
 
 #### Returns
 
@@ -156,13 +200,13 @@ Write a sequence of messages to Kafka.
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `writer` | `Object` | The writer object created with the writer constructor. |
-| `messages` | [`Object`] | An array of message objects containing an optional key and a value. Topic, offset and time and headers are also available and optional. Headers are objects. |
-| `keySchema` | `String` | An optional Avro/JSONSchema schema for the key. |
-| `valueSchema` | `String` | An optional Avro/JSONSchema schema for the value. |
-| `autoCreateTopic` | `boolean` | Automatically creates the topic on the first produced message. Defaults to false. |
+| Name              | Type       | Description                                                                                                                                                  |
+| :---------------- | :--------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `writer`          | `Object`   | The writer object created with the writer constructor.                                                                                                       |
+| `messages`        | [`Object`] | An array of message objects containing an optional key and a value. Topic, offset and time and headers are also available and optional. Headers are objects. |
+| `keySchema`       | `String`   | An optional Avro/JSONSchema schema for the key.                                                                                                              |
+| `valueSchema`     | `String`   | An optional Avro/JSONSchema schema for the value.                                                                                                            |
+| `autoCreateTopic` | `boolean`  | Automatically creates the topic on the first produced message. Defaults to false.                                                                            |
 
 #### Returns
 
@@ -182,14 +226,14 @@ Write a sequence of messages to Kafka with a specific serializer/deserializer.
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `writer` | `Object` | The writer object created with the writer constructor. |
-| `messages` | [`Object`] | An array of message objects containing an optional key and a value. Topic, offset and time and headers are also available and optional. Headers are objects. |
-| `configurationJson` | `String` | Serializer, deserializer and schemaRegistry configuration. |
-| `keySchema` | `String` | An optional Avro/JSONSchema schema for the key. |
-| `valueSchema` | `String` | An optional Avro/JSONSchema schema for the value. |
-| `autoCreateTopic` | `boolean` | Automatically creates the topic on the first produced message. Defaults to false. |
+| Name                | Type       | Description                                                                                                                                                  |
+| :------------------ | :--------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `writer`            | `Object`   | The writer object created with the writer constructor.                                                                                                       |
+| `messages`          | [`Object`] | An array of message objects containing an optional key and a value. Topic, offset and time and headers are also available and optional. Headers are objects. |
+| `configurationJson` | `String`   | Serializer, deserializer and schemaRegistry configuration.                                                                                                   |
+| `keySchema`         | `String`   | An optional Avro/JSONSchema schema for the key.                                                                                                              |
+| `valueSchema`       | `String`   | An optional Avro/JSONSchema schema for the value.                                                                                                            |
+| `autoCreateTopic`   | `boolean`  | Automatically creates the topic on the first produced message. Defaults to false.                                                                            |
 
 #### Returns
 
@@ -207,15 +251,15 @@ Create a new Reader object for reading messages from Kafka.
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `brokers` | [`String`] | An array of brokers, e.g. ["host:port", ...]. |
-| `topic` | `String` | The topic to read from. |
-| `partition` | `Number` | The partition. |
-| `groupID` | `String` | The group ID. |
-| `offset` | `Number` | The offset to begin reading from. |
-| `saslConfig` | `object` | The SASL configuration. |
-| `tlsConfig` | `object` | The TLS configuration. |
+| Name         | Type       | Description                                   |
+| :----------- | :--------- | :-------------------------------------------- |
+| `brokers`    | [`String`] | An array of brokers, e.g. ["host:port", ...]. |
+| `topic`      | `String`   | The topic to read from.                       |
+| `partition`  | `Number`   | The partition.                                |
+| `groupID`    | `String`   | The group ID.                                 |
+| `offset`     | `Number`   | The offset to begin reading from.             |
+| `saslConfig` | `object`   | The SASL configuration.                       |
+| `tlsConfig`  | `object`   | The TLS configuration.                        |
 
 #### Returns
 
@@ -233,13 +277,13 @@ Create a new Writer object for writing messages to Kafka.
 
 #### Parameters
 
-| Name | Type | Description |
-| :------ | :------ | :------ |
-| `brokers` | [`String`] | An array of brokers, e.g. ["host:port", ...]. |
-| `topic` | `String` | The topic to write to. |
-| `saslConfig` | `object` | The SASL configuration. |
-| `tlsConfig` | `object` | The TLS configuration. |
-| `compression` | `String` | The Compression algorithm. |
+| Name          | Type       | Description                                   |
+| :------------ | :--------- | :-------------------------------------------- |
+| `brokers`     | [`String`] | An array of brokers, e.g. ["host:port", ...]. |
+| `topic`       | `String`   | The topic to write to.                        |
+| `saslConfig`  | `object`   | The SASL configuration.                       |
+| `tlsConfig`   | `object`   | The TLS configuration.                        |
+| `compression` | `String`   | The Compression algorithm.                    |
 
 #### Returns
 

--- a/module.go
+++ b/module.go
@@ -1,19 +1,40 @@
 package kafka
 
 import (
+	"crypto/tls"
+
 	"github.com/dop251/goja"
+	"github.com/segmentio/kafka-go/compress"
 	"github.com/sirupsen/logrus"
 	"go.k6.io/k6/js/common"
 	"go.k6.io/k6/js/modules"
+	"go.k6.io/k6/lib/netext"
 )
 
-// Global logger used by the Kafka module.
-var logger *logrus.Logger
+var (
+	// logger is globally used by the Kafka module.
+	logger *logrus.Logger
+)
 
 // init registers the xk6-kafka module as 'k6/x/kafka'
 func init() {
 	// Initialize the global logger
 	logger = logrus.New()
+
+	// Initialize the TLS versions map
+	TLSVersions = map[string]uint16{
+		netext.TLS_1_0: tls.VersionTLS10,
+		netext.TLS_1_1: tls.VersionTLS11,
+		netext.TLS_1_2: tls.VersionTLS12,
+		netext.TLS_1_3: tls.VersionTLS13,
+	}
+
+	CompressionCodecs = map[string]compress.Compression{
+		CODEC_GZIP:   compress.Gzip,
+		CODEC_SNAPPY: compress.Snappy,
+		CODEC_LZ4:    compress.Lz4,
+		CODEC_ZSTD:   compress.Zstd,
+	}
 
 	// Register the module namespace (aka. JS import path)
 	modules.Register("k6/x/kafka", New())
@@ -25,6 +46,7 @@ type (
 		metrics              kafkaMetrics
 		serializerRegistry   *Serde[Serializer]
 		deserializerRegistry *Serde[Deserializer]
+		exports              *goja.Object
 	}
 	RootModule  struct{}
 	KafkaModule struct {
@@ -44,24 +66,102 @@ func New() *RootModule {
 
 // NewModuleInstance creates a new instance of the Kafka module
 func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
+	rt := vu.Runtime()
+
 	m, err := registerMetrics(vu)
 	if err != nil {
 		common.Throw(vu.Runtime(), err)
 	}
 
+	// Create a new Kafka module
+	kafkaModuleInstance := &KafkaModule{
+		Kafka: &Kafka{
+			vu:                   vu,
+			metrics:              m,
+			serializerRegistry:   NewSerializersRegistry(),
+			deserializerRegistry: NewDeserializersRegistry(),
+			exports:              rt.NewObject(),
+		},
+	}
+
+	// Export constants to the JS code
+	kafkaModuleInstance.defineConstants()
+
+	mustExport := func(name string, value interface{}) {
+		if err := kafkaModuleInstance.exports.Set(name, value); err != nil {
+			common.Throw(rt, err)
+		}
+	}
+
+	// Export the functions from the Kafka module to the JS code
+	mustExport("writer", kafkaModuleInstance.Writer)
+	mustExport("produce", kafkaModuleInstance.Produce)
+	mustExport("produceWithConfiguration", kafkaModuleInstance.ProduceWithConfiguration)
+	mustExport("reader", kafkaModuleInstance.Reader)
+	mustExport("consume", kafkaModuleInstance.Consume)
+	mustExport("consumeWithConfiguration", kafkaModuleInstance.ConsumeWithConfiguration)
+	mustExport("createTopic", kafkaModuleInstance.CreateTopic)
+	mustExport("deleteTopic", kafkaModuleInstance.DeleteTopic)
+	mustExport("listTopics", kafkaModuleInstance.ListTopics)
+
 	// This causes the struct fields to be exported to the native (camelCases) JS code.
 	vu.Runtime().SetFieldNameMapper(goja.TagFieldNameMapper("json", true))
 
-	return &KafkaModule{Kafka: &Kafka{
-		vu:                   vu,
-		metrics:              m,
-		serializerRegistry:   NewSerializersRegistry(),
-		deserializerRegistry: NewDeserializersRegistry()},
-	}
+	return kafkaModuleInstance
 }
 
 // Exports returns the exports of the Kafka module, which are the functions
 // that can be called from the JS code.
 func (c *KafkaModule) Exports() modules.Exports {
-	return modules.Exports{Default: c.Kafka}
+	return modules.Exports{
+		Default: c.Kafka.exports,
+	}
+}
+
+func (c *KafkaModule) defineConstants() {
+	rt := c.vu.Runtime()
+	mustAddProp := func(name, val string) {
+		err := c.exports.DefineDataProperty(
+			name, rt.ToValue(val), goja.FLAG_FALSE, goja.FLAG_FALSE, goja.FLAG_TRUE,
+		)
+		if err != nil {
+			common.Throw(rt, err)
+		}
+	}
+
+	// TLS versions
+	mustAddProp("TLS_1_0", netext.TLS_1_0)
+	mustAddProp("TLS_1_1", netext.TLS_1_1)
+	mustAddProp("TLS_1_2", netext.TLS_1_2)
+	mustAddProp("TLS_1_3", netext.TLS_1_3)
+
+	// SASL mechanisms
+	mustAddProp("NONE", NONE)
+	mustAddProp("SASL_PLAIN", SASL_PLAIN)
+	mustAddProp("SASL_SCRAM_SHA256", SASL_SCRAM_SHA256)
+	mustAddProp("SASL_SCRAM_SHA512", SASL_SCRAM_SHA512)
+	mustAddProp("SASL_SSL", SASL_SSL)
+
+	// Compression codecs
+	mustAddProp("CODEC_GZIP", CODEC_GZIP)
+	mustAddProp("CODEC_SNAPPY", CODEC_SNAPPY)
+	mustAddProp("CODEC_LZ4", CODEC_LZ4)
+	mustAddProp("CODEC_ZSTD", CODEC_ZSTD)
+
+	// Serde types
+	mustAddProp("STRING_SERIALIZER", StringSerializer)
+	mustAddProp("STRING_DESERIALIZER", StringDeserializer)
+	mustAddProp("BYTE_ARRAY_SERIALIZER", ByteArraySerializer)
+	mustAddProp("BYTE_ARRAY_DESERIALIZER", ByteArrayDeserializer)
+	mustAddProp("JSON_SCHEMA_SERIALIZER", JsonSchemaSerializer)
+	mustAddProp("JSON_SCHEMA_DESERIALIZER", JsonSchemaDeserializer)
+	mustAddProp("AVRO_SERIALIZER", AvroSerializer)
+	mustAddProp("AVRO_DESERIALIZER", AvroDeserializer)
+	mustAddProp("PROTOBUF_SERIALIZER", ProtobufSerializer)
+	mustAddProp("PROTOBUF_DESERIALIZER", ProtobufDeserializer)
+
+	// TopicNameStrategy types
+	mustAddProp("TOPIC_NAME_STRATEGY", TopicNameStrategy)
+	mustAddProp("RECORD_NAME_STRATEGY", RecordNameStrategy)
+	mustAddProp("TOPIC_RECORD_NAME_STRATEGY", TopicRecordNameStrategy)
 }

--- a/producer.go
+++ b/producer.go
@@ -10,14 +10,14 @@ import (
 )
 
 var (
-	// CompressionCodecs is a map of compression codec names to their respective codecs
-	// TODO: add as global constants to JS
-	CompressionCodecs = map[string]compress.Codec{
-		"Gzip":   &compress.GzipCodec,
-		"Snappy": &compress.SnappyCodec,
-		"Lz4":    &compress.Lz4Codec,
-		"Zstd":   &compress.ZstdCodec,
-	}
+	// Compression codecs
+	CODEC_GZIP   = "gzip"
+	CODEC_SNAPPY = "snappy"
+	CODEC_LZ4    = "lz4"
+	CODEC_ZSTD   = "zstd"
+
+	// CompressionCodecs is a map of compression codec names to their respective codecs.
+	CompressionCodecs map[string]compress.Compression
 
 	// DefaultSerializer is string serializer
 	DefaultSerializer = StringSerializer
@@ -45,7 +45,7 @@ func (k *Kafka) Writer(brokers []string, topic string, saslConfig SASLConfig, tl
 	}
 
 	if codec, ok := CompressionCodecs[compression]; ok {
-		writerConfig.CompressionCodec = codec
+		writerConfig.CompressionCodec = compress.Codecs[codec]
 	}
 
 	// TODO: instantiate Writer directly

--- a/producer.go
+++ b/producer.go
@@ -107,7 +107,7 @@ func (k *Kafka) produceInternal(
 	if err != nil {
 		configuration.Producer.KeySerializer = DefaultSerializer
 		configuration.Producer.ValueSerializer = DefaultSerializer
-		state.Logger.WithField("error", err).Warn("Using default string serializers")
+		logger.WithField("error", err).Warn("Using default string serializers")
 	}
 
 	keySerializer := k.GetSerializer(configuration.Producer.KeySerializer)

--- a/scripts/test_avro_with_schema_registry.js
+++ b/scripts/test_avro_with_schema_registry.js
@@ -11,6 +11,8 @@ import {
     produceWithConfiguration,
     createTopic,
     deleteTopic,
+    AVRO_SERIALIZER,
+    AVRO_DESERIALIZER,
 } from "k6/x/kafka"; // import kafka extension
 
 const bootstrapServers = ["localhost:9092"];
@@ -49,12 +51,12 @@ const valueSchema = `{
 
 var configuration = JSON.stringify({
     consumer: {
-        keyDeserializer: "io.confluent.kafka.serializers.KafkaAvroDeserializer",
-        valueDeserializer: "io.confluent.kafka.serializers.KafkaAvroDeserializer",
+        keyDeserializer: AVRO_DESERIALIZER,
+        valueDeserializer: AVRO_DESERIALIZER,
     },
     producer: {
-        keySerializer: "io.confluent.kafka.serializers.KafkaAvroSerializer",
-        valueSerializer: "io.confluent.kafka.serializers.KafkaAvroSerializer",
+        keySerializer: AVRO_SERIALIZER,
+        valueSerializer: AVRO_SERIALIZER,
     },
     schemaRegistry: {
         url: "http://localhost:8081",

--- a/scripts/test_avro_with_schema_registry_no_key.js
+++ b/scripts/test_avro_with_schema_registry_no_key.js
@@ -11,6 +11,8 @@ import {
     produceWithConfiguration,
     createTopic,
     deleteTopic,
+    AVRO_SERIALIZER,
+    AVRO_DESERIALIZER,
 } from "k6/x/kafka"; // import kafka extension
 
 const bootstrapServers = ["localhost:9092"];
@@ -38,11 +40,11 @@ const valueSchema = `{
 var configuration = JSON.stringify({
     consumer: {
         keyDeserializer: "",
-        valueDeserializer: "io.confluent.kafka.serializers.KafkaAvroDeserializer",
+        valueDeserializer: AVRO_DESERIALIZER,
     },
     producer: {
         keySerializer: "",
-        valueSerializer: "io.confluent.kafka.serializers.KafkaAvroSerializer",
+        valueSerializer: AVRO_SERIALIZER,
     },
     schemaRegistry: {
         url: "http://localhost:8081",

--- a/scripts/test_bytes.js
+++ b/scripts/test_bytes.js
@@ -13,6 +13,10 @@ import {
     consumeWithConfiguration,
     createTopic,
     deleteTopic,
+    STRING_SERIALIZER,
+    STRING_DESERIALIZER,
+    BYTE_ARRAY_SERIALIZER,
+    BYTE_ARRAY_DESERIALIZER,
 } from "k6/x/kafka"; // import kafka extension
 
 const bootstrapServers = ["localhost:9092"];
@@ -27,12 +31,12 @@ if (__VU == 0) {
 
 var configuration = JSON.stringify({
     producer: {
-        keySerializer: "org.apache.kafka.common.serialization.StringSerializer",
-        valueSerializer: "org.apache.kafka.common.serialization.ByteArraySerializer",
+        keySerializer: STRING_SERIALIZER,
+        valueSerializer: BYTE_ARRAY_SERIALIZER,
     },
     consumer: {
-        keyDeserializer: "org.apache.kafka.common.serialization.StringDeserializer",
-        valueDeserializer: "org.apache.kafka.common.serialization.ByteArrayDeserializer",
+        keyDeserializer: STRING_DESERIALIZER,
+        valueDeserializer: BYTE_ARRAY_DESERIALIZER,
     },
 });
 

--- a/scripts/test_json.js
+++ b/scripts/test_json.js
@@ -6,7 +6,11 @@ tests Kafka with a 200 JSON messages per iteration.
 */
 
 import { check } from "k6";
+// import * as kafka from "k6/x/kafka";
 import { writer, produce, reader, consume, createTopic, deleteTopic } from "k6/x/kafka"; // import kafka extension
+
+// // Prints module-level constants
+// console.log(kafka);
 
 const bootstrapServers = ["localhost:9092"];
 const kafkaTopic = "xk6_kafka_json_topic";

--- a/scripts/test_json_with_snappy_compression.js
+++ b/scripts/test_json_with_snappy_compression.js
@@ -6,7 +6,15 @@ tests Kafka with a 200 JSON messages per iteration.
 */
 
 import { check } from "k6";
-import { writer, produce, reader, consume, createTopic, deleteTopic } from "k6/x/kafka"; // import kafka extension
+import {
+    writer,
+    produce,
+    reader,
+    consume,
+    createTopic,
+    deleteTopic,
+    CODEC_SNAPPY,
+} from "k6/x/kafka"; // import kafka extension
 
 const bootstrapServers = ["localhost:9092"];
 const kafkaTopic = "xk6_kafka_json_snappy_topic";
@@ -14,12 +22,12 @@ const no_auth = "";
 /*
 Supported compression codecs:
 
-- Gzip
-- Snappy
-- Lz4
-- Zstd
+- CODEC_GZIP
+- CODEC_SNAPPY
+- CODEC_LZ4
+- CODEC_ZSTD
 */
-const compression = "Snappy";
+const compression = CODEC_SNAPPY;
 
 const [producer, _writerError] = writer(bootstrapServers, kafkaTopic, no_auth, compression);
 const [consumer, _readerError] = reader(bootstrapServers, kafkaTopic);

--- a/scripts/test_jsonschema_with_schema_registry.js
+++ b/scripts/test_jsonschema_with_schema_registry.js
@@ -11,6 +11,8 @@ import {
     produceWithConfiguration,
     createTopic,
     deleteTopic,
+    JSON_SCHEMA_SERIALIZER,
+    JSON_SCHEMA_DESERIALIZER,
 } from "k6/x/kafka"; // import kafka extension
 
 const bootstrapServers = ["localhost:9092"];
@@ -47,12 +49,12 @@ const valueSchema = JSON.stringify({
 
 var configuration = JSON.stringify({
     consumer: {
-        keyDeserializer: "io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer",
-        valueDeserializer: "io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer",
+        keyDeserializer: JSON_SCHEMA_DESERIALIZER,
+        valueDeserializer: JSON_SCHEMA_DESERIALIZER,
     },
     producer: {
-        keySerializer: "io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializer",
-        valueSerializer: "io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializer",
+        keySerializer: JSON_SCHEMA_SERIALIZER,
+        valueSerializer: JSON_SCHEMA_SERIALIZER,
     },
     schemaRegistry: {
         url: "http://localhost:8081",

--- a/scripts/test_sasl_auth.js
+++ b/scripts/test_sasl_auth.js
@@ -7,7 +7,18 @@ also uses SASL authentication.
 */
 
 import { check } from "k6";
-import { writer, produce, reader, consume, createTopic, deleteTopic, listTopics } from "k6/x/kafka"; // import kafka extension
+import {
+    writer,
+    produce,
+    reader,
+    consume,
+    createTopic,
+    deleteTopic,
+    listTopics,
+    constants,
+    SASL_PLAIN,
+    TLS_1_2,
+} from "k6/x/kafka"; // import kafka extension
 
 export const options = {
     // This is used for testing purposes. For real-world use, you should use your own options:
@@ -30,12 +41,12 @@ const saslConfig = {
     username: "client",
     password: "client-secret",
     // Possible values for the algorithm is:
-    // "none" (default)
-    // "sasl_plain"
-    // "sasl_scram_sha256"
-    // "sasl_scram_sha512"
-    // "sasl_ssl" (must enable TLS)
-    algorithm: "sasl_plain",
+    // NONE (default)
+    // SASL_PLAIN
+    // SASL_SCRAM_SHA256
+    // SASL_SCRAM_SHA512
+    // SASL_SSL (must enable TLS)
+    algorithm: SASL_PLAIN,
 };
 
 // TLS config is optional
@@ -44,8 +55,12 @@ const tlsConfig = {
     enableTLS: false,
     // Skip TLS verification if the certificate is invalid or self-signed (default: false)
     insecureSkipTLSVerify: false,
-    // Possible values: "TLSv1.0", "TLSv1.1", "TLSv1.2" (default), "TLSv1.3"
-    minVersion: "TLSv1.2",
+    // Possible values:
+    // TLS_1_0
+    // TLS_1_1
+    // TLS_1_2 (default)
+    // TLS_1_3
+    minVersion: TLS_1_2,
 
     // Only needed if you have a custom or self-signed certificate and keys
     // clientCertPem: "/path/to/your/client.pem",

--- a/scripts/test_sasl_auth.js
+++ b/scripts/test_sasl_auth.js
@@ -15,7 +15,6 @@ import {
     createTopic,
     deleteTopic,
     listTopics,
-    constants,
     SASL_PLAIN,
     TLS_1_2,
 } from "k6/x/kafka"; // import kafka extension


### PR DESCRIPTION
This PR addresses issue #70 and exports all constants to JS code at the module level. The exports can be printed by using this code:
```javascript
import * as kafka from "k6/x/kafka";

console.log(kafka);
```
The above will print the following:
```json
{
    // TLS versions
    "TLS_1_0": "tls1.0",
    "TLS_1_1": "tls1.1",
    "TLS_1_2": "tls1.2",
    "TLS_1_3": "tls1.3",

    // SASL mechanisms
    "NONE": "none",
    "SASL_PLAIN": "sasl_plain",
    "SASL_SCRAM_SHA256": "sasl_scram_sha256",
    "SASL_SCRAM_SHA512": "sasl_scram_sha512",
    "SASL_SSL": "sasl_ssl",

    // Compression codecs
    "CODEC_GZIP": "gzip",
    "CODEC_SNAPPY": "snappy",
    "CODEC_LZ4": "lz4",
    "CODEC_ZSTD": "zstd",

    // Serde types
    "STRING_SERIALIZER": "org.apache.kafka.common.serialization.StringSerializer",
    "STRING_DESERIALIZER": "org.apache.kafka.common.serialization.StringDeserializer",
    "BYTE_ARRAY_SERIALIZER": "org.apache.kafka.common.serialization.ByteArraySerializer",
    "BYTE_ARRAY_DESERIALIZER": "org.apache.kafka.common.serialization.ByteArrayDeserializer",
    "JSON_SCHEMA_SERIALIZER": "io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializer",
    "JSON_SCHEMA_DESERIALIZER": "io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer",
    "AVRO_SERIALIZER": "io.confluent.kafka.serializers.KafkaAvroSerializer",
    "AVRO_DESERIALIZER": "io.confluent.kafka.serializers.KafkaAvroDeserializer",
    "PROTOBUF_SERIALIZER": "io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer",
    "PROTOBUF_DESERIALIZER": "io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializer",

    // TopicNameStrategy types
    "TOPIC_NAME_STRATEGY": "TopicNameStrategy",
    "RECORD_NAME_STRATEGY": "RecordNameStrategy",
    "TOPIC_RECORD_NAME_STRATEGY": "TopicRecordNameStrategy",
}
```

The meaning of it is that you can either import each constant manually:
```javascript
import { CONSTANT_NAME } from "k6/x/kafka";
```
or import the default exports, `* as kafka`, and use `kafka.CONSTANT_NAME` to use its value.