### PR TITLE
Export a proper constructor

### DIFF
--- a/module.go
+++ b/module.go
@@ -101,6 +101,10 @@ func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 	mustExport("writer", kafkaModuleInstance.Writer)
 	mustExport("produce", kafkaModuleInstance.Produce)
 	mustExport("produceWithConfiguration", kafkaModuleInstance.ProduceWithConfiguration)
+	// The Reader is a constructor and must be called with new, e.g. new Reader(...)
+	mustExport("Reader", kafkaModuleInstance.XReader)
+	// The reader function will continue to work as before,
+	// until the Reader constructor accepts arguments as a struct instead
 	mustExport("reader", kafkaModuleInstance.Reader)
 	mustExport("consume", kafkaModuleInstance.Consume)
 	mustExport("consumeWithConfiguration", kafkaModuleInstance.ConsumeWithConfiguration)

--- a/module.go
+++ b/module.go
@@ -94,6 +94,10 @@ func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 	}
 
 	// Export the functions from the Kafka module to the JS code
+	// The Writer is a constructor and must be called with new, e.g. new Writer(...)
+	mustExport("Writer", kafkaModuleInstance.XWriter)
+	// The writer function will continue to work as before,
+	// until the Writer constructor accepts arguments as a struct instead
 	mustExport("writer", kafkaModuleInstance.Writer)
 	mustExport("produce", kafkaModuleInstance.Produce)
 	mustExport("produceWithConfiguration", kafkaModuleInstance.ProduceWithConfiguration)

--- a/producer.go
+++ b/producer.go
@@ -7,6 +7,7 @@ import (
 	"github.com/dop251/goja"
 	kafkago "github.com/segmentio/kafka-go"
 	"github.com/segmentio/kafka-go/compress"
+	"go.k6.io/k6/js/common"
 	"go.k6.io/k6/metrics"
 )
 
@@ -60,13 +61,16 @@ func (k *Kafka) XWriter(call goja.ConstructorCall) *goja.Object {
 		compression = call.Arguments[4].Export().(string)
 	}
 
-	writer, _ := k.Writer(brokers, topic, saslConfig, tlsConfig, compression)
+	writer, err := k.Writer(brokers, topic, saslConfig, tlsConfig, compression)
+	if err != nil {
+		common.Throw(rt, err)
+	}
 	return rt.ToValue(writer).ToObject(rt)
 }
 
 // Writer creates a new Kafka writer
 // TODO: accept a configuration
-// Deprecated: use Writer instead
+// Deprecated: use XWriter instead
 func (k *Kafka) Writer(brokers []string, topic string, saslConfig SASLConfig, tlsConfig TLSConfig, compression string) (*kafkago.Writer, *Xk6KafkaError) {
 	dialer, err := GetDialer(saslConfig, tlsConfig)
 	if err != nil {

--- a/producer.go
+++ b/producer.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/dop251/goja"
 	kafkago "github.com/segmentio/kafka-go"
 	"github.com/segmentio/kafka-go/compress"
 	"go.k6.io/k6/metrics"
@@ -23,8 +24,49 @@ var (
 	DefaultSerializer = StringSerializer
 )
 
+// XWriter is a wrapper around kafkago.Writer and acts as a JS constructor
+// for this extension, thus it must be called with new operator, e.g. new Writer(...).
+func (k *Kafka) XWriter(call goja.ConstructorCall) *goja.Object {
+	rt := k.vu.Runtime()
+	var (
+		brokers     []string
+		topic       string
+		saslConfig  SASLConfig
+		tlsConfig   TLSConfig
+		compression string
+	)
+
+	if len(call.Arguments) > 0 {
+		b := call.Arguments[0].Export().([]interface{})
+		brokers = make([]string, len(b))
+		for i, v := range b {
+			brokers[i] = v.(string)
+		}
+	}
+
+	if len(call.Arguments) > 1 {
+		topic = call.Arguments[1].Export().(string)
+	}
+
+	if len(call.Arguments) > 2 {
+		saslConfig = call.Arguments[2].Export().(SASLConfig)
+	}
+
+	if len(call.Arguments) > 3 {
+		tlsConfig = call.Arguments[3].Export().(TLSConfig)
+	}
+
+	if len(call.Arguments) > 4 {
+		compression = call.Arguments[4].Export().(string)
+	}
+
+	writer, _ := k.Writer(brokers, topic, saslConfig, tlsConfig, compression)
+	return rt.ToValue(writer).ToObject(rt)
+}
+
 // Writer creates a new Kafka writer
 // TODO: accept a configuration
+// Deprecated: use Writer instead
 func (k *Kafka) Writer(brokers []string, topic string, saslConfig SASLConfig, tlsConfig TLSConfig, compression string) (*kafkago.Writer, *Xk6KafkaError) {
 	dialer, err := GetDialer(saslConfig, tlsConfig)
 	if err != nil {

--- a/scripts/test_json.js
+++ b/scripts/test_json.js
@@ -9,12 +9,15 @@ import { check } from "k6";
 // import * as kafka from "k6/x/kafka";
 import { writer, produce, reader, consume, createTopic, deleteTopic } from "k6/x/kafka"; // import kafka extension
 
-// // Prints module-level constants
+// Prints module-level constants
 // console.log(kafka);
 
 const bootstrapServers = ["localhost:9092"];
 const kafkaTopic = "xk6_kafka_json_topic";
 
+// The writer function will be deprecated soon after the new constructor changes is released.
+// and the new syntax will be used, for example:
+// const writer = new kafka.Writer(...);
 const [producer, _writerError] = writer(bootstrapServers, kafkaTopic);
 const [consumer, _readerError] = reader(bootstrapServers, kafkaTopic);
 

--- a/scripts/test_json.js
+++ b/scripts/test_json.js
@@ -15,9 +15,11 @@ import { writer, produce, reader, consume, createTopic, deleteTopic } from "k6/x
 const bootstrapServers = ["localhost:9092"];
 const kafkaTopic = "xk6_kafka_json_topic";
 
-// The writer function will be deprecated soon after the new constructor changes is released.
-// and the new syntax will be used, for example:
+// The writer and reader functions will be deprecated soon after
+// the new constructor changes is released. So, the new syntax need to be used,
+// for example:
 // const writer = new kafka.Writer(...);
+// const reader = new kafka.Reader(...);
 const [producer, _writerError] = writer(bootstrapServers, kafkaTopic);
 const [consumer, _readerError] = reader(bootstrapServers, kafkaTopic);
 


### PR DESCRIPTION
This PR introduces two changes:
1. A new constructor for `Writer` is introduced which has the same signature as the previous `writer` function:
    ```javascript
    import * as kafka from "k6/x/kafka";
    const writer = new kafka.Writer(...);
    ```
2. A new constructor for `Reader` is introduced which has the same signature as the previous `reader` function:
    ```javascript
    import * as kafka from "k6/x/kafka";
    const reader = new kafka.Reader(...);
    ```

This PR effectively deprecates the `writer` and `reader` functions and I'll remove them after I close issue #89.