### PR TITLE
Throw an exception instead of returning an error

### DIFF
--- a/consumer_test.go
+++ b/consumer_test.go
@@ -20,8 +20,7 @@ func initializeConsumerTest(t *testing.T) (*kafkaTest, *kafkago.Writer) {
 	assert.Nil(t, err)
 
 	// Create a writer to produce messages
-	writer, err := test.module.Kafka.Writer([]string{"localhost:9092"}, "test-topic", SASLConfig{}, TLSConfig{}, "")
-	assert.Nil(t, err)
+	writer := test.module.Kafka.Writer([]string{"localhost:9092"}, "test-topic", SASLConfig{}, TLSConfig{}, "")
 	assert.NotNil(t, writer)
 
 	return test, writer
@@ -43,14 +42,13 @@ func TestConsume(t *testing.T) {
 	require.NoError(t, test.moveToVUCode())
 
 	// Produce a message in the VU function
-	err = test.module.Kafka.Produce(writer, []map[string]interface{}{
+	test.module.Kafka.Produce(writer, []map[string]interface{}{
 		{
 			"key":    "key1",
 			"value":  "value1",
 			"offset": int64(0),
 		},
 	}, "", "", false)
-	assert.Nil(t, err)
 
 	// Consume a message in the VU function
 	messages, err := test.module.Kafka.Consume(reader, 1, "", "")
@@ -100,13 +98,12 @@ func TestConsumeWithoutKey(t *testing.T) {
 	require.NoError(t, test.moveToVUCode())
 
 	// Produce a message in the VU function
-	err = test.module.Kafka.Produce(writer, []map[string]interface{}{
+	test.module.Kafka.Produce(writer, []map[string]interface{}{
 		{
 			"value":  "value1",
 			"offset": int64(1),
 		},
 	}, "", "", false)
-	assert.Nil(t, err)
 
 	// Consume a message in the VU function
 	messages, err := test.module.Kafka.Consume(reader, 1, "", "")
@@ -140,13 +137,12 @@ func TestConsumerContextCancelled(t *testing.T) {
 	require.NoError(t, test.moveToVUCode())
 
 	// Produce a message in the VU function
-	err = test.module.Kafka.Produce(writer, []map[string]interface{}{
+	test.module.Kafka.Produce(writer, []map[string]interface{}{
 		{
 			"value":  "value1",
 			"offset": int64(2),
 		},
 	}, "", "", false)
-	assert.Nil(t, err)
 
 	test.cancelContext()
 
@@ -185,13 +181,12 @@ func TestConsumeJSON(t *testing.T) {
 	assert.Nil(t, jsonErr)
 
 	// Produce a message in the VU function
-	err = test.module.Kafka.Produce(writer, []map[string]interface{}{
+	test.module.Kafka.Produce(writer, []map[string]interface{}{
 		{
 			"value":  string(serialized),
 			"offset": int64(3),
 		},
 	}, "", "", false)
-	assert.Nil(t, err)
 
 	// Consume the message
 	messages, err := test.module.Kafka.Consume(reader, 1, "", "")

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -32,30 +32,34 @@ func TestConsume(t *testing.T) {
 	defer writer.Close()
 
 	// Create a reader to consume messages
-	reader, err := test.module.Kafka.Reader(
-		[]string{"localhost:9092"}, "test-topic", 0, "", 0, SASLConfig{}, TLSConfig{})
-	assert.Nil(t, err)
-	assert.NotNil(t, reader)
-	defer reader.Close()
+	assert.NotPanics(t, func() {
+		reader := test.module.Kafka.Reader(
+			[]string{"localhost:9092"}, "test-topic", 0, "", 0, SASLConfig{}, TLSConfig{})
+		assert.NotNil(t, reader)
+		defer reader.Close()
 
-	// Switch to VU code
-	require.NoError(t, test.moveToVUCode())
+		// Switch to VU code
+		require.NoError(t, test.moveToVUCode())
 
-	// Produce a message in the VU function
-	test.module.Kafka.Produce(writer, []map[string]interface{}{
-		{
-			"key":    "key1",
-			"value":  "value1",
-			"offset": int64(0),
-		},
-	}, "", "", false)
+		// Produce a message in the VU function
+		assert.NotPanics(t, func() {
+			test.module.Kafka.Produce(writer, []map[string]interface{}{
+				{
+					"key":    "key1",
+					"value":  "value1",
+					"offset": int64(0),
+				},
+			}, "", "", false)
+		})
 
-	// Consume a message in the VU function
-	messages, err := test.module.Kafka.Consume(reader, 1, "", "")
-	assert.Nil(t, err)
-	assert.Equal(t, 1, len(messages))
-	assert.Equal(t, "key1", messages[0]["key"].(string))
-	assert.Equal(t, "value1", messages[0]["value"].(string))
+		// Consume a message in the VU function
+		assert.NotPanics(t, func() {
+			messages := test.module.Kafka.Consume(reader, 1, "", "")
+			assert.Equal(t, 1, len(messages))
+			assert.Equal(t, "key1", messages[0]["key"].(string))
+			assert.Equal(t, "value1", messages[0]["value"].(string))
+		})
+	})
 
 	// Check if one message was consumed
 	metricsValues := test.GetCounterMetricsValues()
@@ -88,29 +92,33 @@ func TestConsumeWithoutKey(t *testing.T) {
 	defer writer.Close()
 
 	// Create a reader to consume messages
-	reader, err := test.module.Kafka.Reader(
-		[]string{"localhost:9092"}, "test-topic", 0, "", 1, SASLConfig{}, TLSConfig{})
-	assert.Nil(t, err)
-	assert.NotNil(t, reader)
-	defer reader.Close()
+	assert.NotPanics(t, func() {
+		reader := test.module.Kafka.Reader(
+			[]string{"localhost:9092"}, "test-topic", 0, "", 1, SASLConfig{}, TLSConfig{})
+		assert.NotNil(t, reader)
+		defer reader.Close()
 
-	// Switch to VU code
-	require.NoError(t, test.moveToVUCode())
+		// Switch to VU code
+		require.NoError(t, test.moveToVUCode())
 
-	// Produce a message in the VU function
-	test.module.Kafka.Produce(writer, []map[string]interface{}{
-		{
-			"value":  "value1",
-			"offset": int64(1),
-		},
-	}, "", "", false)
+		// Produce a message in the VU function
+		assert.NotPanics(t, func() {
+			test.module.Kafka.Produce(writer, []map[string]interface{}{
+				{
+					"value":  "value1",
+					"offset": int64(1),
+				},
+			}, "", "", false)
+		})
 
-	// Consume a message in the VU function
-	messages, err := test.module.Kafka.Consume(reader, 1, "", "")
-	assert.Nil(t, err)
-	assert.Equal(t, 1, len(messages))
-	assert.NotContains(t, messages[0], "key")
-	assert.Equal(t, "value1", messages[0]["value"].(string))
+		// Consume a message in the VU function
+		assert.NotPanics(t, func() {
+			messages := test.module.Kafka.Consume(reader, 1, "", "")
+			assert.Equal(t, 1, len(messages))
+			assert.NotContains(t, messages[0], "key")
+			assert.Equal(t, "value1", messages[0]["value"].(string))
+		})
+	})
 
 	// Check if one message was consumed
 	metricsValues := test.GetCounterMetricsValues()
@@ -127,31 +135,33 @@ func TestConsumerContextCancelled(t *testing.T) {
 	defer writer.Close()
 
 	// Create a reader to consume messages
-	reader, err := test.module.Kafka.Reader(
-		[]string{"localhost:9092"}, "test-topic", 0, "", 2, SASLConfig{}, TLSConfig{})
-	assert.Nil(t, err)
-	assert.NotNil(t, reader)
-	defer reader.Close()
+	assert.NotPanics(t, func() {
+		reader := test.module.Kafka.Reader(
+			[]string{"localhost:9092"}, "test-topic", 0, "", 2, SASLConfig{}, TLSConfig{})
+		assert.NotNil(t, reader)
+		defer reader.Close()
 
-	// Switch to VU code
-	require.NoError(t, test.moveToVUCode())
+		// Switch to VU code
+		require.NoError(t, test.moveToVUCode())
 
-	// Produce a message in the VU function
-	test.module.Kafka.Produce(writer, []map[string]interface{}{
-		{
-			"value":  "value1",
-			"offset": int64(2),
-		},
-	}, "", "", false)
+		// Produce a message in the VU function
+		assert.NotPanics(t, func() {
+			test.module.Kafka.Produce(writer, []map[string]interface{}{
+				{
+					"value":  "value1",
+					"offset": int64(2),
+				},
+			}, "", "", false)
+		})
 
-	test.cancelContext()
+		test.cancelContext()
 
-	// Consume a message in the VU function
-	messages, err := test.module.Kafka.Consume(reader, 1, "", "")
-	assert.NotNil(t, err)
-	assert.Empty(t, messages)
-	assert.Equal(t, "Unable to read messages.", err.Message)
-	assert.Equal(t, nil, err.Unwrap())
+		// Consume a message in the VU function
+		assert.NotPanics(t, func() {
+			messages := test.module.Kafka.Consume(reader, 1, "", "")
+			assert.Empty(t, messages)
+		})
+	})
 
 	// Check if one message was consumed
 	metricsValues := test.GetCounterMetricsValues()
@@ -168,36 +178,40 @@ func TestConsumeJSON(t *testing.T) {
 	defer writer.Close()
 
 	// Create a reader to consume messages
-	reader, err := test.module.Kafka.Reader(
-		[]string{"localhost:9092"}, "test-topic", 0, "", 3, SASLConfig{}, TLSConfig{})
-	assert.Nil(t, err)
-	assert.NotNil(t, reader)
-	defer reader.Close()
+	assert.NotPanics(t, func() {
+		reader := test.module.Kafka.Reader(
+			[]string{"localhost:9092"}, "test-topic", 0, "", 3, SASLConfig{}, TLSConfig{})
+		assert.NotNil(t, reader)
+		defer reader.Close()
 
-	// Switch to VU code
-	require.NoError(t, test.moveToVUCode())
+		// Switch to VU code
+		require.NoError(t, test.moveToVUCode())
 
-	serialized, jsonErr := json.Marshal(map[string]interface{}{"field": "value"})
-	assert.Nil(t, jsonErr)
+		serialized, jsonErr := json.Marshal(map[string]interface{}{"field": "value"})
+		assert.Nil(t, jsonErr)
 
-	// Produce a message in the VU function
-	test.module.Kafka.Produce(writer, []map[string]interface{}{
-		{
-			"value":  string(serialized),
-			"offset": int64(3),
-		},
-	}, "", "", false)
+		// Produce a message in the VU function
+		assert.NotPanics(t, func() {
+			test.module.Kafka.Produce(writer, []map[string]interface{}{
+				{
+					"value":  string(serialized),
+					"offset": int64(3),
+				},
+			}, "", "", false)
+		})
 
-	// Consume the message
-	messages, err := test.module.Kafka.Consume(reader, 1, "", "")
-	assert.Nil(t, err)
-	assert.Equal(t, 1, len(messages))
+		// Consume the message
+		assert.NotPanics(t, func() {
+			messages := test.module.Kafka.Consume(reader, 1, "", "")
+			assert.Equal(t, 1, len(messages))
 
-	type F struct {
-		Field string `json:"field"`
-	}
-	var f *F
-	jsonErr = json.Unmarshal([]byte(messages[0]["value"].(string)), &f)
-	assert.Nil(t, jsonErr)
-	assert.Equal(t, "value", f.Field)
+			type F struct {
+				Field string `json:"field"`
+			}
+			var f *F
+			jsonErr = json.Unmarshal([]byte(messages[0]["value"].(string)), &f)
+			assert.Nil(t, jsonErr)
+			assert.Equal(t, "value", f.Field)
+		})
+	})
 }

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -15,9 +15,8 @@ func initializeConsumerTest(t *testing.T) (*kafkaTest, *kafkago.Writer) {
 	test := GetTestModuleInstance(t)
 
 	// Create a topic before consuming messages, other tests will fail.
-	err := test.module.CreateTopic(
+	test.module.CreateTopic(
 		"localhost:9092", "test-topic", 1, 1, "", SASLConfig{}, TLSConfig{})
-	assert.Nil(t, err)
 
 	// Create a writer to produce messages
 	writer := test.module.Kafka.Writer([]string{"localhost:9092"}, "test-topic", SASLConfig{}, TLSConfig{}, "")

--- a/scripts/test_avro_with_schema_registry.js
+++ b/scripts/test_avro_with_schema_registry.js
@@ -5,8 +5,8 @@ tests Kafka with a 100 Avro messages per iteration.
 
 import { check } from "k6";
 import {
-    writer,
-    reader,
+    Writer,
+    Reader,
     consumeWithConfiguration,
     produceWithConfiguration,
     createTopic,
@@ -18,8 +18,8 @@ import {
 const bootstrapServers = ["localhost:9092"];
 const kafkaTopic = "com.example.person";
 
-const [producer, _writerError] = writer(bootstrapServers, kafkaTopic);
-const [consumer, _readerError] = reader(bootstrapServers, kafkaTopic, null, "", null);
+const writer = new Writer(bootstrapServers, kafkaTopic);
+const reader = new Reader(bootstrapServers, kafkaTopic, null, "", null);
 
 const keySchema = `{
   "name": "KeySchema",
@@ -93,7 +93,7 @@ export default function () {
     }
 
     let [messages, _consumeError] = consumeWithConfiguration(
-        consumer,
+        reader,
         20,
         configuration,
         keySchema,
@@ -107,15 +107,8 @@ export default function () {
 export function teardown(data) {
     if (__VU == 0) {
         // Delete the topic
-        const error = deleteTopic(bootstrapServers[0], kafkaTopic);
-        if (error == null) {
-            // If no error returns, it means that the topic
-            // is successfully deleted
-            console.log("Topic deleted successfully");
-        } else {
-            console.log("Error while deleting topic: ", error);
-        }
+        deleteTopic(bootstrapServers[0], kafkaTopic);
     }
-    producer.close();
-    consumer.close();
+    writer.close();
+    reader.close();
 }

--- a/scripts/test_bytes.js
+++ b/scripts/test_bytes.js
@@ -7,9 +7,9 @@ tests Kafka with a 200 byte array messages per iteration.
 
 import { check } from "k6";
 import {
-    writer,
+    Writer,
     produceWithConfiguration,
-    reader,
+    Reader,
     consumeWithConfiguration,
     createTopic,
     deleteTopic,
@@ -22,8 +22,8 @@ import {
 const bootstrapServers = ["localhost:9092"];
 const kafkaTopic = "xk6_kafka_byte_array_topic";
 
-const [producer, _writerError] = writer(bootstrapServers, kafkaTopic);
-const [consumer, _readerError] = reader(bootstrapServers, kafkaTopic);
+const writer = new Writer(bootstrapServers, kafkaTopic);
+const reader = new Reader(bootstrapServers, kafkaTopic);
 
 if (__VU == 0) {
     createTopic(bootstrapServers[0], kafkaTopic);
@@ -55,7 +55,7 @@ export default function () {
             },
         ];
 
-        let error = produceWithConfiguration(producer, messages, configuration);
+        let error = produceWithConfiguration(writer, messages, configuration);
         check(error, {
             "is sent": (err) => err == undefined,
         });
@@ -73,15 +73,8 @@ export default function () {
 export function teardown(data) {
     if (__VU == 0) {
         // Delete the topic
-        const error = deleteTopic(bootstrapServers[0], kafkaTopic);
-        if (error == null) {
-            // If no error returns, it means that the topic
-            // is successfully deleted
-            console.log("Topic deleted successfully");
-        } else {
-            console.log("Error while deleting topic: ", error);
-        }
+        deleteTopic(bootstrapServers[0], kafkaTopic);
     }
-    producer.close();
-    consumer.close();
+    writer.close();
+    reader.close();
 }

--- a/scripts/test_jsonschema_with_schema_registry.js
+++ b/scripts/test_jsonschema_with_schema_registry.js
@@ -5,8 +5,8 @@ tests Kafka with a 100 Avro messages per iteration.
 
 import { check } from "k6";
 import {
-    writer,
-    reader,
+    Writer,
+    Reader,
     consumeWithConfiguration,
     produceWithConfiguration,
     createTopic,
@@ -18,8 +18,8 @@ import {
 const bootstrapServers = ["localhost:9092"];
 const kafkaTopic = "xk6_jsonschema_test";
 
-const [producer, _writerError] = writer(bootstrapServers, kafkaTopic, null);
-const [consumer, _readerError] = reader(bootstrapServers, kafkaTopic, null, "", null, null);
+const writer = new Writer(bootstrapServers, kafkaTopic, null);
+const reader = new Reader(bootstrapServers, kafkaTopic, null, "", null, null);
 
 const keySchema = JSON.stringify({
     title: "Key",
@@ -91,7 +91,7 @@ export default function () {
     }
 
     let [messages, _consumeError] = consumeWithConfiguration(
-        consumer,
+        reader,
         20,
         configuration,
         keySchema,
@@ -117,15 +117,8 @@ export default function () {
 export function teardown(data) {
     if (__VU == 0) {
         // Delete the kafkaTopic
-        const error = deleteTopic(bootstrapServers[0], kafkaTopic);
-        if (error == null) {
-            // If no error returns, it means that the kafkaTopic
-            // is successfully deleted
-            console.log("Topic deleted successfully");
-        } else {
-            console.log("Error while deleting kafkaTopic: ", error);
-        }
+        deleteTopic(bootstrapServers[0], kafkaTopic);
     }
-    producer.close();
-    consumer.close();
+    writer.close();
+    reader.close();
 }

--- a/scripts/test_topics.js
+++ b/scripts/test_topics.js
@@ -11,30 +11,15 @@ const address = "localhost:9092";
 const kafkaTopic = "xk6_kafka_test_topic";
 
 const results = listTopics(address);
-const error = createTopic(address, kafkaTopic);
+createTopic(address, kafkaTopic);
 
 export default function () {
     results.forEach((topic) => console.log(topic));
-
-    if (error == null) {
-        // If no error returns, it means that the topic
-        // is successfully created or already exists
-        console.log("Topic created successfully");
-    } else {
-        console.log("Error while creating topic: ", error);
-    }
 }
 
 export function teardown(data) {
     if (__VU == 0) {
         // Delete the topic
-        const error = deleteTopic(address, kafkaTopic);
-        if (error == null) {
-            // If no error returns, it means that the topic
-            // is successfully deleted
-            console.log("Topic deleted successfully");
-        } else {
-            console.log("Error while deleting topic: ", error);
-        }
+        deleteTopic(address, kafkaTopic);
     }
 }

--- a/topic_test.go
+++ b/topic_test.go
@@ -10,10 +10,12 @@ import (
 // TestGetKafkaControllerConnection tests whether a connection can be established to a kafka broker
 func TestGetKafkaControllerConnection(t *testing.T) {
 	test := GetTestModuleInstance(t)
-	connection, xk6KafkaError := test.module.Kafka.GetKafkaControllerConnection(
-		"localhost:9092", SASLConfig{}, TLSConfig{})
-	assert.Nil(t, xk6KafkaError)
-	assert.NotNil(t, connection)
+	assert.NotPanics(t, func() {
+		connection := test.module.Kafka.GetKafkaControllerConnection(
+			"localhost:9092", SASLConfig{}, TLSConfig{})
+		defer connection.Close()
+		assert.NotNil(t, connection)
+	})
 }
 
 // TestGetKafkaControllerConnectionFails tests whether a connection can be established to a kafka broker
@@ -21,12 +23,11 @@ func TestGetKafkaControllerConnection(t *testing.T) {
 func TestGetKafkaControllerConnectionFails(t *testing.T) {
 	test := GetTestModuleInstance(t)
 
-	connection, xk6KafkaError := test.module.Kafka.GetKafkaControllerConnection(
-		"localhost:9094", SASLConfig{}, TLSConfig{})
-	assert.Nil(t, connection)
-	assert.NotNil(t, xk6KafkaError)
-	assert.Contains(t, xk6KafkaError.Unwrap().Error(), "failed to dial: failed to open connection to localhost:9094")
-	assert.Equal(t, xk6KafkaError.Code, dialerError)
+	assert.Panics(t, func() {
+		connection := test.module.Kafka.GetKafkaControllerConnection(
+			"localhost:9094", SASLConfig{}, TLSConfig{})
+		assert.Nil(t, connection)
+	})
 }
 
 // TestTopics tests various functions to create, delete and list topics.
@@ -34,18 +35,16 @@ func TestTopics(t *testing.T) {
 	test := GetTestModuleInstance(t)
 
 	require.NoError(t, test.moveToVUCode())
-	err := test.module.Kafka.CreateTopic(
-		"localhost:9092", "test-topic", 1, 1, "", SASLConfig{}, TLSConfig{})
-	assert.Nil(t, err)
+	assert.NotPanics(t, func() {
+		test.module.Kafka.CreateTopic(
+			"localhost:9092", "test-topic", 1, 1, "", SASLConfig{}, TLSConfig{})
 
-	topics, err := test.module.Kafka.ListTopics("localhost:9092", SASLConfig{}, TLSConfig{})
-	assert.Nil(t, err)
-	assert.Contains(t, topics, "test-topic")
+		topics := test.module.Kafka.ListTopics("localhost:9092", SASLConfig{}, TLSConfig{})
+		assert.Contains(t, topics, "test-topic")
 
-	err = test.module.Kafka.DeleteTopic("localhost:9092", "test-topic", SASLConfig{}, TLSConfig{})
-	assert.Nil(t, err)
+		test.module.Kafka.DeleteTopic("localhost:9092", "test-topic", SASLConfig{}, TLSConfig{})
 
-	topics, err = test.module.Kafka.ListTopics("localhost:9092", SASLConfig{}, TLSConfig{})
-	assert.Nil(t, err)
-	assert.NotContains(t, topics, "test-topic")
+		topics = test.module.Kafka.ListTopics("localhost:9092", SASLConfig{}, TLSConfig{})
+		assert.NotContains(t, topics, "test-topic")
+	})
 }


### PR DESCRIPTION
In this PR I address an issue I proposed in #89. The issue is that the JS functions usually throw exceptions instead of returning them, as is the standard in Golang. Note that only exposed functions and constructors are 

I also update scripts to reflect the changes in this PR and PR #92.