### PR TITLE
Consolidate options

### DIFF
--- a/configuration.go
+++ b/configuration.go
@@ -1,9 +1,5 @@
 package kafka
 
-import (
-	"encoding/json"
-)
-
 type ConsumerConfiguration struct {
 	KeyDeserializer     string `json:"keyDeserializer"`
 	ValueDeserializer   string `json:"valueDeserializer"`
@@ -21,17 +17,6 @@ type Configuration struct {
 	Consumer       ConsumerConfiguration       `json:"consumer"`
 	Producer       ProducerConfiguration       `json:"producer"`
 	SchemaRegistry SchemaRegistryConfiguration `json:"schemaRegistry"`
-}
-
-// UnmarshalConfiguration unmarshalls the given JSON string into a Configuration.
-func UnmarshalConfiguration(jsonConfiguration string) (Configuration, *Xk6KafkaError) {
-	var configuration Configuration
-	err := json.Unmarshal([]byte(jsonConfiguration), &configuration)
-	if err != nil {
-		return Configuration{}, NewXk6KafkaError(
-			configurationError, "Cannot unmarshal configuration.", err)
-	}
-	return configuration, nil
 }
 
 // ValidateConfiguration validates the given configuration.

--- a/configuration_test.go
+++ b/configuration_test.go
@@ -1,7 +1,6 @@
 package kafka
 
 import (
-	"encoding/json"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -24,24 +23,6 @@ var configuration Configuration = Configuration{
 		},
 		UseLatest: true,
 	},
-}
-
-// TestUnmarshalConfiguration tests unmarshalling of a given configuration
-func TestUnmarshalConfiguration(t *testing.T) {
-	configJson, _ := json.Marshal(configuration)
-	config, err := UnmarshalConfiguration(string(configJson))
-	assert.Nil(t, err)
-	assert.Equal(t, configuration, config)
-}
-
-// TestUnmarshalConfigurationsFails tests unmarshalling of a given configuration and fails
-// on invalid JSON.
-func TestUnmarshalConfigurationsFails(t *testing.T) {
-	configJson := `{"}`
-
-	_, err := UnmarshalConfiguration(configJson)
-	assert.NotNil(t, err)
-	assert.Equal(t, "Cannot unmarshal configuration.", err.Message)
 }
 
 // TestValidateConfiguration tests the validation of a given configuration.

--- a/consumer.go
+++ b/consumer.go
@@ -14,13 +14,13 @@ import (
 var DefaultDeserializer = StringDeserializer
 
 type ReaderConfig struct {
-	Brokers    []string   `json:"brokers"`
-	Topic      string     `json:"topic"`
-	Partition  int        `json:"partition"`
-	GroupID    string     `json:"groupID"`
-	Offset     int64      `json:"offset"`
-	SaslConfig SASLConfig `json:"saslConfig"`
-	TlsConfig  TLSConfig  `json:"tlsConfig"`
+	Brokers   []string   `json:"brokers"`
+	Topic     string     `json:"topic"`
+	Partition int        `json:"partition"`
+	GroupID   string     `json:"groupID"`
+	Offset    int64      `json:"offset"`
+	SASL      SASLConfig `json:"sasl"`
+	TLS       TLSConfig  `json:"tls"`
 }
 
 type ConsumeConfig struct {
@@ -50,7 +50,7 @@ func (k *Kafka) XReader(call goja.ConstructorCall) *goja.Object {
 
 	reader := k.Reader(
 		rConfig.Brokers, rConfig.Topic, rConfig.Partition, rConfig.GroupID, rConfig.Offset,
-		rConfig.SaslConfig, rConfig.TlsConfig)
+		rConfig.SASL, rConfig.TLS)
 
 	readerObject := rt.NewObject()
 	// This is the reader object itself

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -19,7 +19,9 @@ func initializeConsumerTest(t *testing.T) (*kafkaTest, *kafkago.Writer) {
 		"localhost:9092", "test-topic", 1, 1, "", SASLConfig{}, TLSConfig{})
 
 	// Create a writer to produce messages
-	writer := test.module.Kafka.Writer([]string{"localhost:9092"}, "test-topic", SASLConfig{}, TLSConfig{}, "")
+	writer := test.module.Kafka.Writer(
+		[]string{"localhost:9092"}, "test-topic",
+		SASLConfig{}, TLSConfig{}, "", 1, BALANCER_LEAST_BYTES)
 	assert.NotNil(t, writer)
 
 	return test, writer

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -35,8 +35,10 @@ func TestConsume(t *testing.T) {
 
 	// Create a reader to consume messages
 	assert.NotPanics(t, func() {
-		reader := test.module.Kafka.Reader(
-			[]string{"localhost:9092"}, "test-topic", 0, "", 0, SASLConfig{}, TLSConfig{})
+		reader := test.module.Kafka.Reader(&ReaderConfig{
+			Brokers: []string{"localhost:9092"},
+			Topic:   "test-topic",
+		})
 		assert.NotNil(t, reader)
 		defer reader.Close()
 
@@ -57,7 +59,7 @@ func TestConsume(t *testing.T) {
 
 		// Consume a message in the VU function
 		assert.NotPanics(t, func() {
-			messages := test.module.Kafka.Consume(reader, 1, "", "")
+			messages := test.module.Kafka.consumeInternal(reader, &ConsumeConfig{Limit: 1})
 			assert.Equal(t, 1, len(messages))
 			assert.Equal(t, "key1", messages[0]["key"].(string))
 			assert.Equal(t, "value1", messages[0]["value"].(string))
@@ -96,8 +98,11 @@ func TestConsumeWithoutKey(t *testing.T) {
 
 	// Create a reader to consume messages
 	assert.NotPanics(t, func() {
-		reader := test.module.Kafka.Reader(
-			[]string{"localhost:9092"}, "test-topic", 0, "", 1, SASLConfig{}, TLSConfig{})
+		reader := test.module.Kafka.Reader(&ReaderConfig{
+			Brokers: []string{"localhost:9092"},
+			Topic:   "test-topic",
+			Offset:  1,
+		})
 		assert.NotNil(t, reader)
 		defer reader.Close()
 
@@ -117,7 +122,7 @@ func TestConsumeWithoutKey(t *testing.T) {
 
 		// Consume a message in the VU function
 		assert.NotPanics(t, func() {
-			messages := test.module.Kafka.Consume(reader, 1, "", "")
+			messages := test.module.Kafka.consumeInternal(reader, &ConsumeConfig{Limit: 1})
 			assert.Equal(t, 1, len(messages))
 			assert.NotContains(t, messages[0], "key")
 			assert.Equal(t, "value1", messages[0]["value"].(string))
@@ -140,8 +145,10 @@ func TestConsumerContextCancelled(t *testing.T) {
 
 	// Create a reader to consume messages
 	assert.NotPanics(t, func() {
-		reader := test.module.Kafka.Reader(
-			[]string{"localhost:9092"}, "test-topic", 0, "", 2, SASLConfig{}, TLSConfig{})
+		reader := test.module.Kafka.Reader(&ReaderConfig{
+			Brokers: []string{"localhost:9092"},
+			Topic:   "test-topic",
+		})
 		assert.NotNil(t, reader)
 		defer reader.Close()
 
@@ -163,7 +170,7 @@ func TestConsumerContextCancelled(t *testing.T) {
 
 		// Consume a message in the VU function
 		assert.NotPanics(t, func() {
-			messages := test.module.Kafka.Consume(reader, 1, "", "")
+			messages := test.module.Kafka.consumeInternal(reader, &ConsumeConfig{Limit: 1})
 			assert.Empty(t, messages)
 		})
 	})
@@ -184,8 +191,11 @@ func TestConsumeJSON(t *testing.T) {
 
 	// Create a reader to consume messages
 	assert.NotPanics(t, func() {
-		reader := test.module.Kafka.Reader(
-			[]string{"localhost:9092"}, "test-topic", 0, "", 3, SASLConfig{}, TLSConfig{})
+		reader := test.module.Kafka.Reader(&ReaderConfig{
+			Brokers: []string{"localhost:9092"},
+			Topic:   "test-topic",
+			Offset:  3,
+		})
 		assert.NotNil(t, reader)
 		defer reader.Close()
 
@@ -208,7 +218,7 @@ func TestConsumeJSON(t *testing.T) {
 
 		// Consume the message
 		assert.NotPanics(t, func() {
-			messages := test.module.Kafka.Consume(reader, 1, "", "")
+			messages := test.module.Kafka.consumeInternal(reader, &ConsumeConfig{Limit: 1})
 			assert.Equal(t, 1, len(messages))
 
 			type F struct {

--- a/error_codes.go
+++ b/error_codes.go
@@ -7,14 +7,13 @@ type errCode uint32
 const (
 	// non specific
 	kafkaForbiddenInInitContext errCode = 1000
-	configurationError          errCode = 1001
-	noContextError              errCode = 1002
-	contextCancelled            errCode = 1003
-	cannotReportStats           errCode = 1004
-	fileNotFound                errCode = 1005
-	dialerError                 errCode = 1006
-	noTLSConfig                 errCode = 1007
-	invalidTLSVersion           errCode = 1008
+	noContextError              errCode = 1001
+	contextCancelled            errCode = 1002
+	cannotReportStats           errCode = 1003
+	fileNotFound                errCode = 1004
+	dialerError                 errCode = 1005
+	noTLSConfig                 errCode = 1006
+	invalidTLSVersion           errCode = 1007
 
 	// serdes errors
 	invalidDataType             errCode = 2000

--- a/module.go
+++ b/module.go
@@ -107,11 +107,6 @@ func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 	mustExport("Writer", kafkaModuleInstance.XWriter)
 	// The Reader is a constructor and must be called with new, e.g. new Reader(...)
 	mustExport("Reader", kafkaModuleInstance.XReader)
-	// The reader function will continue to work as before,
-	// until the Reader constructor accepts arguments as a struct instead
-	mustExport("reader", kafkaModuleInstance.Reader)
-	mustExport("consume", kafkaModuleInstance.Consume)
-	mustExport("consumeWithConfiguration", kafkaModuleInstance.ConsumeWithConfiguration)
 	mustExport("createTopic", kafkaModuleInstance.CreateTopic)
 	mustExport("deleteTopic", kafkaModuleInstance.DeleteTopic)
 	mustExport("listTopics", kafkaModuleInstance.ListTopics)

--- a/module.go
+++ b/module.go
@@ -30,6 +30,7 @@ func init() {
 		netext.TLS_1_3: tls.VersionTLS13,
 	}
 
+	// Initialize the compression types map
 	CompressionCodecs = map[string]compress.Compression{
 		CODEC_GZIP:   compress.Gzip,
 		CODEC_SNAPPY: compress.Snappy,
@@ -37,12 +38,26 @@ func init() {
 		CODEC_ZSTD:   compress.Zstd,
 	}
 
-	BalancerRegistry = map[string]kafkago.Balancer{
+	// Initialize the balancer types map
+	Balancers = map[string]kafkago.Balancer{
 		BALANCER_ROUND_ROBIN: &kafkago.RoundRobin{},
 		BALANCER_LEAST_BYTES: &kafkago.LeastBytes{},
 		BALANCER_HASH:        &kafkago.Hash{},
 		BALANCER_CRC32:       &kafkago.CRC32Balancer{},
 		BALANCER_MURMUR2:     &kafkago.Murmur2Balancer{},
+	}
+
+	// Initialize the group balancer types map
+	GroupBalancers = map[string]kafkago.GroupBalancer{
+		GROUP_BALANCER_RANGE:         &kafkago.RangeGroupBalancer{},
+		GROUP_BALANCER_ROUND_ROBIN:   &kafkago.RoundRobinGroupBalancer{},
+		GROUP_BALANCER_RACK_AFFINITY: &kafkago.RackAffinityGroupBalancer{},
+	}
+
+	// Initialize the isolation levels map
+	IsolationLevels = map[string]kafkago.IsolationLevel{
+		ISOLATION_LEVEL_READ_UNCOMMITTED: kafkago.ReadUncommitted,
+		ISOLATION_LEVEL_READ_COMMITTED:   kafkago.ReadCommitted,
 	}
 
 	// Register the module namespace (aka. JS import path)
@@ -161,6 +176,15 @@ func (c *KafkaModule) defineConstants() {
 	mustAddProp("BALANCER_HASH", BALANCER_HASH)
 	mustAddProp("BALANCER_CRC32", BALANCER_CRC32)
 	mustAddProp("BALANCER_MURMUR2", BALANCER_MURMUR2)
+
+	// Group balancer types
+	mustAddProp("GROUP_BALANCER_RANGE", GROUP_BALANCER_RANGE)
+	mustAddProp("GROUP_BALANCER_ROUND_ROBIN", GROUP_BALANCER_ROUND_ROBIN)
+	mustAddProp("GROUP_BALANCER_RACK_AFFINITY", GROUP_BALANCER_RACK_AFFINITY)
+
+	// Isolation levels
+	mustAddProp("ISOLATION_LEVEL_READ_UNCOMMITTED", ISOLATION_LEVEL_READ_UNCOMMITTED)
+	mustAddProp("ISOLATION_LEVEL_READ_COMMITTED", ISOLATION_LEVEL_READ_COMMITTED)
 
 	// Serde types
 	mustAddProp("STRING_SERIALIZER", StringSerializer)

--- a/module.go
+++ b/module.go
@@ -105,11 +105,6 @@ func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 	// Export the functions from the Kafka module to the JS code
 	// The Writer is a constructor and must be called with new, e.g. new Writer(...)
 	mustExport("Writer", kafkaModuleInstance.XWriter)
-	// The writer function will continue to work as before,
-	// until the Writer constructor accepts arguments as a struct instead
-	mustExport("writer", kafkaModuleInstance.Writer)
-	mustExport("produce", kafkaModuleInstance.Produce)
-	mustExport("produceWithConfiguration", kafkaModuleInstance.ProduceWithConfiguration)
 	// The Reader is a constructor and must be called with new, e.g. new Reader(...)
 	mustExport("Reader", kafkaModuleInstance.XReader)
 	// The reader function will continue to work as before,

--- a/module.go
+++ b/module.go
@@ -4,6 +4,7 @@ import (
 	"crypto/tls"
 
 	"github.com/dop251/goja"
+	kafkago "github.com/segmentio/kafka-go"
 	"github.com/segmentio/kafka-go/compress"
 	"github.com/sirupsen/logrus"
 	"go.k6.io/k6/js/common"
@@ -34,6 +35,14 @@ func init() {
 		CODEC_SNAPPY: compress.Snappy,
 		CODEC_LZ4:    compress.Lz4,
 		CODEC_ZSTD:   compress.Zstd,
+	}
+
+	BalancerRegistry = map[string]kafkago.Balancer{
+		BALANCER_ROUND_ROBIN: &kafkago.RoundRobin{},
+		BALANCER_LEAST_BYTES: &kafkago.LeastBytes{},
+		BALANCER_HASH:        &kafkago.Hash{},
+		BALANCER_CRC32:       &kafkago.CRC32Balancer{},
+		BALANCER_MURMUR2:     &kafkago.Murmur2Balancer{},
 	}
 
 	// Register the module namespace (aka. JS import path)
@@ -155,6 +164,13 @@ func (c *KafkaModule) defineConstants() {
 	mustAddProp("CODEC_SNAPPY", CODEC_SNAPPY)
 	mustAddProp("CODEC_LZ4", CODEC_LZ4)
 	mustAddProp("CODEC_ZSTD", CODEC_ZSTD)
+
+	// Balancer types
+	mustAddProp("BALANCER_ROUND_ROBIN", BALANCER_ROUND_ROBIN)
+	mustAddProp("BALANCER_LEAST_BYTES", BALANCER_LEAST_BYTES)
+	mustAddProp("BALANCER_HASH", BALANCER_HASH)
+	mustAddProp("BALANCER_CRC32", BALANCER_CRC32)
+	mustAddProp("BALANCER_MURMUR2", BALANCER_MURMUR2)
 
 	// Serde types
 	mustAddProp("STRING_SERIALIZER", StringSerializer)

--- a/producer.go
+++ b/producer.go
@@ -29,8 +29,8 @@ var (
 	BALANCER_CRC32       = "balancer_crc32"
 	BALANCER_MURMUR2     = "balancer_murmur2"
 
-	// BalancerRegistry is a map of balancer names to their respective balancers.
-	BalancerRegistry map[string]kafkago.Balancer
+	// Balancers is a map of balancer names to their respective balancers.
+	Balancers map[string]kafkago.Balancer
 
 	// DefaultSerializer is string serializer
 	DefaultSerializer = StringSerializer
@@ -156,8 +156,6 @@ func (k *Kafka) XWriter(call goja.ConstructorCall) *goja.Object {
 }
 
 // Writer creates a new Kafka writer
-// TODO: accept a configuration
-// Deprecated: use XWriter instead
 func (k *Kafka) Writer(writerConfig *WriterConfig) *kafkago.Writer {
 	dialer, err := GetDialer(writerConfig.SASL, writerConfig.TLS)
 	if err != nil {
@@ -172,8 +170,8 @@ func (k *Kafka) Writer(writerConfig *WriterConfig) *kafkago.Writer {
 		writerConfig.BatchSize = 1
 	}
 
-	balancerType := BalancerRegistry[BALANCER_LEAST_BYTES]
-	if b, ok := BalancerRegistry[writerConfig.Balancer]; ok {
+	balancerType := Balancers[BALANCER_LEAST_BYTES]
+	if b, ok := Balancers[writerConfig.Balancer]; ok {
 		balancerType = b
 	}
 

--- a/producer_test.go
+++ b/producer_test.go
@@ -15,7 +15,8 @@ func TestProduce(t *testing.T) {
 
 	assert.NotPanics(t, func() {
 		writer := test.module.Kafka.Writer(
-			[]string{"localhost:9092"}, "test-topic", SASLConfig{}, TLSConfig{}, "")
+			[]string{"localhost:9092"}, "test-topic",
+			SASLConfig{}, TLSConfig{}, "", 1, BALANCER_LEAST_BYTES)
 		assert.NotNil(t, writer)
 		defer writer.Close()
 
@@ -82,7 +83,8 @@ func TestProduceWithoutKey(t *testing.T) {
 
 	assert.NotPanics(t, func() {
 		writer := test.module.Kafka.Writer(
-			[]string{"localhost:9092"}, "", SASLConfig{}, TLSConfig{}, "")
+			[]string{"localhost:9092"}, "",
+			SASLConfig{}, TLSConfig{}, "", 1, BALANCER_LEAST_BYTES)
 		assert.NotNil(t, writer)
 		defer writer.Close()
 
@@ -127,7 +129,8 @@ func TestProducerContextCancelled(t *testing.T) {
 
 	assert.NotPanics(t, func() {
 		writer := test.module.Kafka.Writer(
-			[]string{"localhost:9092"}, "test-topic", SASLConfig{}, TLSConfig{}, "")
+			[]string{"localhost:9092"}, "test-topic",
+			SASLConfig{}, TLSConfig{}, "", 1, BALANCER_LEAST_BYTES)
 		assert.NotNil(t, writer)
 		defer writer.Close()
 
@@ -174,7 +177,8 @@ func TestProduceJSON(t *testing.T) {
 
 	assert.NotPanics(t, func() {
 		writer := test.module.Kafka.Writer(
-			[]string{"localhost:9092"}, "test-topic", SASLConfig{}, TLSConfig{}, "")
+			[]string{"localhost:9092"}, "test-topic",
+			SASLConfig{}, TLSConfig{}, "", 1, BALANCER_LEAST_BYTES)
 		assert.NotNil(t, writer)
 		defer writer.Close()
 

--- a/producer_test.go
+++ b/producer_test.go
@@ -14,24 +14,26 @@ func TestProduce(t *testing.T) {
 	test := GetTestModuleInstance(t)
 
 	assert.NotPanics(t, func() {
-		writer := test.module.Kafka.Writer(
-			[]string{"localhost:9092"}, "test-topic",
-			SASLConfig{}, TLSConfig{}, "", 1, BALANCER_LEAST_BYTES)
+		writer := test.module.Kafka.Writer(&WriterConfig{
+			Brokers: []string{"localhost:9092"},
+			Topic:   "test-topic",
+		})
 		assert.NotNil(t, writer)
 		defer writer.Close()
 
 		// Produce a message in the init context
 		assert.Panics(t, func() {
-			test.module.Kafka.Produce(writer, []map[string]interface{}{
-				{
-					"key":   "key1",
-					"value": "value1",
-				},
-				{
-					"key":   "key2",
-					"value": "value2",
-				},
-			}, "", "", false)
+			test.module.Kafka.produceInternal(writer, &ProduceConfig{
+				Messages: []Message{
+					{
+						Key:   "key1",
+						Value: "value1",
+					},
+					{
+						Key:   "key2",
+						Value: "value2",
+					},
+				}})
 		})
 
 		// Create a topic before producing messages, otherwise tests will fail.
@@ -44,16 +46,17 @@ func TestProduce(t *testing.T) {
 
 		// Produce two messages in the VU function
 		assert.NotPanics(t, func() {
-			test.module.Kafka.Produce(writer, []map[string]interface{}{
-				{
-					"key":   "key1",
-					"value": "value1",
-				},
-				{
-					"key":   "key2",
-					"value": "value2",
-				},
-			}, "", "", false)
+			test.module.Kafka.produceInternal(writer, &ProduceConfig{
+				Messages: []Message{
+					{
+						Key:   "key1",
+						Value: "value1",
+					},
+					{
+						Key:   "key2",
+						Value: "value2",
+					},
+				}})
 		})
 	})
 
@@ -82,9 +85,9 @@ func TestProduceWithoutKey(t *testing.T) {
 	test := GetTestModuleInstance(t)
 
 	assert.NotPanics(t, func() {
-		writer := test.module.Kafka.Writer(
-			[]string{"localhost:9092"}, "",
-			SASLConfig{}, TLSConfig{}, "", 1, BALANCER_LEAST_BYTES)
+		writer := test.module.Kafka.Writer(&WriterConfig{
+			Brokers: []string{"localhost:9092"},
+		})
 		assert.NotNil(t, writer)
 		defer writer.Close()
 
@@ -98,19 +101,19 @@ func TestProduceWithoutKey(t *testing.T) {
 
 		// Produce two messages in the VU function
 		assert.NotPanics(t, func() {
-			test.module.Kafka.Produce(writer, []map[string]interface{}{
-				{
-					"value": "value1",
-					// The topic should be set either on the writer or on individual messages
-					"topic":  "test-topic",
-					"offset": int64(0),
-					"time":   time.Now().UnixMilli(),
-				},
-				{
-					"value": "value2",
-					"topic": "test-topic",
-				},
-			}, "", "", false)
+			test.module.Kafka.produceInternal(writer, &ProduceConfig{
+				Messages: []Message{
+					{
+						Value:  "value1",
+						Topic:  "test-topic",
+						Offset: 0,
+						Time:   time.Now(),
+					},
+					{
+						Value: "value2",
+						Topic: "test-topic",
+					},
+				}})
 		})
 	})
 
@@ -128,9 +131,10 @@ func TestProducerContextCancelled(t *testing.T) {
 	test := GetTestModuleInstance(t)
 
 	assert.NotPanics(t, func() {
-		writer := test.module.Kafka.Writer(
-			[]string{"localhost:9092"}, "test-topic",
-			SASLConfig{}, TLSConfig{}, "", 1, BALANCER_LEAST_BYTES)
+		writer := test.module.Kafka.Writer(&WriterConfig{
+			Brokers: []string{"localhost:9092"},
+			Topic:   "test-topic",
+		})
 		assert.NotNil(t, writer)
 		defer writer.Close()
 
@@ -147,16 +151,17 @@ func TestProducerContextCancelled(t *testing.T) {
 
 		// Produce two messages in the VU function
 		assert.Panics(t, func() {
-			test.module.Kafka.Produce(writer, []map[string]interface{}{
-				{
-					"key":   "key1",
-					"value": "value1",
-				},
-				{
-					"key":   "key2",
-					"value": "value2",
-				},
-			}, "", "", false)
+			test.module.Kafka.produceInternal(writer, &ProduceConfig{
+				Messages: []Message{
+					{
+						Key:   "key1",
+						Value: "value1",
+					},
+					{
+						Key:   "key2",
+						Value: "value2",
+					},
+				}})
 		})
 	})
 
@@ -176,9 +181,10 @@ func TestProduceJSON(t *testing.T) {
 	test := GetTestModuleInstance(t)
 
 	assert.NotPanics(t, func() {
-		writer := test.module.Kafka.Writer(
-			[]string{"localhost:9092"}, "test-topic",
-			SASLConfig{}, TLSConfig{}, "", 1, BALANCER_LEAST_BYTES)
+		writer := test.module.Kafka.Writer(&WriterConfig{
+			Brokers: []string{"localhost:9092"},
+			Topic:   "test-topic",
+		})
 		assert.NotNil(t, writer)
 		defer writer.Close()
 
@@ -195,11 +201,12 @@ func TestProduceJSON(t *testing.T) {
 
 		// Produce a message in the VU function
 		assert.NotPanics(t, func() {
-			test.module.Kafka.Produce(writer, []map[string]interface{}{
-				{
-					"value": string(serialized),
-				},
-			}, "", "", false)
+			test.module.Kafka.produceInternal(writer, &ProduceConfig{
+				Messages: []Message{
+					{
+						Value: string(serialized),
+					},
+				}})
 		})
 	})
 

--- a/scripts/test_avro.js
+++ b/scripts/test_avro.js
@@ -108,7 +108,11 @@ export default function () {
     }
 
     // Read 10 messages only
-    let messages = reader.consume(10, keySchema, valueSchema);
+    let messages = reader.consume({
+        limit: 10,
+        keySchema: keySchema,
+        valueSchema: valueSchema,
+    });
     check(messages, {
         "10 messages returned": (msgs) => msgs.length == 10,
     });

--- a/scripts/test_avro.js
+++ b/scripts/test_avro.js
@@ -100,7 +100,11 @@ export default function () {
                 }),
             },
         ];
-        writer.produce(messages, keySchema, valueSchema);
+        writer.produce({
+            messages: messages,
+            keySchema: keySchema,
+            valueSchema: valueSchema,
+        });
     }
 
     // Read 10 messages only

--- a/scripts/test_avro_named_strategy_and_magic_prefix.js
+++ b/scripts/test_avro_named_strategy_and_magic_prefix.js
@@ -77,7 +77,7 @@ export default function () {
         "status is 200": (r) => r.status === 200,
     });
 
-    let messages = reader.consumeWithConfiguration(reader, 1, config, null, valueSchema);
+    let messages = reader.consume({ limit: 1, config: config, valueSchema: valueSchema });
     check(messages, {
         "1 message returned": (msgs) => msgs.length === 1,
     });

--- a/scripts/test_avro_named_strategy_and_magic_prefix.js
+++ b/scripts/test_avro_named_strategy_and_magic_prefix.js
@@ -27,14 +27,12 @@ const reader = new Reader({
     topic: topic,
 });
 
-let configuration = JSON.stringify({
+let config = JSON.stringify({
     consumer: {
-        keyDeserializer: "",
         valueDeserializer: AVRO_DESERIALIZER,
         userMagicPrefix: true,
     },
     producer: {
-        keySerializer: "",
         valueSerializer: AVRO_SERIALIZER,
         subjectNameStrategy: RECORD_NAME_STRATEGY,
     },
@@ -69,13 +67,17 @@ export default function () {
             },
         ],
     });
-    writer.produceWithConfiguration([message], configuration, null, valueSchema);
+    writer.produce({
+        messages: [message],
+        config: config,
+        valueSchema: valueSchema,
+    });
 
     check(getSubject("com.example.MagicNameValueSchema"), {
         "status is 200": (r) => r.status === 200,
     });
 
-    let messages = reader.consumeWithConfiguration(reader, 1, configuration, null, valueSchema);
+    let messages = reader.consumeWithConfiguration(reader, 1, config, null, valueSchema);
     check(messages, {
         "1 message returned": (msgs) => msgs.length === 1,
     });

--- a/scripts/test_avro_no_key.js
+++ b/scripts/test_avro_no_key.js
@@ -82,7 +82,7 @@ export default function () {
                 }),
             },
         ];
-        writer.produce(messages, null, valueSchema);
+        writer.produce({ messages: messages, valueSchema: valueSchema });
     }
 
     // Read 10 messages only

--- a/scripts/test_avro_no_key.js
+++ b/scripts/test_avro_no_key.js
@@ -86,7 +86,7 @@ export default function () {
     }
 
     // Read 10 messages only
-    let messages = reader.consume(10, null, valueSchema);
+    let messages = reader.consume({ limit: 10, valueSchema: valueSchema });
     check(messages, {
         "10 messages returned": (msgs) => msgs.length == 10,
     });

--- a/scripts/test_avro_with_schema_registry.js
+++ b/scripts/test_avro_with_schema_registry.js
@@ -53,7 +53,7 @@ const valueSchema = `{
   ]
 }`;
 
-var configuration = JSON.stringify({
+var config = JSON.stringify({
     consumer: {
         keyDeserializer: AVRO_DESERIALIZER,
         valueDeserializer: AVRO_DESERIALIZER,
@@ -84,10 +84,15 @@ export default function () {
                 }),
             },
         ];
-        writer.produceWithConfiguration(messages, configuration, keySchema, valueSchema);
+        writer.produce({
+            messages: messages,
+            config: config,
+            keySchema: keySchema,
+            valueSchema: valueSchema,
+        });
     }
 
-    let messages = reader.consumeWithConfiguration(20, configuration, keySchema, valueSchema);
+    let messages = reader.consumeWithConfiguration(20, config, keySchema, valueSchema);
     check(messages, {
         "20 message returned": (msgs) => msgs.length == 20,
     });

--- a/scripts/test_avro_with_schema_registry.js
+++ b/scripts/test_avro_with_schema_registry.js
@@ -92,7 +92,12 @@ export default function () {
         });
     }
 
-    let messages = reader.consumeWithConfiguration(20, config, keySchema, valueSchema);
+    let messages = reader.consume({
+        limit: 20,
+        config: config,
+        keySchema: keySchema,
+        valueSchema: valueSchema,
+    });
     check(messages, {
         "20 message returned": (msgs) => msgs.length == 20,
     });

--- a/scripts/test_avro_with_schema_registry_no_key.js
+++ b/scripts/test_avro_with_schema_registry_no_key.js
@@ -41,7 +41,7 @@ const valueSchema = `{
   ]
 }`;
 
-var configuration = JSON.stringify({
+var config = JSON.stringify({
     consumer: {
         keyDeserializer: "",
         valueDeserializer: AVRO_DESERIALIZER,
@@ -69,10 +69,14 @@ export default function () {
                 }),
             },
         ];
-        writer.produceWithConfiguration(messages, configuration, null, valueSchema);
+        writer.produce({
+            messages: [message],
+            config: config,
+            valueSchema: valueSchema,
+        });
     }
 
-    let messages = reader.consumeWithConfiguration(20, configuration, null, valueSchema);
+    let messages = reader.consumeWithConfiguration(20, config, null, valueSchema);
     check(messages, {
         "20 message returned": (msgs) => msgs.length == 20,
     });

--- a/scripts/test_avro_with_schema_registry_no_key.js
+++ b/scripts/test_avro_with_schema_registry_no_key.js
@@ -76,7 +76,7 @@ export default function () {
         });
     }
 
-    let messages = reader.consumeWithConfiguration(20, config, null, valueSchema);
+    let messages = reader.consume({ limit: 20, config: config, valueSchema: valueSchema });
     check(messages, {
         "20 message returned": (msgs) => msgs.length == 20,
     });

--- a/scripts/test_bytes.js
+++ b/scripts/test_bytes.js
@@ -33,7 +33,7 @@ if (__VU == 0) {
     createTopic(brokers[0], topic);
 }
 
-var configuration = JSON.stringify({
+var config = JSON.stringify({
     producer: {
         keySerializer: STRING_SERIALIZER,
         valueSerializer: BYTE_ARRAY_SERIALIZER,
@@ -59,11 +59,14 @@ export default function () {
             },
         ];
 
-        writer.produceWithConfiguration(messages, configuration);
+        writer.produce({
+            messages: messages,
+            config: config,
+        });
     }
 
     // Read 10 messages only
-    let messages = reader.consume(consumer, 10, configuration);
+    let messages = reader.consume(consumer, 10, config);
     check(messages, {
         "10 messages returned": (msgs) => msgs.length == 10,
         "key starts with 'test-id-' string": (msgs) => msgs[0].key.startsWith("test-id-"),

--- a/scripts/test_bytes.js
+++ b/scripts/test_bytes.js
@@ -66,7 +66,10 @@ export default function () {
     }
 
     // Read 10 messages only
-    let messages = reader.consume(consumer, 10, config);
+    let messages = reader.consume({
+        limit: 10,
+        config: config,
+    });
     check(messages, {
         "10 messages returned": (msgs) => msgs.length == 10,
         "key starts with 'test-id-' string": (msgs) => msgs[0].key.startsWith("test-id-"),

--- a/scripts/test_json.js
+++ b/scripts/test_json.js
@@ -85,7 +85,7 @@ export default function () {
     }
 
     // Read 10 messages only
-    let messages = reader.consume(10);
+    let messages = reader.consume({ limit: 10 });
 
     check(messages, {
         "10 messages are received": (messages) => messages.length == 10,

--- a/scripts/test_json.js
+++ b/scripts/test_json.js
@@ -61,7 +61,7 @@ export default function () {
                 },
                 offset: index,
                 partition: 0,
-                time: new Date().getTime(), // timestamp
+                time: new Date(), // Will be converted to timestamp automatically
             },
             {
                 key: JSON.stringify({
@@ -81,7 +81,7 @@ export default function () {
             },
         ];
 
-        writer.produce(messages);
+        writer.produce({ messages: messages });
     }
 
     // Read 10 messages only

--- a/scripts/test_json_with_snappy_compression.js
+++ b/scripts/test_json_with_snappy_compression.js
@@ -69,7 +69,7 @@ export default function () {
             },
         ];
 
-        writer.produce(messages);
+        writer.produce({ messages: messages });
     }
 
     // Read 10 messages only

--- a/scripts/test_json_with_snappy_compression.js
+++ b/scripts/test_json_with_snappy_compression.js
@@ -73,7 +73,7 @@ export default function () {
     }
 
     // Read 10 messages only
-    let messages = reader.consume(10);
+    let messages = reader.consume({ limit: 10 });
     check(messages, {
         "10 messages returned": (msgs) => msgs.length == 10,
     });

--- a/scripts/test_jsonschema_with_schema_registry.js
+++ b/scripts/test_jsonschema_with_schema_registry.js
@@ -51,7 +51,7 @@ const valueSchema = JSON.stringify({
     },
 });
 
-var configuration = JSON.stringify({
+var config = JSON.stringify({
     consumer: {
         keyDeserializer: JSON_SCHEMA_DESERIALIZER,
         valueDeserializer: JSON_SCHEMA_DESERIALIZER,
@@ -90,7 +90,12 @@ export default function () {
         });
     }
 
-    let messages = reader.consumeWithConfiguration(20, configuration, keySchema, valueSchema);
+    let messages = reader.consume({
+        limit: 20,
+        config: config,
+        keySchema: keySchema,
+        valueSchema: valueSchema,
+    });
     check(messages, {
         "20 message returned": (msgs) => msgs.length == 20,
     });

--- a/scripts/test_jsonschema_with_schema_registry.js
+++ b/scripts/test_jsonschema_with_schema_registry.js
@@ -82,7 +82,12 @@ export default function () {
                 }),
             },
         ];
-        writer.produceWithConfiguration(messages, configuration, keySchema, valueSchema);
+        writer.produce({
+            messages: messages,
+            config: config,
+            keySchema: keySchema,
+            valueSchema: valueSchema,
+        });
     }
 
     let messages = reader.consumeWithConfiguration(20, configuration, keySchema, valueSchema);

--- a/scripts/test_sasl_auth.js
+++ b/scripts/test_sasl_auth.js
@@ -137,7 +137,7 @@ export default function () {
     }
 
     // Read 10 messages only
-    let messages = reader.consume(10);
+    let messages = reader.consume({ limit: 10 });
     check(messages, {
         "10 messages returned": (msgs) => msgs.length == 10,
     });

--- a/scripts/test_sasl_auth.js
+++ b/scripts/test_sasl_auth.js
@@ -76,8 +76,8 @@ const compression = "";
 const writer = new Writer({
     brokers: brokers,
     topic: topic,
-    saslConfig: saslConfig,
-    tlsConfig: tlsConfig,
+    sasl: saslConfig,
+    tls: tlsConfig,
 });
 const reader = new Reader({
     brokers: brokers,
@@ -85,8 +85,8 @@ const reader = new Reader({
     partition: partition,
     groupID: groupID,
     offset: offset,
-    saslConfig: saslConfig,
-    tlsConfig: tlsConfig,
+    sasl: saslConfig,
+    tls: tlsConfig,
 });
 
 if (__VU == 0) {
@@ -133,7 +133,7 @@ export default function () {
             },
         ];
 
-        writer.produce(messages);
+        writer.produce({ messages: messages });
     }
 
     // Read 10 messages only


### PR DESCRIPTION
In this PR I address issue #89 (No. 6), in which I:
1. deprecate and remove most of the old functions.
2. add all available kafka-go's `Reader` and `Writer` config parameters to be available to the `consume` and `produce` methods and export necessary constants and interfaces.
3. update scripts and tests to reflect changes.