### PR TITLE
Create Connection class and methods for creating, deleting and listing topics

### DIFF
--- a/consumer_test.go
+++ b/consumer_test.go
@@ -14,14 +14,11 @@ import (
 func initializeConsumerTest(t *testing.T) (*kafkaTest, *kafkago.Writer) {
 	test := GetTestModuleInstance(t)
 
-	// Create a topic before consuming messages, other tests will fail.
-	test.module.CreateTopic(
-		"localhost:9092", "test-topic", 1, 1, "", SASLConfig{}, TLSConfig{})
-
 	// Create a writer to produce messages
 	writer := test.module.Kafka.Writer(&WriterConfig{
-		Brokers: []string{"localhost:9092"},
-		Topic:   "test-topic",
+		Brokers:         []string{"localhost:9092"},
+		Topic:           "test-topic",
+		AutoCreateTopic: true,
 	})
 	assert.NotNil(t, writer)
 

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -14,11 +14,20 @@ import (
 func initializeConsumerTest(t *testing.T) (*kafkaTest, *kafkago.Writer) {
 	test := GetTestModuleInstance(t)
 
+	// Create a Kafka topic
+	connection := test.module.Kafka.GetKafkaControllerConnection(&ConnectionConfig{
+		Address: "localhost:9092",
+	})
+	defer connection.Close()
+
+	test.module.Kafka.CreateTopic(connection, &kafkago.TopicConfig{
+		Topic: "test-topic",
+	})
+
 	// Create a writer to produce messages
 	writer := test.module.Kafka.Writer(&WriterConfig{
-		Brokers:         []string{"localhost:9092"},
-		Topic:           "test-topic",
-		AutoCreateTopic: true,
+		Brokers: []string{"localhost:9092"},
+		Topic:   "test-topic",
 	})
 	assert.NotNil(t, writer)
 

--- a/module.go
+++ b/module.go
@@ -122,9 +122,8 @@ func (*RootModule) NewModuleInstance(vu modules.VU) modules.Instance {
 	mustExport("Writer", kafkaModuleInstance.XWriter)
 	// The Reader is a constructor and must be called with new, e.g. new Reader(...)
 	mustExport("Reader", kafkaModuleInstance.XReader)
-	mustExport("createTopic", kafkaModuleInstance.CreateTopic)
-	mustExport("deleteTopic", kafkaModuleInstance.DeleteTopic)
-	mustExport("listTopics", kafkaModuleInstance.ListTopics)
+	// The Connection is a constructor and must be called with new, e.g. new Connection(...)
+	mustExport("Connection", kafkaModuleInstance.XConnection)
 
 	// This causes the struct fields to be exported to the native (camelCases) JS code.
 	vu.Runtime().SetFieldNameMapper(goja.TagFieldNameMapper("json", true))

--- a/producer_test.go
+++ b/producer_test.go
@@ -92,12 +92,12 @@ func TestProduceWithoutKey(t *testing.T) {
 			connection := test.module.GetKafkaControllerConnection(&ConnectionConfig{
 				Address: "localhost:9092",
 			})
-			defer connection.Close()
 			test.module.CreateTopic(connection, &kafkago.TopicConfig{
 				Topic:             "test-topic",
 				NumPartitions:     1,
 				ReplicationFactor: 1,
 			})
+			connection.Close()
 		})
 
 		require.NoError(t, test.moveToVUCode())

--- a/scripts/test_avro.js
+++ b/scripts/test_avro.js
@@ -6,7 +6,7 @@ tests Kafka with a 200 Avro messages per iteration.
 */
 
 import { check } from "k6";
-import { Writer, Reader, createTopic, deleteTopic } from "k6/x/kafka"; // import kafka extension
+import { Writer, Reader, Connection } from "k6/x/kafka"; // import kafka extension
 
 const brokers = ["localhost:9092"];
 const topic = "xk6_kafka_avro_topic";
@@ -14,10 +14,14 @@ const topic = "xk6_kafka_avro_topic";
 const writer = new Writer({
     brokers: brokers,
     topic: topic,
+    autoCreateTopic: true,
 });
 const reader = new Reader({
     brokers: brokers,
     topic: topic,
+});
+const connection = new Connection({
+    address: brokers[0],
 });
 
 const keySchema = JSON.stringify({
@@ -63,10 +67,6 @@ const valueSchema = JSON.stringify({
         },
     ],
 });
-
-if (__VU == 0) {
-    createTopic(brokers[0], topic);
-}
 
 export default function () {
     for (let index = 0; index < 100; index++) {
@@ -121,8 +121,9 @@ export default function () {
 export function teardown(data) {
     if (__VU == 0) {
         // Delete the topic
-        deleteTopic(brokers[0], topic);
+        connection.deleteTopic(topic);
     }
     writer.close();
     reader.close();
+    connection.close();
 }

--- a/scripts/test_avro_named_strategy_and_magic_prefix.js
+++ b/scripts/test_avro_named_strategy_and_magic_prefix.js
@@ -7,8 +7,7 @@ import { check } from "k6";
 import {
     Writer,
     Reader,
-    createTopic,
-    deleteTopic,
+    Connection,
     AVRO_SERIALIZER,
     AVRO_DESERIALIZER,
     RECORD_NAME_STRATEGY,
@@ -21,10 +20,14 @@ const topic = "test_schema_registry_consume_magic_prefix";
 const writer = new Writer({
     brokers: brokers,
     topic: topic,
+    autoCreateTopic: true,
 });
 const reader = new Reader({
     brokers: brokers,
     topic: topic,
+});
+const connection = new Connection({
+    address: brokers[0],
 });
 
 let config = JSON.stringify({
@@ -40,10 +43,6 @@ let config = JSON.stringify({
         url: "http://localhost:8081",
     },
 });
-
-if (__VU == 0) {
-    createTopic(brokers[0], topic);
-}
 
 export default function () {
     let message = {
@@ -86,8 +85,9 @@ export default function () {
 export function teardown(data) {
     if (__VU == 0) {
         // Delete the topic
-        deleteTopic(brokers[0], topic);
+        connection.deleteTopic(topic);
     }
     writer.close();
     reader.close();
+    connection.close();
 }

--- a/scripts/test_avro_no_key.js
+++ b/scripts/test_avro_no_key.js
@@ -6,7 +6,7 @@ without any associated key.
 */
 
 import { check } from "k6";
-import { Writer, Reader, createTopic, deleteTopic } from "k6/x/kafka"; // import kafka extension
+import { Writer, Reader, Connection } from "k6/x/kafka"; // import kafka extension
 
 const brokers = ["localhost:9092"];
 const topic = "xk6_kafka_avro_topic";
@@ -14,10 +14,14 @@ const topic = "xk6_kafka_avro_topic";
 const writer = new Writer({
     brokers: brokers,
     topic: topic,
+    autoCreateTopic: true,
 });
 const reader = new Reader({
     brokers: brokers,
     topic: topic,
+});
+const connection = new Connection({
+    address: brokers[0],
 });
 
 const valueSchema = JSON.stringify({
@@ -51,10 +55,6 @@ const valueSchema = JSON.stringify({
         },
     ],
 });
-
-if (__VU == 0) {
-    createTopic(brokers[0], topic);
-}
 
 export default function () {
     for (let index = 0; index < 100; index++) {
@@ -99,8 +99,9 @@ export default function () {
 export function teardown(data) {
     if (__VU == 0) {
         // Delete the topic
-        deleteTopic(brokers[0], topic);
+        connection.deleteTopic(topic);
     }
     writer.close();
     reader.close();
+    connection.close();
 }

--- a/scripts/test_avro_with_schema_registry_no_key.js
+++ b/scripts/test_avro_with_schema_registry_no_key.js
@@ -4,14 +4,7 @@ tests Kafka with a 100 Avro messages per iteration.
 */
 
 import { check } from "k6";
-import {
-    Writer,
-    Reader,
-    createTopic,
-    deleteTopic,
-    AVRO_SERIALIZER,
-    AVRO_DESERIALIZER,
-} from "k6/x/kafka"; // import kafka extension
+import { Writer, Reader, Connection, AVRO_SERIALIZER, AVRO_DESERIALIZER } from "k6/x/kafka"; // import kafka extension
 
 const brokers = ["localhost:9092"];
 const topic = "com.example.person";
@@ -19,10 +12,14 @@ const topic = "com.example.person";
 const writer = new Writer({
     brokers: brokers,
     topic: topic,
+    autoCreateTopic: true,
 });
 const reader = new Reader({
     brokers: brokers,
     topic: topic,
+});
+const connection = new Connection({
+    address: brokers[0],
 });
 
 const valueSchema = `{
@@ -55,10 +52,6 @@ var config = JSON.stringify({
     },
 });
 
-if (__VU == 0) {
-    createTopic(brokers[0], topic);
-}
-
 export default function () {
     for (let index = 0; index < 100; index++) {
         let messages = [
@@ -70,7 +63,7 @@ export default function () {
             },
         ];
         writer.produce({
-            messages: [message],
+            messages: messages,
             config: config,
             valueSchema: valueSchema,
         });
@@ -89,8 +82,9 @@ export default function () {
 export function teardown(data) {
     if (__VU == 0) {
         // Delete the topic
-        deleteTopic(brokers[0], topic);
+        connection.deleteTopic(topic);
     }
     writer.close();
     reader.close();
+    connection.close();
 }

--- a/scripts/test_bytes.js
+++ b/scripts/test_bytes.js
@@ -9,8 +9,7 @@ import { check } from "k6";
 import {
     Writer,
     Reader,
-    createTopic,
-    deleteTopic,
+    Connection,
     STRING_SERIALIZER,
     STRING_DESERIALIZER,
     BYTE_ARRAY_SERIALIZER,
@@ -23,15 +22,15 @@ const topic = "xk6_kafka_byte_array_topic";
 const writer = new Writer({
     brokers: brokers,
     topic: topic,
+    autoCreateTopic: true,
 });
 const reader = new Reader({
     brokers: brokers,
     topic: topic,
 });
-
-if (__VU == 0) {
-    createTopic(brokers[0], topic);
-}
+const connection = new Connection({
+    address: brokers[0],
+});
 
 var config = JSON.stringify({
     producer: {
@@ -80,8 +79,9 @@ export default function () {
 export function teardown(data) {
     if (__VU == 0) {
         // Delete the topic
-        deleteTopic(brokers[0], topic);
+        connection.deleteTopic(topic);
     }
     writer.close();
     reader.close();
+    connection.close();
 }

--- a/scripts/test_json.js
+++ b/scripts/test_json.js
@@ -7,7 +7,7 @@ tests Kafka with a 200 JSON messages per iteration.
 
 import { check } from "k6";
 // import * as kafka from "k6/x/kafka";
-import { Writer, Reader, createTopic, deleteTopic } from "k6/x/kafka"; // import kafka extension
+import { Writer, Reader, Connection } from "k6/x/kafka"; // import kafka extension
 
 // Prints module-level constants
 // console.log(kafka);
@@ -15,23 +15,20 @@ import { Writer, Reader, createTopic, deleteTopic } from "k6/x/kafka"; // import
 const brokers = ["localhost:9092"];
 const topic = "xk6_kafka_json_topic";
 
-// The writer and reader functions will be deprecated soon after
-// the new constructor changes is released. So, the new syntax need to be used,
-// for example:
 // const writer = new kafka.Writer(...);
 // const reader = new kafka.Reader(...);
 const writer = new Writer({
     brokers: brokers,
     topic: topic,
+    autoCreateTopic: true,
 });
 const reader = new Reader({
     brokers: brokers,
     topic: topic,
 });
-
-if (__VU == 0) {
-    createTopic(brokers[0], topic);
-}
+const connection = new Connection({
+    address: brokers[0],
+});
 
 export const options = {
     thresholds: {
@@ -117,8 +114,9 @@ export default function () {
 export function teardown(data) {
     if (__VU == 0) {
         // Delete the topic
-        deleteTopic(brokers[0], topic);
+        connection.deleteTopic(topic);
     }
     writer.close();
     reader.close();
+    connection.close();
 }

--- a/scripts/test_jsonschema_with_schema_registry.js
+++ b/scripts/test_jsonschema_with_schema_registry.js
@@ -4,14 +4,7 @@ tests Kafka with a 100 Avro messages per iteration.
 */
 
 import { check } from "k6";
-import {
-    Writer,
-    Reader,
-    createTopic,
-    deleteTopic,
-    JSON_SCHEMA_SERIALIZER,
-    JSON_SCHEMA_DESERIALIZER,
-} from "k6/x/kafka"; // import kafka extension
+import { Writer, Reader, JSON_SCHEMA_SERIALIZER, JSON_SCHEMA_DESERIALIZER } from "k6/x/kafka"; // import kafka extension
 
 const brokers = ["localhost:9092"];
 const topic = "xk6_jsonschema_test";
@@ -19,6 +12,7 @@ const topic = "xk6_jsonschema_test";
 const writer = new Writer({
     brokers: brokers,
     topic: topic,
+    autoCreateTopic: true,
 });
 const reader = new Reader({
     brokers: brokers,
@@ -64,10 +58,6 @@ var config = JSON.stringify({
         url: "http://localhost:8081",
     },
 });
-
-if (__VU == 0) {
-    createTopic(brokers[0], topic);
-}
 
 export default function () {
     for (let index = 0; index < 100; index++) {
@@ -116,8 +106,9 @@ export default function () {
 export function teardown(data) {
     if (__VU == 0) {
         // Delete the topic
-        deleteTopic(brokers[0], topic);
+        connection.deleteTopic(topic);
     }
     writer.close();
     reader.close();
+    connection.close();
 }

--- a/scripts/test_topics.js
+++ b/scripts/test_topics.js
@@ -5,13 +5,17 @@ list topics on all Kafka partitions and creates a topic.
 
 */
 
-import { createTopic, deleteTopic, listTopics } from "k6/x/kafka"; // import kafka extension
+import { Connection } from "k6/x/kafka"; // import kafka extension
 
 const address = "localhost:9092";
 const topic = "xk6_kafka_test_topic";
 
-const results = listTopics(address);
-createTopic(address, topic);
+const connection = new Connection({
+    address: address,
+});
+
+const results = connection.listTopics();
+connection.createTopic({ topic: topic });
 
 export default function () {
     results.forEach((topic) => console.log(topic));
@@ -20,6 +24,7 @@ export default function () {
 export function teardown(data) {
     if (__VU == 0) {
         // Delete the topic
-        deleteTopic(address, topic);
+        connection.deleteTopic(topic);
     }
+    connection.close();
 }

--- a/topic.go
+++ b/topic.go
@@ -85,7 +85,11 @@ func (k *Kafka) XConnection(call goja.ConstructorCall) *goja.Object {
 	}
 
 	err = connectionObject.Set("close", func(call goja.FunctionCall) goja.Value {
-		connection.Close()
+		err := connection.Close()
+		if err != nil {
+			common.Throw(rt, err)
+		}
+
 		return goja.Undefined()
 	})
 	if err != nil {

--- a/topic.go
+++ b/topic.go
@@ -98,8 +98,8 @@ func (k *Kafka) XConnection(call goja.ConstructorCall) *goja.Object {
 // GetKafkaControllerConnection returns a kafka controller connection with a given node address.
 // It will also try to use the auth and TLS settings to create a secure connection. The connection
 // should be closed after use.
-func (k *Kafka) GetKafkaControllerConnection(topicsConfig *ConnectionConfig) *kafkago.Conn {
-	dialer, wrappedError := GetDialer(topicsConfig.SASL, topicsConfig.TLS)
+func (k *Kafka) GetKafkaControllerConnection(connectionConfig *ConnectionConfig) *kafkago.Conn {
+	dialer, wrappedError := GetDialer(connectionConfig.SASL, connectionConfig.TLS)
 	if wrappedError != nil {
 		logger.WithField("error", wrappedError).Error(wrappedError)
 		if dialer == nil {
@@ -116,7 +116,7 @@ func (k *Kafka) GetKafkaControllerConnection(topicsConfig *ConnectionConfig) *ka
 		return nil
 	}
 
-	conn, err := dialer.DialContext(ctx, "tcp", topicsConfig.Address)
+	conn, err := dialer.DialContext(ctx, "tcp", connectionConfig.Address)
 	if err != nil {
 		wrappedError := NewXk6KafkaError(dialerError, "Failed to create dialer.", err)
 		logger.WithField("error", wrappedError).Error(wrappedError)

--- a/topic.go
+++ b/topic.go
@@ -1,20 +1,105 @@
 package kafka
 
 import (
+	"encoding/json"
 	"net"
 	"strconv"
-	"strings"
 
-	"github.com/segmentio/kafka-go"
+	"github.com/dop251/goja"
 	kafkago "github.com/segmentio/kafka-go"
 	"go.k6.io/k6/js/common"
 )
 
+type ConnectionConfig struct {
+	Address string     `json:"address"`
+	SASL    SASLConfig `json:"sasl"`
+	TLS     TLSConfig  `json:"tls"`
+}
+
+func (k *Kafka) XConnection(call goja.ConstructorCall) *goja.Object {
+	rt := k.vu.Runtime()
+	var connectionConfig *ConnectionConfig
+	if len(call.Arguments) > 0 {
+		if params, ok := call.Argument(0).Export().(map[string]interface{}); ok {
+			b, err := json.Marshal(params)
+			if err != nil {
+				common.Throw(rt, err)
+			}
+			err = json.Unmarshal(b, &connectionConfig)
+			if err != nil {
+				common.Throw(rt, err)
+			}
+		}
+	}
+
+	connection := k.GetKafkaControllerConnection(connectionConfig)
+
+	connectionObject := rt.NewObject()
+	// This is the connection object itself
+	err := connectionObject.Set("This", connection)
+	if err != nil {
+		common.Throw(rt, err)
+	}
+
+	err = connectionObject.Set("createTopic", func(call goja.FunctionCall) goja.Value {
+		var topicConfig *kafkago.TopicConfig
+		if len(call.Arguments) > 0 {
+			if params, ok := call.Argument(0).Export().(map[string]interface{}); ok {
+				b, err := json.Marshal(params)
+				if err != nil {
+					common.Throw(rt, err)
+				}
+				err = json.Unmarshal(b, &topicConfig)
+				if err != nil {
+					common.Throw(rt, err)
+				}
+			}
+		}
+
+		k.CreateTopic(connection, topicConfig)
+		return goja.Undefined()
+	})
+	if err != nil {
+		common.Throw(rt, err)
+	}
+
+	err = connectionObject.Set("deleteTopic", func(call goja.FunctionCall) goja.Value {
+		var topic string
+		if len(call.Arguments) > 0 {
+			topic = call.Argument(0).Export().(string)
+		}
+
+		k.DeleteTopic(connection, topic)
+		return goja.Undefined()
+	})
+	if err != nil {
+		common.Throw(rt, err)
+	}
+
+	err = connectionObject.Set("listTopics", func(call goja.FunctionCall) goja.Value {
+		topics := k.ListTopics(connection)
+		return rt.ToValue(topics)
+	})
+	if err != nil {
+		common.Throw(rt, err)
+	}
+
+	err = connectionObject.Set("close", func(call goja.FunctionCall) goja.Value {
+		connection.Close()
+		return goja.Undefined()
+	})
+	if err != nil {
+		common.Throw(rt, err)
+	}
+
+	return connectionObject
+}
+
 // GetKafkaControllerConnection returns a kafka controller connection with a given node address.
 // It will also try to use the auth and TLS settings to create a secure connection. The connection
 // should be closed after use.
-func (k *Kafka) GetKafkaControllerConnection(address string, saslConfig SASLConfig, tlsConfig TLSConfig) *kafkago.Conn {
-	dialer, wrappedError := GetDialer(saslConfig, tlsConfig)
+func (k *Kafka) GetKafkaControllerConnection(topicsConfig *ConnectionConfig) *kafkago.Conn {
+	dialer, wrappedError := GetDialer(topicsConfig.SASL, topicsConfig.TLS)
 	if wrappedError != nil {
 		logger.WithField("error", wrappedError).Error(wrappedError)
 		if dialer == nil {
@@ -31,7 +116,7 @@ func (k *Kafka) GetKafkaControllerConnection(address string, saslConfig SASLConf
 		return nil
 	}
 
-	conn, err := dialer.DialContext(ctx, "tcp", address)
+	conn, err := dialer.DialContext(ctx, "tcp", topicsConfig.Address)
 	if err != nil {
 		wrappedError := NewXk6KafkaError(dialerError, "Failed to create dialer.", err)
 		logger.WithField("error", wrappedError).Error(wrappedError)
@@ -62,32 +147,16 @@ func (k *Kafka) GetKafkaControllerConnection(address string, saslConfig SASLConf
 // CreateTopic creates a topic with the given name, partitions, replication factor and compression.
 // It will also try to use the auth and TLS settings to create a secure connection. If the topic
 // already exists, it will do no-op.
-func (k *Kafka) CreateTopic(address, topic string, partitions, replicationFactor int, compression string, saslConfig SASLConfig, tlsConfig TLSConfig) {
-	conn := k.GetKafkaControllerConnection(address, saslConfig, tlsConfig)
-	defer conn.Close()
-
-	if partitions <= 0 {
-		partitions = 1
+func (k *Kafka) CreateTopic(conn *kafkago.Conn, topicConfig *kafkago.TopicConfig) {
+	if topicConfig.NumPartitions <= 0 {
+		topicConfig.NumPartitions = 1
 	}
 
-	if replicationFactor <= 0 {
-		replicationFactor = 1
+	if topicConfig.ReplicationFactor <= 0 {
+		topicConfig.ReplicationFactor = 1
 	}
 
-	topicConfig := kafka.TopicConfig{
-		Topic:             topic,
-		NumPartitions:     partitions,
-		ReplicationFactor: replicationFactor,
-	}
-
-	if _, ok := CompressionCodecs[compression]; ok {
-		topicConfig.ConfigEntries = append(topicConfig.ConfigEntries, kafkago.ConfigEntry{
-			ConfigName:  "compression.type",
-			ConfigValue: strings.ToLower(compression),
-		})
-	}
-
-	err := conn.CreateTopics([]kafkago.TopicConfig{topicConfig}...)
+	err := conn.CreateTopics(*topicConfig)
 	if err != nil {
 		wrappedError := NewXk6KafkaError(failedCreateTopic, "Failed to create topic.", err)
 		logger.WithField("error", wrappedError).Error(wrappedError)
@@ -98,10 +167,7 @@ func (k *Kafka) CreateTopic(address, topic string, partitions, replicationFactor
 // DeleteTopic deletes the given topic from the given address. It will also try to
 // use the auth and TLS settings to create a secure connection. If the topic
 // does not exist, it will raise an error.
-func (k *Kafka) DeleteTopic(address, topic string, saslConfig SASLConfig, tlsConfig TLSConfig) {
-	conn := k.GetKafkaControllerConnection(address, saslConfig, tlsConfig)
-	defer conn.Close()
-
+func (k *Kafka) DeleteTopic(conn *kafkago.Conn, topic string) {
 	err := conn.DeleteTopics([]string{topic}...)
 	if err != nil {
 		wrappedError := NewXk6KafkaError(failedDeleteTopic, "Failed to delete topic.", err)
@@ -113,10 +179,7 @@ func (k *Kafka) DeleteTopic(address, topic string, saslConfig SASLConfig, tlsCon
 // ListTopics lists the topics from the given address. It will also try to
 // use the auth and TLS settings to create a secure connection. If the topic
 // does not exist, it will raise an error.
-func (k *Kafka) ListTopics(address string, saslConfig SASLConfig, tlsConfig TLSConfig) []string {
-	conn := k.GetKafkaControllerConnection(address, saslConfig, tlsConfig)
-	defer conn.Close()
-
+func (k *Kafka) ListTopics(conn *kafkago.Conn) []string {
 	partitions, err := conn.ReadPartitions()
 	if err != nil {
 		wrappedError := NewXk6KafkaError(failedReadPartitions, "Failed to read partitions.", err)

--- a/topic_test.go
+++ b/topic_test.go
@@ -15,8 +15,8 @@ func TestGetKafkaControllerConnection(t *testing.T) {
 		connection := test.module.Kafka.GetKafkaControllerConnection(&ConnectionConfig{
 			Address: "localhost:9092",
 		})
-		defer connection.Close()
 		assert.NotNil(t, connection)
+		connection.Close()
 	})
 }
 
@@ -42,7 +42,6 @@ func TestTopics(t *testing.T) {
 		connection := test.module.Kafka.GetKafkaControllerConnection(&ConnectionConfig{
 			Address: "localhost:9092",
 		})
-		defer connection.Close()
 
 		test.module.Kafka.CreateTopic(connection, &kafkago.TopicConfig{
 			Topic: "test-topic",
@@ -55,5 +54,7 @@ func TestTopics(t *testing.T) {
 
 		topics = test.module.Kafka.ListTopics(connection)
 		assert.NotContains(t, topics, "test-topic")
+
+		connection.Close()
 	})
 }

--- a/topic_test.go
+++ b/topic_test.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"testing"
 
+	kafkago "github.com/segmentio/kafka-go"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -11,8 +12,9 @@ import (
 func TestGetKafkaControllerConnection(t *testing.T) {
 	test := GetTestModuleInstance(t)
 	assert.NotPanics(t, func() {
-		connection := test.module.Kafka.GetKafkaControllerConnection(
-			"localhost:9092", SASLConfig{}, TLSConfig{})
+		connection := test.module.Kafka.GetKafkaControllerConnection(&ConnectionConfig{
+			Address: "localhost:9092",
+		})
 		defer connection.Close()
 		assert.NotNil(t, connection)
 	})
@@ -24,8 +26,9 @@ func TestGetKafkaControllerConnectionFails(t *testing.T) {
 	test := GetTestModuleInstance(t)
 
 	assert.Panics(t, func() {
-		connection := test.module.Kafka.GetKafkaControllerConnection(
-			"localhost:9094", SASLConfig{}, TLSConfig{})
+		connection := test.module.Kafka.GetKafkaControllerConnection(&ConnectionConfig{
+			Address: "localhost:9094",
+		})
 		assert.Nil(t, connection)
 	})
 }
@@ -36,15 +39,21 @@ func TestTopics(t *testing.T) {
 
 	require.NoError(t, test.moveToVUCode())
 	assert.NotPanics(t, func() {
-		test.module.Kafka.CreateTopic(
-			"localhost:9092", "test-topic", 1, 1, "", SASLConfig{}, TLSConfig{})
+		connection := test.module.Kafka.GetKafkaControllerConnection(&ConnectionConfig{
+			Address: "localhost:9092",
+		})
+		defer connection.Close()
 
-		topics := test.module.Kafka.ListTopics("localhost:9092", SASLConfig{}, TLSConfig{})
+		test.module.Kafka.CreateTopic(connection, &kafkago.TopicConfig{
+			Topic: "test-topic",
+		})
+
+		topics := test.module.Kafka.ListTopics(connection)
 		assert.Contains(t, topics, "test-topic")
 
-		test.module.Kafka.DeleteTopic("localhost:9092", "test-topic", SASLConfig{}, TLSConfig{})
+		test.module.Kafka.DeleteTopic(connection, "test-topic")
 
-		topics = test.module.Kafka.ListTopics("localhost:9092", SASLConfig{}, TLSConfig{})
+		topics = test.module.Kafka.ListTopics(connection)
 		assert.NotContains(t, topics, "test-topic")
 	})
 }


### PR DESCRIPTION
In this PR I created the `Connection` class for creating, deleting, and listing topics, as mentioned in issue #89 (No. 8). The new syntax is as follows:
```javascript
const connection = new Connection({
    address: ...,
    sasl: {...},
    tls: {...}
});

// Create a topic
connection.createTopic({
    topic: topic,
    numPartitions: numPartitions,
    replicationFactor: replicationFactor,
    replicaAssignments: [...],
    configEntries: [...]
});

// List all topics
const result = connection.listTopics();

// Delete a specific topic
connection.deleteTopic(topic);

// Close the connection in teardown function
connection.close()
```