### PR TITLE
Update JS API docs

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -29,7 +29,6 @@ var (
 )
 
 type ReaderConfig struct {
-	*kafkago.ReaderConfig
 	Brokers                []string      `json:"brokers"`
 	GroupID                string        `json:"groupID"`
 	GroupTopics            []string      `json:"groupTopics"`

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,292 +1,46 @@
 # xk6-kafka
 
+**`description`**
+The xk6-kafka project is a k6 extension that enables k6 users to load test Apache Kafka using a producer and possibly a consumer for debugging.
 This documentation refers to the development version of the xk6-kafka project, which means the latest changes on `main` branch and might not be released yet, as explained in [the release process](https://github.com/mostafa/xk6-kafka#the-release-process).
+
+**`see`** [https://github.com/mostafa/xk6-kafka](https://github.com/mostafa/xk6-kafka)
 
 ## Table of contents
 
-### Module-level constants
-
-The following constants are available on the module-level (and the default export) and you can use them for various purposes. The usage of these constants are available in the example [scripts](https://github.com/mostafa/xk6-kafka/blob/main/scripts/) directory.
-
-```json
-{
-    // TLS versions
-    "TLS_1_0": "tls1.0",
-    "TLS_1_1": "tls1.1",
-    "TLS_1_2": "tls1.2",
-    "TLS_1_3": "tls1.3",
-
-    // SASL mechanisms
-    "NONE": "none",
-    "SASL_PLAIN": "sasl_plain",
-    "SASL_SCRAM_SHA256": "sasl_scram_sha256",
-    "SASL_SCRAM_SHA512": "sasl_scram_sha512",
-    "SASL_SSL": "sasl_ssl",
-
-    // Compression codecs
-    "CODEC_GZIP": "gzip",
-    "CODEC_SNAPPY": "snappy",
-    "CODEC_LZ4": "lz4",
-    "CODEC_ZSTD": "zstd",
-
-    // Serde types
-    "STRING_SERIALIZER": "org.apache.kafka.common.serialization.StringSerializer",
-    "STRING_DESERIALIZER": "org.apache.kafka.common.serialization.StringDeserializer",
-    "BYTE_ARRAY_SERIALIZER": "org.apache.kafka.common.serialization.ByteArraySerializer",
-    "BYTE_ARRAY_DESERIALIZER": "org.apache.kafka.common.serialization.ByteArrayDeserializer",
-    "JSON_SCHEMA_SERIALIZER": "io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializer",
-    "JSON_SCHEMA_DESERIALIZER": "io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer",
-    "AVRO_SERIALIZER": "io.confluent.kafka.serializers.KafkaAvroSerializer",
-    "AVRO_DESERIALIZER": "io.confluent.kafka.serializers.KafkaAvroDeserializer",
-    "PROTOBUF_SERIALIZER": "io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer",
-    "PROTOBUF_DESERIALIZER": "io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializer",
-
-    // TopicNameStrategy types
-    "TOPIC_NAME_STRATEGY": "TopicNameStrategy",
-    "RECORD_NAME_STRATEGY": "RecordNameStrategy",
-    "TOPIC_RECORD_NAME_STRATEGY": "TopicRecordNameStrategy",
-}
-```
-
-### Functions
-
-- [consume](README.md#consume)
-- [consumeWithConfiguration](README.md#consumewithconfiguration)
-- [createTopic](README.md#createtopic)
-- [deleteTopic](README.md#deletetopic)
-- [listTopics](README.md#listtopics)
-- [produce](README.md#produce)
-- [produceWithConfiguration](README.md#producewithconfiguration)
-- [reader](README.md#reader)
-- [writer](README.md#writer)
-
-## Functions
-
-### consume
-
-▸ **consume**(`reader`, `limit`, `keySchema`, `valueSchema`): [[`Object`], `Object`]
-
-Read a sequence of messages from Kafka.
-
-**`function`**
-
-#### Parameters
-
-| Name          | Type     | Description                                                              |
-| :------------ | :------- | :----------------------------------------------------------------------- |
-| `reader`      | `Object` | The reader object created with the reader constructor.                   |
-| `limit`       | `Number` | How many messages should be read in one go, which blocks. Defaults to 1. |
-| `keySchema`   | `String` | An optional Avro/JSONSchema schema for the key.                          |
-| `valueSchema` | `String` | An optional Avro/JSONSchema schema for the value.                        |
-
-#### Returns
-
-[[`Object`], `Object`]
-
-An array of two objects: an array of objects and an error object. Each message object can contain a value and an optional set of key, topic, partition, offset, time, highWaterMark and headers. Headers are objects.
-
-___
-
-### consumeWithConfiguration
-
-▸ **consumeWithConfiguration**(`reader`, `limit`, `configurationJson`, `keySchema`, `valueSchema`): [[`Object`], `Object`]
-
-Read a sequence of messages from Kafka.
-
-**`function`**
-
-#### Parameters
-
-| Name                | Type     | Description                                                              |
-| :------------------ | :------- | :----------------------------------------------------------------------- |
-| `reader`            | `object` | The reader object created with the reader constructor.                   |
-| `limit`             | `Number` | How many messages should be read in one go, which blocks. Defaults to 1. |
-| `configurationJson` | `String` | Serializer, deserializer and schemaRegistry configuration.               |
-| `keySchema`         | `String` | An optional Avro/JSONSchema schema for the key.                          |
-| `valueSchema`       | `String` | An optional Avro/JSONSchema schema for the value.                        |
-
-#### Returns
-
-[[`Object`], `Object`]
-
-An array of two objects: an array of objects and an error object. Each message object can contain a value and an optional set of key, topic, partition, offset, time, highWaterMark and headers. Headers are objects.
-
-___
-
-### createTopic
-
-▸ **createTopic**(`address`, `topic`, `partitions`, `replicationFactor`, `compression`, `saslConfig`, `tlsConfig`): `Object`
-
-Create a topic in Kafka. It does nothing if the topic exists.
-
-**`function`**
-
-#### Parameters
-
-| Name                | Type     | Description                                  |
-| :------------------ | :------- | :------------------------------------------- |
-| `address`           | `String` | The broker address.                          |
-| `topic`             | `String` | The topic name.                              |
-| `partitions`        | `Number` | The Number of partitions.                    |
-| `replicationFactor` | `Number` | The replication factor in a clustered setup. |
-| `compression`       | `String` | The compression algorithm.                   |
-| `saslConfig`        | `object` | The SASL configuration.                      |
-| `tlsConfig`         | `object` | The TLS configuration.                       |
-
-#### Returns
-
-`Object`
-
-A error object.
-
-___
-
-### deleteTopic
-
-▸ **deleteTopic**(`address`, `topic`, `saslConfig`, `tlsConfig`): `Object`
-
-Delete a topic from Kafka. It raises an error if the topic doesn't exist.
-
-**`function`**
-
-#### Parameters
-
-| Name         | Type     | Description             |
-| :----------- | :------- | :---------------------- |
-| `address`    | `String` | The broker address.     |
-| `topic`      | `String` | The topic name.         |
-| `saslConfig` | `Object` | The SASL configuration. |
-| `tlsConfig`  | `object` | The TLS configuration.  |
-
-#### Returns
-
-`Object`
-
-A error object.
-
-___
-
-### listTopics
-
-▸ **listTopics**(`address`, `saslConfig`, `tlsConfig`): [[`String`], `Object`]
-
-List all topics in Kafka.
-
-**`function`**
-
-#### Parameters
-
-| Name         | Type     | Description             |
-| :----------- | :------- | :---------------------- |
-| `address`    | `String` | The broker address.     |
-| `saslConfig` | `Object` | The SASL configuration. |
-| `tlsConfig`  | `Object` | The TLS configuration.  |
-
-#### Returns
-
-[[`String`], `Object`]
-
-A nested list of strings containing a list of topics and the error object (if any).
-
-___
-
-### produce
-
-▸ **produce**(`writer`, `messages`, `keySchema`, `valueSchema`, `autoCreateTopic`): `Object`
-
-Write a sequence of messages to Kafka.
-
-**`function`**
-
-#### Parameters
-
-| Name              | Type       | Description                                                                                                                                                  |
-| :---------------- | :--------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `writer`          | `Object`   | The writer object created with the writer constructor.                                                                                                       |
-| `messages`        | [`Object`] | An array of message objects containing an optional key and a value. Topic, offset and time and headers are also available and optional. Headers are objects. |
-| `keySchema`       | `String`   | An optional Avro/JSONSchema schema for the key.                                                                                                              |
-| `valueSchema`     | `String`   | An optional Avro/JSONSchema schema for the value.                                                                                                            |
-| `autoCreateTopic` | `boolean`  | Automatically creates the topic on the first produced message. Defaults to false.                                                                            |
-
-#### Returns
-
-`Object`
-
-A error object.
-
-___
-
-### produceWithConfiguration
-
-▸ **produceWithConfiguration**(`writer`, `messages`, `configurationJson`, `keySchema`, `valueSchema`, `autoCreateTopic`): `Object`
-
-Write a sequence of messages to Kafka with a specific serializer/deserializer.
-
-**`function`**
-
-#### Parameters
-
-| Name                | Type       | Description                                                                                                                                                  |
-| :------------------ | :--------- | :----------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `writer`            | `Object`   | The writer object created with the writer constructor.                                                                                                       |
-| `messages`          | [`Object`] | An array of message objects containing an optional key and a value. Topic, offset and time and headers are also available and optional. Headers are objects. |
-| `configurationJson` | `String`   | Serializer, deserializer and schemaRegistry configuration.                                                                                                   |
-| `keySchema`         | `String`   | An optional Avro/JSONSchema schema for the key.                                                                                                              |
-| `valueSchema`       | `String`   | An optional Avro/JSONSchema schema for the value.                                                                                                            |
-| `autoCreateTopic`   | `boolean`  | Automatically creates the topic on the first produced message. Defaults to false.                                                                            |
-
-#### Returns
-
-`Object`
-
-A error object.
-
-___
-
-### reader
-
-▸ **reader**(`brokers`, `topic`, `partition`, `groupID`, `offset`, `saslConfig`, `tlsConfig`): [`Object`, `Object`]
-
-Create a new Reader object for reading messages from Kafka.
-
-#### Parameters
-
-| Name         | Type       | Description                                   |
-| :----------- | :--------- | :-------------------------------------------- |
-| `brokers`    | [`String`] | An array of brokers, e.g. ["host:port", ...]. |
-| `topic`      | `String`   | The topic to read from.                       |
-| `partition`  | `Number`   | The partition.                                |
-| `groupID`    | `String`   | The group ID.                                 |
-| `offset`     | `Number`   | The offset to begin reading from.             |
-| `saslConfig` | `object`   | The SASL configuration.                       |
-| `tlsConfig`  | `object`   | The TLS configuration.                        |
-
-#### Returns
-
-[`Object`, `Object`]
-
-An array of two objects: A Reader object and an error object.
-
-___
-
-### writer
-
-▸ **writer**(`brokers`, `topic`, `saslConfig`, `tlsConfig`, `compression`): [`Object`, `Object`]
-
-Create a new Writer object for writing messages to Kafka.
-
-#### Parameters
-
-| Name          | Type       | Description                                   |
-| :------------ | :--------- | :-------------------------------------------- |
-| `brokers`     | [`String`] | An array of brokers, e.g. ["host:port", ...]. |
-| `topic`       | `String`   | The topic to write to.                        |
-| `saslConfig`  | `object`   | The SASL configuration.                       |
-| `tlsConfig`   | `object`   | The TLS configuration.                        |
-| `compression` | `String`   | The Compression algorithm.                    |
-
-#### Returns
-
-[`Object`, `Object`]
-
-An array of two objects: A Writer object and an error object.
+### Enumerations
+
+- [BALANCERS](enums/BALANCERS.md)
+- [COMPRESSION\_CODECS](enums/COMPRESSION_CODECS.md)
+- [DESERIALIZERS](enums/DESERIALIZERS.md)
+- [GROUP\_BALANCERS](enums/GROUP_BALANCERS.md)
+- [ISOLATION\_LEVEL](enums/ISOLATION_LEVEL.md)
+- [SASL\_MECHANISMS](enums/SASL_MECHANISMS.md)
+- [SERIALIZERS](enums/SERIALIZERS.md)
+- [SUBJECT\_NAME\_STRATEGY](enums/SUBJECT_NAME_STRATEGY.md)
+- [TLS\_VERSIONS](enums/TLS_VERSIONS.md)
+
+### Classes
+
+- [Connection](classes/Connection.md)
+- [Reader](classes/Reader.md)
+- [Writer](classes/Writer.md)
+
+### Interfaces
+
+- [BasicAuth](interfaces/BasicAuth.md)
+- [ConfigEntry](interfaces/ConfigEntry.md)
+- [Configuration](interfaces/Configuration.md)
+- [ConnectionConfig](interfaces/ConnectionConfig.md)
+- [ConsumeConfig](interfaces/ConsumeConfig.md)
+- [ConsumerConfiguration](interfaces/ConsumerConfiguration.md)
+- [Message](interfaces/Message.md)
+- [ProduceConfig](interfaces/ProduceConfig.md)
+- [ProducerConfiguration](interfaces/ProducerConfiguration.md)
+- [ReaderConfig](interfaces/ReaderConfig.md)
+- [ReplicaAssignment](interfaces/ReplicaAssignment.md)
+- [SASLConfig](interfaces/SASLConfig.md)
+- [SchemaRegistryConfiguration](interfaces/SchemaRegistryConfiguration.md)
+- [TLSConfig](interfaces/TLSConfig.md)
+- [TopicConfig](interfaces/TopicConfig.md)
+- [WriterConfig](interfaces/WriterConfig.md)

--- a/docs/classes/Connection.md
+++ b/docs/classes/Connection.md
@@ -1,0 +1,116 @@
+# Class: Connection
+
+**`classdesc`** Connection can connect to Kafka for working with topics.
+
+**`example`**
+
+```javascript
+// In init context
+const connection = new Connection({
+  address: "localhost:9092",
+});
+
+// In VU code (default function)
+const topics = connection.listTopics();
+
+// In teardown function
+connection.close();
+```
+
+## Table of contents
+
+### Constructors
+
+- [constructor](Connection.md#constructor)
+
+### Methods
+
+- [close](Connection.md#close)
+- [createTopic](Connection.md#createtopic)
+- [deleteTopic](Connection.md#deletetopic)
+- [listTopics](Connection.md#listtopics)
+
+## Constructors
+
+### constructor
+
+• **new Connection**(`connectionConfig`)
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `connectionConfig` | [`ConnectionConfig`](../interfaces/ConnectionConfig.md) | Connection configuration. |
+
+## Methods
+
+### close
+
+▸ **close**(): `void`
+
+**`destructor`**
+
+**`description`** Close the connection.
+
+#### Returns
+
+`void`
+
+- Nothing.
+
+___
+
+### createTopic
+
+▸ **createTopic**(`topicConfig`): `void`
+
+**`method`**
+Create a new topic.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `topicConfig` | [`TopicConfig`](../interfaces/TopicConfig.md) | Topic configuration. |
+
+#### Returns
+
+`void`
+
+- Nothing.
+
+___
+
+### deleteTopic
+
+▸ **deleteTopic**(`topic`): `void`
+
+**`method`**
+Delete a topic.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `topic` | `string` | Topic name. |
+
+#### Returns
+
+`void`
+
+- Nothing.
+
+___
+
+### listTopics
+
+▸ **listTopics**(): `string`[]
+
+**`method`**
+List topics.
+
+#### Returns
+
+`string`[]
+
+- Topics.

--- a/docs/classes/Reader.md
+++ b/docs/classes/Reader.md
@@ -1,0 +1,79 @@
+# Class: Reader
+
+**`classdesc`** Reader can read messages from Kafka.
+
+**`example`**
+
+```javascript
+// In init context
+const reader = new Reader({
+  brokers: ["localhost:9092"],
+  topic: "my-topic",
+});
+
+// In VU code (default function)
+const messages = reader.consume({limit: 10});
+
+// In teardown function
+reader.close();
+```
+
+## Table of contents
+
+### Constructors
+
+- [constructor](Reader.md#constructor)
+
+### Methods
+
+- [close](Reader.md#close)
+- [consume](Reader.md#consume)
+
+## Constructors
+
+### constructor
+
+• **new Reader**(`readerConfig`)
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `readerConfig` | [`ReaderConfig`](../interfaces/ReaderConfig.md) | Reader configuration. |
+
+## Methods
+
+### close
+
+▸ **close**(): `void`
+
+**`destructor`**
+
+**`description`** Close the reader.
+
+#### Returns
+
+`void`
+
+- Nothing.
+
+___
+
+### consume
+
+▸ **consume**(`consumeConfig`): [`Message`](../interfaces/Message.md)[]
+
+**`method`**
+Read messages from Kafka.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `consumeConfig` | [`ConsumeConfig`](../interfaces/ConsumeConfig.md) | Consume configuration. |
+
+#### Returns
+
+[`Message`](../interfaces/Message.md)[]
+
+- Messages.

--- a/docs/classes/Writer.md
+++ b/docs/classes/Writer.md
@@ -1,0 +1,87 @@
+# Class: Writer
+
+**`classdesc`** Writer can write messages to Kafka.
+
+**`example`**
+
+```javascript
+// In init context
+const writer = new Writer({
+  brokers: ["localhost:9092"],
+  topic: "my-topic",
+  autoCreateTopic: true,
+});
+
+// In VU code (default function)
+writer.produce({
+  messages: [
+    {
+      key: "key",
+      value: "value",
+    }
+  ]
+});
+
+// In teardown function
+writer.close();
+```
+
+## Table of contents
+
+### Constructors
+
+- [constructor](Writer.md#constructor)
+
+### Methods
+
+- [close](Writer.md#close)
+- [produce](Writer.md#produce)
+
+## Constructors
+
+### constructor
+
+• **new Writer**(`writerConfig`)
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `writerConfig` | [`WriterConfig`](../interfaces/WriterConfig.md) | Writer configuration. |
+
+## Methods
+
+### close
+
+▸ **close**(): `void`
+
+**`destructor`**
+
+**`description`** Close the writer.
+
+#### Returns
+
+`void`
+
+- Nothing.
+
+___
+
+### produce
+
+▸ **produce**(`produceConfig`): `void`
+
+**`method`**
+Write messages to Kafka.
+
+#### Parameters
+
+| Name | Type | Description |
+| :------ | :------ | :------ |
+| `produceConfig` | [`ProduceConfig`](../interfaces/ProduceConfig.md) | Produce configuration. |
+
+#### Returns
+
+`void`
+
+- Nothing.

--- a/docs/enums/BALANCERS.md
+++ b/docs/enums/BALANCERS.md
@@ -1,0 +1,41 @@
+# Enumeration: BALANCERS
+
+## Table of contents
+
+### Enumeration Members
+
+- [BALANCER\_CRC32](BALANCERS.md#balancer_crc32)
+- [BALANCER\_HASH](BALANCERS.md#balancer_hash)
+- [BALANCER\_LEAST\_BYTES](BALANCERS.md#balancer_least_bytes)
+- [BALANCER\_MURMUR2](BALANCERS.md#balancer_murmur2)
+- [BALANCER\_ROUND\_ROBIN](BALANCERS.md#balancer_round_robin)
+
+## Enumeration Members
+
+### BALANCER\_CRC32
+
+• **BALANCER\_CRC32**
+
+___
+
+### BALANCER\_HASH
+
+• **BALANCER\_HASH**
+
+___
+
+### BALANCER\_LEAST\_BYTES
+
+• **BALANCER\_LEAST\_BYTES**
+
+___
+
+### BALANCER\_MURMUR2
+
+• **BALANCER\_MURMUR2**
+
+___
+
+### BALANCER\_ROUND\_ROBIN
+
+• **BALANCER\_ROUND\_ROBIN**

--- a/docs/enums/COMPRESSION_CODECS.md
+++ b/docs/enums/COMPRESSION_CODECS.md
@@ -1,0 +1,36 @@
+# Enumeration: COMPRESSION\_CODECS
+
+Compression codecs for compressing messages when producing to a topic or reading from it.
+
+## Table of contents
+
+### Enumeration Members
+
+- [CODEC\_GZIP](COMPRESSION_CODECS.md#codec_gzip)
+- [CODEC\_LZ4](COMPRESSION_CODECS.md#codec_lz4)
+- [CODEC\_SNAPPY](COMPRESSION_CODECS.md#codec_snappy)
+- [CODEC\_ZSTD](COMPRESSION_CODECS.md#codec_zstd)
+
+## Enumeration Members
+
+### CODEC\_GZIP
+
+• **CODEC\_GZIP**
+
+___
+
+### CODEC\_LZ4
+
+• **CODEC\_LZ4**
+
+___
+
+### CODEC\_SNAPPY
+
+• **CODEC\_SNAPPY**
+
+___
+
+### CODEC\_ZSTD
+
+• **CODEC\_ZSTD**

--- a/docs/enums/DESERIALIZERS.md
+++ b/docs/enums/DESERIALIZERS.md
@@ -1,0 +1,41 @@
+# Enumeration: DESERIALIZERS
+
+## Table of contents
+
+### Enumeration Members
+
+- [AVRO\_DESERIALIZER](DESERIALIZERS.md#avro_deserializer)
+- [BYTE\_ARRAY\_DESERIALIZER](DESERIALIZERS.md#byte_array_deserializer)
+- [JSON\_SCHEMA\_DESERIALIZER](DESERIALIZERS.md#json_schema_deserializer)
+- [PROTOBUF\_DESERIALIZER](DESERIALIZERS.md#protobuf_deserializer)
+- [STRING\_DESERIALIZER](DESERIALIZERS.md#string_deserializer)
+
+## Enumeration Members
+
+### AVRO\_DESERIALIZER
+
+• **AVRO\_DESERIALIZER**
+
+___
+
+### BYTE\_ARRAY\_DESERIALIZER
+
+• **BYTE\_ARRAY\_DESERIALIZER**
+
+___
+
+### JSON\_SCHEMA\_DESERIALIZER
+
+• **JSON\_SCHEMA\_DESERIALIZER**
+
+___
+
+### PROTOBUF\_DESERIALIZER
+
+• **PROTOBUF\_DESERIALIZER**
+
+___
+
+### STRING\_DESERIALIZER
+
+• **STRING\_DESERIALIZER**

--- a/docs/enums/GROUP_BALANCERS.md
+++ b/docs/enums/GROUP_BALANCERS.md
@@ -1,0 +1,27 @@
+# Enumeration: GROUP\_BALANCERS
+
+## Table of contents
+
+### Enumeration Members
+
+- [GROUP\_BALANCER\_RACK\_AFFINITY](GROUP_BALANCERS.md#group_balancer_rack_affinity)
+- [GROUP\_BALANCER\_RANGE](GROUP_BALANCERS.md#group_balancer_range)
+- [GROUP\_BALANCER\_ROUND\_ROBIN](GROUP_BALANCERS.md#group_balancer_round_robin)
+
+## Enumeration Members
+
+### GROUP\_BALANCER\_RACK\_AFFINITY
+
+• **GROUP\_BALANCER\_RACK\_AFFINITY**
+
+___
+
+### GROUP\_BALANCER\_RANGE
+
+• **GROUP\_BALANCER\_RANGE**
+
+___
+
+### GROUP\_BALANCER\_ROUND\_ROBIN
+
+• **GROUP\_BALANCER\_ROUND\_ROBIN**

--- a/docs/enums/ISOLATION_LEVEL.md
+++ b/docs/enums/ISOLATION_LEVEL.md
@@ -1,0 +1,20 @@
+# Enumeration: ISOLATION\_LEVEL
+
+## Table of contents
+
+### Enumeration Members
+
+- [ISOLATION\_LEVEL\_READ\_COMMITTED](ISOLATION_LEVEL.md#isolation_level_read_committed)
+- [ISOLATION\_LEVEL\_READ\_UNCOMMITTED](ISOLATION_LEVEL.md#isolation_level_read_uncommitted)
+
+## Enumeration Members
+
+### ISOLATION\_LEVEL\_READ\_COMMITTED
+
+• **ISOLATION\_LEVEL\_READ\_COMMITTED**
+
+___
+
+### ISOLATION\_LEVEL\_READ\_UNCOMMITTED
+
+• **ISOLATION\_LEVEL\_READ\_UNCOMMITTED**

--- a/docs/enums/SASL_MECHANISMS.md
+++ b/docs/enums/SASL_MECHANISMS.md
@@ -1,0 +1,41 @@
+# Enumeration: SASL\_MECHANISMS
+
+## Table of contents
+
+### Enumeration Members
+
+- [NONE](SASL_MECHANISMS.md#none)
+- [SASL\_PLAIN](SASL_MECHANISMS.md#sasl_plain)
+- [SASL\_SCRAM\_SHA256](SASL_MECHANISMS.md#sasl_scram_sha256)
+- [SASL\_SCRAM\_SHA512](SASL_MECHANISMS.md#sasl_scram_sha512)
+- [SASL\_SSL](SASL_MECHANISMS.md#sasl_ssl)
+
+## Enumeration Members
+
+### NONE
+
+• **NONE**
+
+___
+
+### SASL\_PLAIN
+
+• **SASL\_PLAIN**
+
+___
+
+### SASL\_SCRAM\_SHA256
+
+• **SASL\_SCRAM\_SHA256**
+
+___
+
+### SASL\_SCRAM\_SHA512
+
+• **SASL\_SCRAM\_SHA512**
+
+___
+
+### SASL\_SSL
+
+• **SASL\_SSL**

--- a/docs/enums/SERIALIZERS.md
+++ b/docs/enums/SERIALIZERS.md
@@ -1,0 +1,41 @@
+# Enumeration: SERIALIZERS
+
+## Table of contents
+
+### Enumeration Members
+
+- [AVRO\_SERIALIZER](SERIALIZERS.md#avro_serializer)
+- [BYTE\_ARRAY\_SERIALIZER](SERIALIZERS.md#byte_array_serializer)
+- [JSON\_SCHEMA\_SERIALIZER](SERIALIZERS.md#json_schema_serializer)
+- [PROTOBUF\_SERIALIZER](SERIALIZERS.md#protobuf_serializer)
+- [STRING\_SERIALIZER](SERIALIZERS.md#string_serializer)
+
+## Enumeration Members
+
+### AVRO\_SERIALIZER
+
+• **AVRO\_SERIALIZER**
+
+___
+
+### BYTE\_ARRAY\_SERIALIZER
+
+• **BYTE\_ARRAY\_SERIALIZER**
+
+___
+
+### JSON\_SCHEMA\_SERIALIZER
+
+• **JSON\_SCHEMA\_SERIALIZER**
+
+___
+
+### PROTOBUF\_SERIALIZER
+
+• **PROTOBUF\_SERIALIZER**
+
+___
+
+### STRING\_SERIALIZER
+
+• **STRING\_SERIALIZER**

--- a/docs/enums/SUBJECT_NAME_STRATEGY.md
+++ b/docs/enums/SUBJECT_NAME_STRATEGY.md
@@ -1,0 +1,27 @@
+# Enumeration: SUBJECT\_NAME\_STRATEGY
+
+## Table of contents
+
+### Enumeration Members
+
+- [RECORD\_NAME\_STRATEGY](SUBJECT_NAME_STRATEGY.md#record_name_strategy)
+- [TOPIC\_NAME\_STRATEGY](SUBJECT_NAME_STRATEGY.md#topic_name_strategy)
+- [TOPIC\_RECORD\_NAME\_STRATEGY](SUBJECT_NAME_STRATEGY.md#topic_record_name_strategy)
+
+## Enumeration Members
+
+### RECORD\_NAME\_STRATEGY
+
+• **RECORD\_NAME\_STRATEGY**
+
+___
+
+### TOPIC\_NAME\_STRATEGY
+
+• **TOPIC\_NAME\_STRATEGY**
+
+___
+
+### TOPIC\_RECORD\_NAME\_STRATEGY
+
+• **TOPIC\_RECORD\_NAME\_STRATEGY**

--- a/docs/enums/TLS_VERSIONS.md
+++ b/docs/enums/TLS_VERSIONS.md
@@ -1,0 +1,34 @@
+# Enumeration: TLS\_VERSIONS
+
+## Table of contents
+
+### Enumeration Members
+
+- [TLS\_1\_0](TLS_VERSIONS.md#tls_1_0)
+- [TLS\_1\_1](TLS_VERSIONS.md#tls_1_1)
+- [TLS\_1\_2](TLS_VERSIONS.md#tls_1_2)
+- [TLS\_1\_3](TLS_VERSIONS.md#tls_1_3)
+
+## Enumeration Members
+
+### TLS\_1\_0
+
+• **TLS\_1\_0**
+
+___
+
+### TLS\_1\_1
+
+• **TLS\_1\_1**
+
+___
+
+### TLS\_1\_2
+
+• **TLS\_1\_2**
+
+___
+
+### TLS\_1\_3
+
+• **TLS\_1\_3**

--- a/docs/interfaces/BasicAuth.md
+++ b/docs/interfaces/BasicAuth.md
@@ -1,0 +1,20 @@
+# Interface: BasicAuth
+
+## Table of contents
+
+### Properties
+
+- [password](BasicAuth.md#password)
+- [username](BasicAuth.md#username)
+
+## Properties
+
+### password
+
+• **password**: `string`
+
+___
+
+### username
+
+• **username**: `string`

--- a/docs/interfaces/ConfigEntry.md
+++ b/docs/interfaces/ConfigEntry.md
@@ -1,0 +1,20 @@
+# Interface: ConfigEntry
+
+## Table of contents
+
+### Properties
+
+- [configName](ConfigEntry.md#configname)
+- [configValue](ConfigEntry.md#configvalue)
+
+## Properties
+
+### configName
+
+• **configName**: `string`
+
+___
+
+### configValue
+
+• **configValue**: `string`

--- a/docs/interfaces/Configuration.md
+++ b/docs/interfaces/Configuration.md
@@ -1,0 +1,27 @@
+# Interface: Configuration
+
+## Table of contents
+
+### Properties
+
+- [consumer](Configuration.md#consumer)
+- [producer](Configuration.md#producer)
+- [schemaRegistry](Configuration.md#schemaregistry)
+
+## Properties
+
+### consumer
+
+• **consumer**: [`ConsumerConfiguration`](ConsumerConfiguration.md)
+
+___
+
+### producer
+
+• **producer**: [`ProducerConfiguration`](ProducerConfiguration.md)
+
+___
+
+### schemaRegistry
+
+• **schemaRegistry**: [`SchemaRegistryConfiguration`](SchemaRegistryConfiguration.md)

--- a/docs/interfaces/ConnectionConfig.md
+++ b/docs/interfaces/ConnectionConfig.md
@@ -1,0 +1,27 @@
+# Interface: ConnectionConfig
+
+## Table of contents
+
+### Properties
+
+- [address](ConnectionConfig.md#address)
+- [sasl](ConnectionConfig.md#sasl)
+- [tls](ConnectionConfig.md#tls)
+
+## Properties
+
+### address
+
+• **address**: `string`
+
+___
+
+### sasl
+
+• **sasl**: [`SASLConfig`](SASLConfig.md)
+
+___
+
+### tls
+
+• **tls**: [`TLSConfig`](TLSConfig.md)

--- a/docs/interfaces/ConsumeConfig.md
+++ b/docs/interfaces/ConsumeConfig.md
@@ -1,0 +1,34 @@
+# Interface: ConsumeConfig
+
+## Table of contents
+
+### Properties
+
+- [config](ConsumeConfig.md#config)
+- [keySchema](ConsumeConfig.md#keyschema)
+- [limit](ConsumeConfig.md#limit)
+- [valueSchema](ConsumeConfig.md#valueschema)
+
+## Properties
+
+### config
+
+• **config**: [`Configuration`](Configuration.md)
+
+___
+
+### keySchema
+
+• **keySchema**: `string`
+
+___
+
+### limit
+
+• **limit**: `number`
+
+___
+
+### valueSchema
+
+• **valueSchema**: `string`

--- a/docs/interfaces/ConsumerConfiguration.md
+++ b/docs/interfaces/ConsumerConfiguration.md
@@ -1,0 +1,34 @@
+# Interface: ConsumerConfiguration
+
+## Table of contents
+
+### Properties
+
+- [SubjectNameStrategy](ConsumerConfiguration.md#subjectnamestrategy)
+- [keyDeserializer](ConsumerConfiguration.md#keydeserializer)
+- [useMagicPrefix](ConsumerConfiguration.md#usemagicprefix)
+- [valueDeserializer](ConsumerConfiguration.md#valuedeserializer)
+
+## Properties
+
+### SubjectNameStrategy
+
+• **SubjectNameStrategy**: [`SUBJECT_NAME_STRATEGY`](../enums/SUBJECT_NAME_STRATEGY.md)
+
+___
+
+### keyDeserializer
+
+• **keyDeserializer**: [`DESERIALIZERS`](../enums/DESERIALIZERS.md)
+
+___
+
+### useMagicPrefix
+
+• **useMagicPrefix**: `boolean`
+
+___
+
+### valueDeserializer
+
+• **valueDeserializer**: [`DESERIALIZERS`](../enums/DESERIALIZERS.md)

--- a/docs/interfaces/Message.md
+++ b/docs/interfaces/Message.md
@@ -1,0 +1,62 @@
+# Interface: Message
+
+## Table of contents
+
+### Properties
+
+- [headers](Message.md#headers)
+- [highwaterMark](Message.md#highwatermark)
+- [key](Message.md#key)
+- [offset](Message.md#offset)
+- [partition](Message.md#partition)
+- [time](Message.md#time)
+- [topic](Message.md#topic)
+- [value](Message.md#value)
+
+## Properties
+
+### headers
+
+• **headers**: `Map`<`string`, `any`\>
+
+___
+
+### highwaterMark
+
+• **highwaterMark**: `number`
+
+___
+
+### key
+
+• **key**: `string`
+
+___
+
+### offset
+
+• **offset**: `number`
+
+___
+
+### partition
+
+• **partition**: `number`
+
+___
+
+### time
+
+• **time**: `Date`
+
+___
+
+### topic
+
+• **topic**: `string`
+
+___
+
+### value
+
+• **value**: `string`

--- a/docs/interfaces/ProduceConfig.md
+++ b/docs/interfaces/ProduceConfig.md
@@ -1,0 +1,34 @@
+# Interface: ProduceConfig
+
+## Table of contents
+
+### Properties
+
+- [config](ProduceConfig.md#config)
+- [keySchema](ProduceConfig.md#keyschema)
+- [messages](ProduceConfig.md#messages)
+- [valueSchema](ProduceConfig.md#valueschema)
+
+## Properties
+
+### config
+
+• **config**: [`Configuration`](Configuration.md)
+
+___
+
+### keySchema
+
+• **keySchema**: `string`
+
+___
+
+### messages
+
+• **messages**: [`Message`](Message.md)[]
+
+___
+
+### valueSchema
+
+• **valueSchema**: `string`

--- a/docs/interfaces/ProducerConfiguration.md
+++ b/docs/interfaces/ProducerConfiguration.md
@@ -1,0 +1,27 @@
+# Interface: ProducerConfiguration
+
+## Table of contents
+
+### Properties
+
+- [SubjectNameStrategy](ProducerConfiguration.md#subjectnamestrategy)
+- [keyDeserializer](ProducerConfiguration.md#keydeserializer)
+- [valueDeserializer](ProducerConfiguration.md#valuedeserializer)
+
+## Properties
+
+### SubjectNameStrategy
+
+• **SubjectNameStrategy**: [`SUBJECT_NAME_STRATEGY`](../enums/SUBJECT_NAME_STRATEGY.md)
+
+___
+
+### keyDeserializer
+
+• **keyDeserializer**: [`SERIALIZERS`](../enums/SERIALIZERS.md)
+
+___
+
+### valueDeserializer
+
+• **valueDeserializer**: [`SERIALIZERS`](../enums/SERIALIZERS.md)

--- a/docs/interfaces/ReaderConfig.md
+++ b/docs/interfaces/ReaderConfig.md
@@ -1,0 +1,202 @@
+# Interface: ReaderConfig
+
+## Table of contents
+
+### Properties
+
+- [brokers](ReaderConfig.md#brokers)
+- [commitInterval](ReaderConfig.md#commitinterval)
+- [connectLogger](ReaderConfig.md#connectlogger)
+- [groupBalancers](ReaderConfig.md#groupbalancers)
+- [groupID](ReaderConfig.md#groupid)
+- [groupTopics](ReaderConfig.md#grouptopics)
+- [heartbeatInterval](ReaderConfig.md#heartbeatinterval)
+- [isolationLevel](ReaderConfig.md#isolationlevel)
+- [joinGroupBackoff](ReaderConfig.md#joingroupbackoff)
+- [maxAttempts](ReaderConfig.md#maxattempts)
+- [maxBytes](ReaderConfig.md#maxbytes)
+- [maxWait](ReaderConfig.md#maxwait)
+- [minBytes](ReaderConfig.md#minbytes)
+- [offset](ReaderConfig.md#offset)
+- [partition](ReaderConfig.md#partition)
+- [partitionWatchInterval](ReaderConfig.md#partitionwatchinterval)
+- [queueCapacity](ReaderConfig.md#queuecapacity)
+- [readBackoffMax](ReaderConfig.md#readbackoffmax)
+- [readBackoffMin](ReaderConfig.md#readbackoffmin)
+- [readLagInterval](ReaderConfig.md#readlaginterval)
+- [rebalanceTimeout](ReaderConfig.md#rebalancetimeout)
+- [retentionTime](ReaderConfig.md#retentiontime)
+- [sasl](ReaderConfig.md#sasl)
+- [sessionTimeout](ReaderConfig.md#sessiontimeout)
+- [startOffset](ReaderConfig.md#startoffset)
+- [tls](ReaderConfig.md#tls)
+- [topic](ReaderConfig.md#topic)
+- [watchPartitionChanges](ReaderConfig.md#watchpartitionchanges)
+
+## Properties
+
+### brokers
+
+• **brokers**: `string`[]
+
+___
+
+### commitInterval
+
+• **commitInterval**: `number`
+
+___
+
+### connectLogger
+
+• **connectLogger**: `boolean`
+
+___
+
+### groupBalancers
+
+• **groupBalancers**: [`GROUP_BALANCERS`](../enums/GROUP_BALANCERS.md)[]
+
+___
+
+### groupID
+
+• **groupID**: `string`
+
+___
+
+### groupTopics
+
+• **groupTopics**: `string`[]
+
+___
+
+### heartbeatInterval
+
+• **heartbeatInterval**: `number`
+
+___
+
+### isolationLevel
+
+• **isolationLevel**: [`ISOLATION_LEVEL`](../enums/ISOLATION_LEVEL.md)
+
+___
+
+### joinGroupBackoff
+
+• **joinGroupBackoff**: `number`
+
+___
+
+### maxAttempts
+
+• **maxAttempts**: `number`
+
+___
+
+### maxBytes
+
+• **maxBytes**: `number`
+
+___
+
+### maxWait
+
+• **maxWait**: `number`
+
+___
+
+### minBytes
+
+• **minBytes**: `number`
+
+___
+
+### offset
+
+• **offset**: `number`
+
+___
+
+### partition
+
+• **partition**: `number`
+
+___
+
+### partitionWatchInterval
+
+• **partitionWatchInterval**: `number`
+
+___
+
+### queueCapacity
+
+• **queueCapacity**: `number`
+
+___
+
+### readBackoffMax
+
+• **readBackoffMax**: `number`
+
+___
+
+### readBackoffMin
+
+• **readBackoffMin**: `number`
+
+___
+
+### readLagInterval
+
+• **readLagInterval**: `number`
+
+___
+
+### rebalanceTimeout
+
+• **rebalanceTimeout**: `number`
+
+___
+
+### retentionTime
+
+• **retentionTime**: `number`
+
+___
+
+### sasl
+
+• **sasl**: [`SASLConfig`](SASLConfig.md)
+
+___
+
+### sessionTimeout
+
+• **sessionTimeout**: `number`
+
+___
+
+### startOffset
+
+• **startOffset**: `number`
+
+___
+
+### tls
+
+• **tls**: [`TLSConfig`](TLSConfig.md)
+
+___
+
+### topic
+
+• **topic**: `string`
+
+___
+
+### watchPartitionChanges
+
+• **watchPartitionChanges**: `boolean`

--- a/docs/interfaces/ReplicaAssignment.md
+++ b/docs/interfaces/ReplicaAssignment.md
@@ -1,0 +1,20 @@
+# Interface: ReplicaAssignment
+
+## Table of contents
+
+### Properties
+
+- [partition](ReplicaAssignment.md#partition)
+- [replicas](ReplicaAssignment.md#replicas)
+
+## Properties
+
+### partition
+
+• **partition**: `number`
+
+___
+
+### replicas
+
+• **replicas**: `number`[]

--- a/docs/interfaces/SASLConfig.md
+++ b/docs/interfaces/SASLConfig.md
@@ -1,0 +1,27 @@
+# Interface: SASLConfig
+
+## Table of contents
+
+### Properties
+
+- [algorithm](SASLConfig.md#algorithm)
+- [password](SASLConfig.md#password)
+- [username](SASLConfig.md#username)
+
+## Properties
+
+### algorithm
+
+• **algorithm**: [`SASL_MECHANISMS`](../enums/SASL_MECHANISMS.md)
+
+___
+
+### password
+
+• **password**: `string`
+
+___
+
+### username
+
+• **username**: `string`

--- a/docs/interfaces/SchemaRegistryConfiguration.md
+++ b/docs/interfaces/SchemaRegistryConfiguration.md
@@ -1,0 +1,34 @@
+# Interface: SchemaRegistryConfiguration
+
+## Table of contents
+
+### Properties
+
+- [basicAuth](SchemaRegistryConfiguration.md#basicauth)
+- [tlsConfig](SchemaRegistryConfiguration.md#tlsconfig)
+- [url](SchemaRegistryConfiguration.md#url)
+- [useLatest](SchemaRegistryConfiguration.md#uselatest)
+
+## Properties
+
+### basicAuth
+
+• **basicAuth**: [`BasicAuth`](BasicAuth.md)
+
+___
+
+### tlsConfig
+
+• **tlsConfig**: [`TLSConfig`](TLSConfig.md)
+
+___
+
+### url
+
+• **url**: `string`
+
+___
+
+### useLatest
+
+• **useLatest**: `boolean`

--- a/docs/interfaces/TLSConfig.md
+++ b/docs/interfaces/TLSConfig.md
@@ -1,0 +1,48 @@
+# Interface: TLSConfig
+
+## Table of contents
+
+### Properties
+
+- [clientCertPem](TLSConfig.md#clientcertpem)
+- [clientKeyPem](TLSConfig.md#clientkeypem)
+- [enableTLS](TLSConfig.md#enabletls)
+- [insecureSkipVerify](TLSConfig.md#insecureskipverify)
+- [minVersion](TLSConfig.md#minversion)
+- [serverCertPem](TLSConfig.md#servercertpem)
+
+## Properties
+
+### clientCertPem
+
+• **clientCertPem**: `string`
+
+___
+
+### clientKeyPem
+
+• **clientKeyPem**: `string`
+
+___
+
+### enableTLS
+
+• **enableTLS**: `boolean`
+
+___
+
+### insecureSkipVerify
+
+• **insecureSkipVerify**: `boolean`
+
+___
+
+### minVersion
+
+• **minVersion**: [`TLS_VERSIONS`](../enums/TLS_VERSIONS.md)
+
+___
+
+### serverCertPem
+
+• **serverCertPem**: `string`

--- a/docs/interfaces/TopicConfig.md
+++ b/docs/interfaces/TopicConfig.md
@@ -1,0 +1,41 @@
+# Interface: TopicConfig
+
+## Table of contents
+
+### Properties
+
+- [configEntries](TopicConfig.md#configentries)
+- [numPartitions](TopicConfig.md#numpartitions)
+- [replicaAssignments](TopicConfig.md#replicaassignments)
+- [replicationFactor](TopicConfig.md#replicationfactor)
+- [topic](TopicConfig.md#topic)
+
+## Properties
+
+### configEntries
+
+• **configEntries**: [`ConfigEntry`](ConfigEntry.md)[]
+
+___
+
+### numPartitions
+
+• **numPartitions**: `number`
+
+___
+
+### replicaAssignments
+
+• **replicaAssignments**: [`ReplicaAssignment`](ReplicaAssignment.md)[]
+
+___
+
+### replicationFactor
+
+• **replicationFactor**: `number`
+
+___
+
+### topic
+
+• **topic**: `string`

--- a/docs/interfaces/WriterConfig.md
+++ b/docs/interfaces/WriterConfig.md
@@ -1,0 +1,104 @@
+# Interface: WriterConfig
+
+## Table of contents
+
+### Properties
+
+- [autoCreateTopic](WriterConfig.md#autocreatetopic)
+- [balancer](WriterConfig.md#balancer)
+- [batchBytes](WriterConfig.md#batchbytes)
+- [batchSize](WriterConfig.md#batchsize)
+- [batchTimeout](WriterConfig.md#batchtimeout)
+- [brokers](WriterConfig.md#brokers)
+- [compression](WriterConfig.md#compression)
+- [connectLogger](WriterConfig.md#connectlogger)
+- [maxAttempts](WriterConfig.md#maxattempts)
+- [readTimeout](WriterConfig.md#readtimeout)
+- [sasl](WriterConfig.md#sasl)
+- [tls](WriterConfig.md#tls)
+- [topic](WriterConfig.md#topic)
+- [writeTimeout](WriterConfig.md#writetimeout)
+
+## Properties
+
+### autoCreateTopic
+
+• **autoCreateTopic**: `boolean`
+
+___
+
+### balancer
+
+• **balancer**: [`BALANCERS`](../enums/BALANCERS.md)
+
+___
+
+### batchBytes
+
+• **batchBytes**: `number`
+
+___
+
+### batchSize
+
+• **batchSize**: `number`
+
+___
+
+### batchTimeout
+
+• **batchTimeout**: `number`
+
+___
+
+### brokers
+
+• **brokers**: `string`[]
+
+___
+
+### compression
+
+• **compression**: [`COMPRESSION_CODECS`](../enums/COMPRESSION_CODECS.md)
+
+___
+
+### connectLogger
+
+• **connectLogger**: `boolean`
+
+___
+
+### maxAttempts
+
+• **maxAttempts**: `number`
+
+___
+
+### readTimeout
+
+• **readTimeout**: `number`
+
+___
+
+### sasl
+
+• **sasl**: [`SASLConfig`](SASLConfig.md)
+
+___
+
+### tls
+
+• **tls**: [`TLSConfig`](TLSConfig.md)
+
+___
+
+### topic
+
+• **topic**: `string`
+
+___
+
+### writeTimeout
+
+• **writeTimeout**: `number`

--- a/index.d.ts
+++ b/index.d.ts
@@ -4,119 +4,389 @@
  */
 
 /**
- * Create a new Writer object for writing messages to Kafka.
- *
- * @constructor
- * @param   {[String]}          brokers     An array of brokers, e.g. ["host:port", ...].
- * @param   {String}            topic       The topic to write to.
- * @param   {Object}            saslConfig  The SASL configuration.
- * @param   {Object}            tlsConfig   The TLS configuration.
- * @param   {String}            compression The Compression algorithm.
- * @returns {[Object, Object]}   An array of two objects: A Writer object and an error object.
+ * @module k6/x/kafka
+ * @description
+ * The xk6-kafka project is a k6 extension that enables k6 users to load test Apache Kafka using a producer and possibly a consumer for debugging.
+ * This documentation refers to the development version of the xk6-kafka project, which means the latest changes on `main` branch and might not be released yet, as explained in [the release process](https://github.com/mostafa/xk6-kafka#the-release-process).
+ * @see {@link https://github.com/mostafa/xk6-kafka}
  */
-export declare function writer(brokers: [String], topic: String, saslConfig: object, tlsConfig: object, compression: String): [Object, Object];
+
+/** Compression codecs for compressing messages when producing to a topic or reading from it. */
+export enum COMPRESSION_CODECS {
+    CODEC_GZIP = "gzip",
+    CODEC_SNAPPY = "snappy",
+    CODEC_LZ4 = "lz4",
+    CODEC_ZSTD = "zstd",
+}
+
+/* SASL mechanisms for authenticating to Kafka. */
+export enum SASL_MECHANISMS {
+    NONE = "none",
+    SASL_PLAIN = "sasl_plain",
+    SASL_SCRAM_SHA256 = "sasl_scram_sha256",
+    SASL_SCRAM_SHA512 = "sasl_scram_sha512",
+    SASL_SSL = "sasl_ssl",
+}
+
+/* TLS versions for creating a secure communication channel with Kafka. */
+export enum TLS_VERSIONS {
+    TLS_1_0 = "tlsv1.0",
+    TLS_1_1 = "tlsv1.1",
+    TLS_1_2 = "tlsv1.2",
+    TLS_1_3 = "tlsv1.3",
+}
+
+/* Message serializers for producing messages to a topic. */
+export enum SERIALIZERS {
+    STRING_SERIALIZER = "org.apache.kafka.common.serialization.StringSerializer",
+    BYTE_ARRAY_SERIALIZER = "org.apache.kafka.common.serialization.ByteArraySerializer",
+    JSON_SCHEMA_SERIALIZER = "io.confluent.kafka.serializers.json.KafkaJsonSchemaSerializer",
+    AVRO_SERIALIZER = "io.confluent.kafka.serializers.KafkaAvroSerializer",
+    PROTOBUF_SERIALIZER = "io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer",
+}
+
+/* Message deserializers for consuming messages from a topic. */
+export enum DESERIALIZERS {
+    STRING_DESERIALIZER = "org.apache.kafka.common.serialization.StringDeserializer",
+    BYTE_ARRAY_DESERIALIZER = "org.apache.kafka.common.serialization.ByteArrayDeserializer",
+    JSON_SCHEMA_DESERIALIZER = "io.confluent.kafka.serializers.json.KafkaJsonSchemaDeserializer",
+    AVRO_DESERIALIZER = "io.confluent.kafka.serializers.KafkaAvroDeserializer",
+    PROTOBUF_DESERIALIZER = "io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializer",
+}
+
+/* Isolation levels controls the visibility of transactional records. */
+export enum ISOLATION_LEVEL {
+    ISOLATION_LEVEL_READ_UNCOMMITTED = "isolation_level_read_uncommitted",
+    ISOLATION_LEVEL_READ_COMMITTED = "isolation_level_read_committed",
+}
+
+/* Subject name strategy for storing a schema in Schema Registry. */
+export enum SUBJECT_NAME_STRATEGY {
+    TOPIC_NAME_STRATEGY = "TopicNameStrategy",
+    RECORD_NAME_STRATEGY = "RecordNameStrategy",
+    TOPIC_RECORD_NAME_STRATEGY = "TopicRecordNameStrategy",
+}
+
+/* Balancers for distributing messages to partitions. */
+export enum BALANCERS {
+    BALANCER_ROUND_ROBIN = "balancer_roundrobin",
+    BALANCER_LEAST_BYTES = "balancer_leastbytes",
+    BALANCER_HASH = "balancer_hash",
+    BALANCER_CRC32 = "balancer_crc32",
+    BALANCER_MURMUR2 = "balancer_murmur2",
+}
+
+/* Consumer group balancing strategies for consuming messages. */
+export enum GROUP_BALANCERS {
+    GROUP_BALANCER_RANGE = "group_balancer_range",
+    GROUP_BALANCER_ROUND_ROBIN = "group_balancer_round_robin",
+    GROUP_BALANCER_RACK_AFFINITY = "group_balancer_rack_affinity",
+}
+
+/* SASL configurations for authenticating to Kafka. */
+export interface SASLConfig {
+    username: string;
+    password: string;
+    algorithm: SASL_MECHANISMS;
+}
+
+/* TLS configurations for creating a secure communication channel with Kafka. */
+export interface TLSConfig {
+    enableTLS: boolean;
+    insecureSkipVerify: boolean;
+    minVersion: TLS_VERSIONS;
+    clientCertPem: string;
+    clientKeyPem: string;
+    serverCertPem: string;
+}
+
+/* Writer configurations for producing messages to a topic. */
+export interface WriterConfig {
+    brokers: string[];
+    topic: string;
+    autoCreateTopic: boolean;
+    balancer: BALANCERS;
+    maxAttempts: number;
+    batchSize: number;
+    batchBytes: number;
+    batchTimeout: number;
+    readTimeout: number;
+    writeTimeout: number;
+    compression: COMPRESSION_CODECS;
+    sasl: SASLConfig;
+    tls: TLSConfig;
+    connectLogger: boolean;
+}
+
+/*
+ * Message format for producing messages to a topic.
+ * @note: The message format will be adopted by the reader at some point.
+ */
+export interface Message {
+    topic: string;
+    partition: number;
+    offset: number;
+    highwaterMark: number;
+    key: string;
+    value: string;
+    headers: Map<string, any>;
+    time: Date;
+}
+
+/* Consumer configurations for consuming deserialized messages from a topic. */
+export interface ConsumerConfiguration {
+    keyDeserializer: DESERIALIZERS;
+    valueDeserializer: DESERIALIZERS;
+    SubjectNameStrategy: SUBJECT_NAME_STRATEGY;
+    useMagicPrefix: boolean;
+}
+
+/* Producer configurations for producing serialized messages to a topic. */
+export interface ProducerConfiguration {
+    keyDeserializer: SERIALIZERS;
+    valueDeserializer: SERIALIZERS;
+    SubjectNameStrategy: SUBJECT_NAME_STRATEGY;
+}
+
+/* Basic authentication for connecting to Schema Registry. */
+export interface BasicAuth {
+    username: string;
+    password: string;
+}
+
+/* Schema Registry configurations for creating a possible secure communication channel with Schema Registry for storing and retrieving schemas. */
+export interface SchemaRegistryConfiguration {
+    url: string;
+    basicAuth: BasicAuth;
+    useLatest: boolean;
+    tlsConfig: TLSConfig;
+}
+
+/* Configuration for Produce and Consume methods. */
+export interface Configuration {
+    consumer: ConsumerConfiguration;
+    producer: ProducerConfiguration;
+    schemaRegistry: SchemaRegistryConfiguration;
+}
+
+/* Configuration for producing messages to a topic. */
+export interface ProduceConfig {
+    messages: Message[];
+    config: Configuration;
+    keySchema: string;
+    valueSchema: string;
+}
+
+/* Configuration for creating a Reader instance. */
+export interface ReaderConfig {
+    brokers: string[];
+    groupID: string;
+    groupTopics: string[];
+    topic: string;
+    partition: number;
+    queueCapacity: number;
+    minBytes: number;
+    maxBytes: number;
+    maxWait: number;
+    readLagInterval: number;
+    groupBalancers: GROUP_BALANCERS[];
+    heartbeatInterval: number;
+    commitInterval: number;
+    partitionWatchInterval: number;
+    watchPartitionChanges: boolean;
+    sessionTimeout: number;
+    rebalanceTimeout: number;
+    joinGroupBackoff: number;
+    retentionTime: number;
+    startOffset: number;
+    readBackoffMin: number;
+    readBackoffMax: number;
+    connectLogger: boolean;
+    maxAttempts: number;
+    isolationLevel: ISOLATION_LEVEL;
+    offset: number;
+    sasl: SASLConfig;
+    tls: TLSConfig;
+}
+
+/* Configuration for Consume method. */
+export interface ConsumeConfig {
+    limit: number;
+    config: Configuration;
+    keySchema: string;
+    valueSchema: string;
+}
+
+/* Configuration for creating a Connector instance for working with topics. */
+export interface ConnectionConfig {
+    address: string;
+    sasl: SASLConfig;
+    tls: TLSConfig;
+}
+
+/* ReplicaAssignment among kafka brokers for this topic partitions. */
+export interface ReplicaAssignment {
+    partition: number;
+    replicas: number[];
+}
+
+/* ConfigEntry holds topic level configuration for topic to be set. */
+export interface ConfigEntry {
+    configName: string;
+    configValue: string;
+}
+
+/* TopicConfig for creating a new topic. */
+export interface TopicConfig {
+    topic: string;
+    numPartitions: number;
+    replicationFactor: number;
+    replicaAssignments: ReplicaAssignment[];
+    configEntries: ConfigEntry[];
+}
 
 /**
- * Write a sequence of messages to Kafka.
+ * @class
+ * @classdesc Writer can write messages to Kafka.
+ * @example
  *
- * @function
- * @param   {Object}    writer      The writer object created with the writer constructor.
- * @param   {[Object]}  messages    An array of message objects containing an optional key and a value. Topic, offset and time and headers are also available and optional. Headers are objects.
- * @param   {String}    keySchema   An optional Avro/JSONSchema schema for the key.
- * @param   {String}    valueSchema An optional Avro/JSONSchema schema for the value.
- * @param   {boolean}   autoCreateTopic     Automatically creates the topic on the first produced message. Defaults to false.
- * @returns {Object}    A error object.
+ * ```javascript
+ * // In init context
+ * const writer = new Writer({
+ *   brokers: ["localhost:9092"],
+ *   topic: "my-topic",
+ *   autoCreateTopic: true,
+ * });
+ *
+ * // In VU code (default function)
+ * writer.produce({
+ *   messages: [
+ *     {
+ *       key: "key",
+ *       value: "value",
+ *     }
+ *   ]
+ * });
+ *
+ * // In teardown function
+ * writer.close();
+ * ```
  */
-export declare function produce(writer: Object, messages: [Object], keySchema: String, valueSchema: String, autoCreateTopic: boolean): Object;
+export class Writer {
+    /**
+     * @constructor
+     * Create a new Writer.
+     * @param {WriterConfig} writerConfig - Writer configuration.
+     * @returns {Writer} - Writer instance.
+     */
+    constructor(writerConfig: WriterConfig);
+    /**
+     * @method
+     * Write messages to Kafka.
+     * @param {ProduceConfig} produceConfig - Produce configuration.
+     * @returns {void} - Nothing.
+     */
+    produce(produceConfig: ProduceConfig): void;
+    /**
+     * @destructor
+     * @description Close the writer.
+     * @returns {void} - Nothing.
+     */
+    close(): void;
+}
 
 /**
- * Write a sequence of messages to Kafka with a specific serializer/deserializer.
+ * @class
+ * @classdesc Reader can read messages from Kafka.
+ * @example
  *
- * @function
- * @param   {Object}    writer              The writer object created with the writer constructor.
- * @param   {[Object]}  messages            An array of message objects containing an optional key and a value. Topic, offset and time and headers are also available and optional. Headers are objects.
- * @param   {String}    configurationJson   Serializer, deserializer and schemaRegistry configuration.
- * @param   {String}    keySchema           An optional Avro/JSONSchema schema for the key.
- * @param   {String}    valueSchema         An optional Avro/JSONSchema schema for the value.
- * @param   {boolean}   autoCreateTopic     Automatically creates the topic on the first produced message. Defaults to false.
- * @returns {Object}    A error object.
+ * ```javascript
+ * // In init context
+ * const reader = new Reader({
+ *   brokers: ["localhost:9092"],
+ *   topic: "my-topic",
+ * });
+ *
+ * // In VU code (default function)
+ * const messages = reader.consume({limit: 10});
+ *
+ * // In teardown function
+ * reader.close();
+ * ```
  */
-export declare function produceWithConfiguration(writer: Object, messages: [Object], configurationJson: String, keySchema: String, valueSchema: String, autoCreateTopic: boolean): Object;
+export class Reader {
+    /**
+     * @constructor
+     * Create a new Reader.
+     * @param {ReaderConfig} readerConfig - Reader configuration.
+     * @returns {Reader} - Reader instance.
+     */
+    constructor(readerConfig: ReaderConfig);
+    /**
+     * @method
+     * Read messages from Kafka.
+     * @param {ConsumeConfig} consumeConfig - Consume configuration.
+     * @returns {Message[]} - Messages.
+     */
+    consume(consumeConfig: ConsumeConfig): Message[];
+    /**
+     * @destructor
+     * @description Close the reader.
+     * @returns {void} - Nothing.
+     */
+    close(): void;
+}
 
 /**
- * Create a new Reader object for reading messages from Kafka.
+ * @class
+ * @classdesc Connection can connect to Kafka for working with topics.
+ * @example
  *
- * @constructor
- * @param   {[String]}          brokers     An array of brokers, e.g. ["host:port", ...].
- * @param   {String}            topic       The topic to read from.
- * @param   {Number}            partition   The partition.
- * @param   {Number}            groupID     The group ID.
- * @param   {Number}            offset      The offset to begin reading from.
- * @param   {Object}            saslConfig  The SASL configuration.
- * @param   {Object}            tlsConfig   The TLS configuration.
- * @returns {[Object, error]}   An array of two objects: A Reader object and an error object.
- */
-export declare function reader(brokers: [String], topic: String, partition: Number, groupID: String, offset: Number, saslConfig: object, tlsConfig: object): [Object, Object];
-
-/**
- * Read a sequence of messages from Kafka.
+ * ```javascript
+ * // In init context
+ * const connection = new Connection({
+ *   address: "localhost:9092",
+ * });
  *
- * @function
- * @param   {Object}            reader      The reader object created with the reader constructor.
- * @param   {Number}            limit       How many messages should be read in one go, which blocks. Defaults to 1.
- * @param   {String}            keySchema   An optional Avro/JSONSchema schema for the key.
- * @param   {String}            valueSchema An optional Avro/JSONSchema schema for the value.
- * @returns {[[Object], error]} An array of two objects: an array of objects and an error object. Each message object can contain a value and an optional set of key, topic, partition, offset, time, highWaterMark and headers. Headers are objects.
- */
-export declare function consume(reader: Object, limit: Number, keySchema: String, valueSchema: String): [[Object], Object];
-
-/**
- * Read a sequence of messages from Kafka.
+ * // In VU code (default function)
+ * const topics = connection.listTopics();
  *
- * @function
- * @param   {Object}            reader              The reader object created with the reader constructor.
- * @param   {Number}            limit               How many messages should be read in one go, which blocks. Defaults to 1.
- * @param   {String}            configurationJson   Serializer, deserializer and schemaRegistry configuration.
- * @param   {String}            keySchema           An optional Avro/JSONSchema schema for the key.
- * @param   {String}            valueSchema         An optional Avro/JSONSchema schema for the value.
- * @returns {[[Object], Object]} An array of two objects: an array of objects and an error object. Each message object can contain a value and an optional set of key, topic, partition, offset, time, highWaterMark and headers. Headers are objects.
+ * // In teardown function
+ * connection.close();
+ * ```
  */
-export declare function consumeWithConfiguration(reader: object, limit: Number, configurationJson: String, keySchema: String, valueSchema: String): [[Object], Object];
-
-/**
- * Create a topic in Kafka. It does nothing if the topic exists.
- *
- * @function
- * @param   {String}    address             The broker address.
- * @param   {String}    topic               The topic name.
- * @param   {Number}    partitions          The Number of partitions.
- * @param   {Number}    replicationFactor   The replication factor in a clustered setup.
- * @param   {String}    compression         The compression algorithm.
- * @param   {Object}    saslConfig          The SASL configuration.
- * @param   {Object}    tlsConfig           The TLS configuration.
- * @returns {Object}    A error object.
- */
-export declare function createTopic(address: String, topic: String, partitions: Number, replicationFactor: Number, compression: String, saslConfig: object, tlsConfig: object): Object;
-
-/**
- * Delete a topic from Kafka. It raises an error if the topic doesn't exist.
- *
- * @function
- * @param   {String}    address             The broker address.
- * @param   {String}    topic               The topic name.
- * @param   {Object}    saslConfig          The SASL configuration.
- * @param   {Object}    tlsConfig           The TLS configuration.
- * @returns {Object}    A error object.
- */
-export declare function deleteTopic(address: String, topic: String, saslConfig: Object, tlsConfig: object): Object;
-
-/**
- * List all topics in Kafka.
- *
- * @function
- * @param   {String}            address The broker address.
- * @param   {Object}            saslConfig          The SASL configuration.
- * @param   {Object}            tlsConfig           The TLS configuration.
- * @returns {[String], Object}  A nested list of strings containing a list of topics and the error object (if any).
- */
-export declare function listTopics(address: String, saslConfig: Object, tlsConfig: Object): [[String], Object];
+export class Connection {
+    /**
+     * @constructor
+     * Create a new Connection.
+     * @param {ConnectionConfig} connectionConfig - Connection configuration.
+     * @returns {Connection} - Connection instance.
+     */
+    constructor(connectionConfig: ConnectionConfig);
+    /**
+     * @method
+     * Create a new topic.
+     * @param {TopicConfig} topicConfig - Topic configuration.
+     * @returns {void} - Nothing.
+     */
+    createTopic(topicConfig: TopicConfig): void;
+    /**
+     * @method
+     * Delete a topic.
+     * @param {string} topic - Topic name.
+     * @returns {void} - Nothing.
+     */
+    deleteTopic(topic: string): void;
+    /**
+     * @method
+     * List topics.
+     * @returns {string[]} - Topics.
+     */
+    listTopics(): string[];
+    /**
+     * @destructor
+     * @description Close the connection.
+     * @returns {void} - Nothing.
+     */
+    close(): void;
+}

--- a/schema_registry.go
+++ b/schema_registry.go
@@ -25,7 +25,7 @@ type SchemaRegistryConfiguration struct {
 	Url       string    `json:"url"`
 	BasicAuth BasicAuth `json:"basicAuth"`
 	UseLatest bool      `json:"useLatest"`
-	TLSConfig TLSConfig `json:"tlsConfig"`
+	TLS       TLSConfig `json:"tls"`
 }
 
 const (
@@ -64,7 +64,7 @@ func EncodeWireFormat(data []byte, schemaID int) []byte {
 func SchemaRegistryClientWithConfiguration(configuration SchemaRegistryConfiguration) *srclient.SchemaRegistryClient {
 	var srClient *srclient.SchemaRegistryClient
 
-	tlsConfig, err := GetTLSConfig(configuration.TLSConfig)
+	tlsConfig, err := GetTLSConfig(configuration.TLS)
 	if err != nil {
 		logger.WithField("error", err).Warn("Failed to get TLS config. Continuing without TLS.")
 		srClient = srclient.CreateSchemaRegistryClient(configuration.Url)

--- a/schema_registry_test.go
+++ b/schema_registry_test.go
@@ -65,7 +65,7 @@ func TestSchemaRegistryClientWithTLSConfig(t *testing.T) {
 			Username: "username",
 			Password: "password",
 		},
-		TLSConfig: TLSConfig{
+		TLS: TLSConfig{
 			ClientCertPem: "fixtures/client.cer",
 			ClientKeyPem:  "fixtures/client.pem",
 			ServerCaPem:   "fixtures/caroot.cer",


### PR DESCRIPTION
I have completely refactored the JS API, and the old API is practically deprecated and removed. Therefore, I updated the TS types information (in `index.d.ts`) to generate the new JS API docs, available in the `docs` directory. This JS API docs refer to the refactorings done in these PRs, as mentioned in issue #89:
- #92 
- #93 
- #95 
- #96 
- #97 
- #98 