### PR TITLE
Fix header retrieval when consuming messages

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -315,7 +315,10 @@ func (k *Kafka) consumeInternal(
 		message["offset"] = msg.Offset
 		message["time"] = time.Unix(msg.Time.Unix(), 0).Format(time.RFC3339)
 		message["highWaterMark"] = msg.HighWaterMark
-		message["headers"] = msg.Headers
+		message["headers"] = map[string]interface{}{}
+		for _, header := range msg.Headers {
+			message["headers"].(map[string]interface{})[header.Key] = header.Value
+		}
 
 		messages = append(messages, message)
 	}

--- a/scripts/test_json.js
+++ b/scripts/test_json.js
@@ -94,20 +94,10 @@ export default function () {
 
     check(messages[0], {
         "Topic equals to xk6_kafka_json_topic": (msg) => msg["topic"] == topic,
-        "Key is correct": (msg) => msg["key"] == JSON.stringify({ correlationId: "test-id-abc-0" }),
-        "Value is correct": (msg) =>
-            msg["value"] ==
-            JSON.stringify({
-                name: "xk6-kafka",
-                version: "0.9.0",
-                author: "Mostafa Moradian",
-                description:
-                    "k6 extension to load test Apache Kafka with support for Avro messages",
-                index: 0,
-            }),
-        "Header equals {mykey: 'myvalue'}": (msg) =>
-            msg.headers[0]["key"] == "mykey" &&
-            String.fromCharCode(...msg.headers[0]["value"]) == "myvalue",
+        "Key is correct": (msg) => JSON.parse(msg["key"])["correlationId"].startsWith("test-id-"),
+        "Value is correct": (msg) => JSON.parse(msg["value"])["name"] == "xk6-kafka",
+        "Header equals {'mykey': 'myvalue'}": (msg) =>
+            "mykey" in msg.headers && String.fromCharCode(...msg.headers["mykey"]) == "myvalue",
         "Time is past": (msg) => new Date(msg["time"]) < new Date(),
         "Partition is zero": (msg) => msg["partition"] == 0,
         "Offset is gte zero": (msg) => msg["offset"] >= 0,


### PR DESCRIPTION
I was testing the `scripts/test_json.js` script and I found out that the headers are always empty, so I fixed it.