### PR TITLE
Ignore `noTLSConfig` error code, because it is polluting the output log

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -62,7 +62,10 @@ func GetDialer(saslConfig SASLConfig, tlsConfig TLSConfig) (*kafkago.Dialer, *Xk
 	// Create a TLS dialer, either with or without SASL authentication
 	tlsObject, err := GetTLSConfig(tlsConfig)
 	if err != nil {
-		logger.WithField("error", err).Info("Cannot process TLS config")
+		// Ignore the error if we're not using TLS
+		if err.Code != noTLSConfig {
+			logger.WithField("error", err).Error("Cannot process TLS config")
+		}
 	}
 	if tlsObject == nil && saslConfig.Algorithm == SASL_SSL {
 		return nil, NewXk6KafkaError(
@@ -139,7 +142,6 @@ func GetTLSConfig(tlsConfig TLSConfig) (*tls.Config, *Xk6KafkaError) {
 		}
 	} else {
 		// TLS is disabled, and we continue with a unauthenticated dialer
-		// FIXME: This is not an actual error, and we should return nil instead
 		return nil, NewXk6KafkaError(
 			noTLSConfig, "No TLS config provided. Continuing with TLS disabled.", nil)
 	}

--- a/auth_test.go
+++ b/auth_test.go
@@ -135,14 +135,6 @@ func TestTlsConfigFails(t *testing.T) {
 	saslConfig := []*SimpleTLSConfig{
 		{
 			saslConfig: SASLConfig{},
-			tlsConfig:  TLSConfig{},
-			err: &Xk6KafkaError{
-				Code:    noTLSConfig,
-				Message: "No TLS config provided. Continuing with TLS disabled.",
-			},
-		},
-		{
-			saslConfig: SASLConfig{},
 			tlsConfig:  TLSConfig{EnableTLS: true, ClientCertPem: "test.cer"},
 			err: &Xk6KafkaError{
 				Code:    fileNotFound,

--- a/schema_registry.go
+++ b/schema_registry.go
@@ -66,7 +66,10 @@ func SchemaRegistryClientWithConfiguration(configuration SchemaRegistryConfigura
 
 	tlsConfig, err := GetTLSConfig(configuration.TLS)
 	if err != nil {
-		logger.WithField("error", err).Warn("Failed to get TLS config. Continuing without TLS.")
+		// Ignore the error if we're not using TLS
+		if err.Code != noTLSConfig {
+			logger.WithField("error", err).Error("Cannot process TLS config")
+		}
 		srClient = srclient.CreateSchemaRegistryClient(configuration.Url)
 	}
 


### PR DESCRIPTION
This PR addresses a noisy log message when the TLS config is empty or not used. This is part of issue #89.