### PR TITLE
Fix reported issues by gofumpt and goimports

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -13,10 +13,8 @@ import (
 	"github.com/segmentio/kafka-go/sasl/scram"
 )
 
-var (
-	// TLSVersions is a map of TLS versions to their numeric values.
-	TLSVersions map[string]uint16
-)
+// TLSVersions is a map of TLS versions to their numeric values.
+var TLSVersions map[string]uint16
 
 const (
 	NONE              = "none"

--- a/avro.go
+++ b/avro.go
@@ -21,7 +21,7 @@ func SerializeAvro(configuration Configuration, topic string, data interface{}, 
 
 	client := SchemaRegistryClientWithConfiguration(configuration.SchemaRegistry)
 
-	var subject, subjectNameError = GetSubjectName(schema, topic, element, configuration.Producer.SubjectNameStrategy)
+	subject, subjectNameError := GetSubjectName(schema, topic, element, configuration.Producer.SubjectNameStrategy)
 	if subjectNameError != nil {
 		return nil, subjectNameError
 	}
@@ -106,7 +106,7 @@ func DeserializeAvro(configuration Configuration, topic string, data []byte, ele
 
 	client := SchemaRegistryClientWithConfiguration(configuration.SchemaRegistry)
 
-	var subject, subjectNameError = GetSubjectName(schema, topic, element, configuration.Consumer.SubjectNameStrategy)
+	subject, subjectNameError := GetSubjectName(schema, topic, element, configuration.Consumer.SubjectNameStrategy)
 	if subjectNameError != nil {
 		return nil, subjectNameError
 	}

--- a/consumer.go
+++ b/consumer.go
@@ -237,7 +237,8 @@ func (k *Kafka) GetDeserializer(schema string) Deserializer {
 // consume consumes messages from the given reader.
 // nolint: funlen
 func (k *Kafka) consume(
-	reader *kafkago.Reader, consumeConfig *ConsumeConfig) []map[string]interface{} {
+	reader *kafkago.Reader, consumeConfig *ConsumeConfig,
+) []map[string]interface{} {
 	if state := k.vu.State(); state == nil {
 		logger.WithField("error", ErrorForbiddenInInitContext).Error(ErrorForbiddenInInitContext)
 		common.Throw(k.vu.Runtime(), ErrorForbiddenInInitContext)

--- a/consumer_test.go
+++ b/consumer_test.go
@@ -60,7 +60,8 @@ func TestConsume(t *testing.T) {
 						Value:  "value1",
 						Offset: 0,
 					},
-				}})
+				},
+			})
 		})
 
 		// Consume a message in the VU function.
@@ -123,7 +124,8 @@ func TestConsumeWithoutKey(t *testing.T) {
 						Value:  "value1",
 						Offset: 1,
 					},
-				}})
+				},
+			})
 		})
 
 		// Consume a message in the VU function.
@@ -169,7 +171,8 @@ func TestConsumerContextCancelled(t *testing.T) {
 						Value:  "value1",
 						Offset: 2,
 					},
-				}})
+				},
+			})
 		})
 
 		test.cancelContext()
@@ -219,7 +222,8 @@ func TestConsumeJSON(t *testing.T) {
 						Value:  string(serialized),
 						Offset: 3,
 					},
-				}})
+				},
+			})
 		})
 
 		// Consume the message.

--- a/jsonschema.go
+++ b/jsonschema.go
@@ -80,7 +80,6 @@ func SerializeJson(configuration Configuration, topic string, data interface{}, 
 	}
 
 	return EncodeWireFormat(bytesData, schemaID), nil
-
 }
 
 // DeserializeJson deserializes the data from JSON and returns the decoded data. It

--- a/module.go
+++ b/module.go
@@ -12,10 +12,8 @@ import (
 	"go.k6.io/k6/lib/netext"
 )
 
-var (
-	// logger is globally used by the Kafka module.
-	logger *logrus.Logger
-)
+// logger is globally used by the Kafka module.
+var logger *logrus.Logger
 
 // init registers the xk6-kafka module as 'k6/x/kafka'.
 func init() {

--- a/producer_test.go
+++ b/producer_test.go
@@ -36,7 +36,8 @@ func TestProduce(t *testing.T) {
 						Key:   "key2",
 						Value: "value2",
 					},
-				}})
+				},
+			})
 		})
 
 		require.NoError(t, test.moveToVUCode())
@@ -53,7 +54,8 @@ func TestProduce(t *testing.T) {
 						Key:   "key2",
 						Value: "value2",
 					},
-				}})
+				},
+			})
 		})
 	})
 
@@ -117,7 +119,8 @@ func TestProduceWithoutKey(t *testing.T) {
 						Value: "value2",
 						Topic: "test-topic",
 					},
-				}})
+				},
+			})
 		})
 	})
 
@@ -160,7 +163,8 @@ func TestProducerContextCancelled(t *testing.T) {
 						Key:   "key2",
 						Value: "value2",
 					},
-				}})
+				},
+			})
 		})
 	})
 
@@ -200,7 +204,8 @@ func TestProduceJSON(t *testing.T) {
 					{
 						Value: string(serialized),
 					},
-				}})
+				},
+			})
 		})
 	})
 

--- a/schema_registry.go
+++ b/schema_registry.go
@@ -91,7 +91,8 @@ func SchemaRegistryClientWithConfiguration(configuration SchemaRegistryConfigura
 
 // GetSchema returns the schema for the given subject and schema ID and version.
 func GetSchema(
-	client *srclient.SchemaRegistryClient, subject string, schema string, schemaType srclient.SchemaType, version int) (*srclient.Schema, *Xk6KafkaError) {
+	client *srclient.SchemaRegistryClient, subject string, schema string, schemaType srclient.SchemaType, version int,
+) (*srclient.Schema, *Xk6KafkaError) {
 	// The client always caches the schema.
 	var schemaInfo *srclient.Schema
 	var err error
@@ -111,7 +112,8 @@ func GetSchema(
 
 // CreateSchema creates a new schema in the schema registry.
 func CreateSchema(
-	client *srclient.SchemaRegistryClient, subject string, schema string, schemaType srclient.SchemaType) (*srclient.Schema, *Xk6KafkaError) {
+	client *srclient.SchemaRegistryClient, subject string, schema string, schemaType srclient.SchemaType,
+) (*srclient.Schema, *Xk6KafkaError) {
 	schemaInfo, err := client.CreateSchema(subject, schema, schemaType)
 	if err != nil {
 		return nil, NewXk6KafkaError(schemaCreationFailed, "Failed to create schema.", err)
@@ -130,7 +132,7 @@ func GetSubjectName(schema string, topic string, element Element, subjectNameStr
 	if err != nil {
 		return "", NewXk6KafkaError(failedToUnmarshalSchema, "Failed to unmarshal schema", nil)
 	}
-	var recordName = ""
+	recordName := ""
 	if namespace, ok := schemaMap["namespace"]; ok {
 		recordName = namespace.(string) + "."
 	}

--- a/schema_registry_test.go
+++ b/schema_registry_test.go
@@ -7,9 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var (
-	avroSchemaForSRTests string = `{"type":"record","name":"Schema","fields":[{"name":"field","type":"string"}]}`
-)
+var avroSchemaForSRTests string = `{"type":"record","name":"Schema","fields":[{"name":"field","type":"string"}]}`
 
 // TestDecodeWireFormat tests the decoding of a wire-formatted message.
 func TestDecodeWireFormat(t *testing.T) {

--- a/serde.go
+++ b/serde.go
@@ -6,8 +6,10 @@ import (
 	"github.com/riferrei/srclient"
 )
 
-type Serializer func(configuration Configuration, topic string, data interface{}, element Element, schema string, version int) ([]byte, *Xk6KafkaError)
-type Deserializer func(configuration Configuration, topic string, data []byte, element Element, schema string, version int) (interface{}, *Xk6KafkaError)
+type (
+	Serializer   func(configuration Configuration, topic string, data interface{}, element Element, schema string, version int) ([]byte, *Xk6KafkaError)
+	Deserializer func(configuration Configuration, topic string, data []byte, element Element, schema string, version int) (interface{}, *Xk6KafkaError)
+)
 
 const (
 	// TODO: move these to their own package.


### PR DESCRIPTION
Addresses:
- #109 (No. 7)

Commands:
```bash
golangci-lint run --disable-all -E gofumpts
golangci-lint run --disable-all -E goimports
```