### PR TITLE
Fix long lines reported by lll

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -141,7 +141,10 @@ func GetTLSConfig(tlsConfig TLSConfig) (*tls.Config, *Xk6KafkaError) {
 	if err != nil {
 		return nil, NewXk6KafkaError(
 			failedLoadX509KeyPair,
-			fmt.Sprintf("Error creating x509 key pair from client cert file \"%s\" and client key file \"%s\".", tlsConfig.ClientCertPem, tlsConfig.ClientKeyPem),
+			fmt.Sprintf(
+				"Error creating x509 key pair from \"%s\" and \"%s\".",
+				tlsConfig.ClientCertPem,
+				tlsConfig.ClientKeyPem),
 			err)
 	}
 

--- a/auth_test.go
+++ b/auth_test.go
@@ -92,7 +92,9 @@ func TestGetDialerFails(t *testing.T) {
 	dialer, wrappedError := GetDialer(saslConfig, TLSConfig{})
 	assert.Equal(t, wrappedError.Message, "Unable to create SCRAM mechanism")
 	// This is a stringprep (RFC3454) error wrapped inside the Xk6KafkaError.
-	assert.Equal(t, wrappedError.Unwrap().Error(), "Error SASLprepping username 'https://www.exa\t\r\n': prohibited character (rune: '\\u0009')")
+	assert.Equal(t, wrappedError.Unwrap().Error(),
+		"Error SASLprepping username 'https://www.exa\t\r\n': "+
+			"prohibited character (rune: '\\u0009')")
 	assert.Nil(t, dialer)
 }
 
@@ -176,8 +178,9 @@ func TestTlsConfigFails(t *testing.T) {
 				ClientKeyPem:  "fixtures/invalid-client.pem",
 			},
 			err: &Xk6KafkaError{
-				Code:          failedLoadX509KeyPair,
-				Message:       "Error creating x509 key pair from client cert file \"fixtures/invalid-client.cer\" and client key file \"fixtures/invalid-client.pem\".",
+				Code: failedLoadX509KeyPair,
+				Message: "Error creating x509 key pair from \"fixtures/invalid-client.cer\" " +
+					"and \"fixtures/invalid-client.pem\".",
 				OriginalError: errors.New("tls: failed to find any PEM data in certificate input"),
 			},
 		},

--- a/avro.go
+++ b/avro.go
@@ -16,7 +16,9 @@ const (
 // is used to configure the Schema Registry client. The element is used to define the subject.
 // The data should be a string.
 // nolint: funlen
-func SerializeAvro(configuration Configuration, topic string, data interface{}, element Element, schema string, version int) ([]byte, *Xk6KafkaError) {
+func SerializeAvro(
+	configuration Configuration, topic string, data interface{},
+	element Element, schema string, version int) ([]byte, *Xk6KafkaError) {
 	bytesData := []byte(data.(string))
 
 	client := SchemaRegistryClientWithConfiguration(configuration.SchemaRegistry)
@@ -92,7 +94,9 @@ func SerializeAvro(configuration Configuration, topic string, data interface{}, 
 // is used to configure the Schema Registry client. The element is used to define the subject.
 // The data should be a byte array.
 // nolint: funlen
-func DeserializeAvro(configuration Configuration, topic string, data []byte, element Element, schema string, version int) (interface{}, *Xk6KafkaError) {
+func DeserializeAvro(
+	configuration Configuration, topic string, data []byte,
+	element Element, schema string, version int) (interface{}, *Xk6KafkaError) {
 	schemaID, bytesDecodedData, err := DecodeWireFormat(data)
 	if err != nil {
 		return nil, NewXk6KafkaError(failedDecodeFromWireFormat,

--- a/avro_test.go
+++ b/avro_test.go
@@ -19,8 +19,12 @@ var (
 			KeyDeserializer:   AvroDeserializer,
 		},
 	}
-	avroSchemaForAvroTests string = `{"type":"record","name":"Schema","namespace":"io.confluent.kafka.avro","fields":[{"name":"field","type":"string"}]}`
-	data                   string = `{"field":"value"}`
+	avroSchemaForAvroTests string = `{
+		"type":"record",
+		"name":"Schema",
+		"namespace":"io.confluent.kafka.avro",
+		"fields":[{"name":"field","type":"string"}]}`
+	data string = `{"field":"value"}`
 )
 
 // TestSerializeDeserializeAvro tests serialization and deserialization of Avro messages.
@@ -41,7 +45,8 @@ func TestSerializeDeserializeAvro(t *testing.T) {
 	}
 }
 
-// TestSerializeDeserializeAvroFailsOnSchemaError tests serialization and deserialization of Avro messages and fails on schema error.
+// TestSerializeDeserializeAvroFailsOnSchemaError tests serialization and
+// deserialization of Avro messages and fails on schema error.
 func TestSerializeDeserializeAvroFailsOnSchemaError(t *testing.T) {
 	jsonSchema = `{}`
 
@@ -62,7 +67,8 @@ func TestSerializeDeserializeAvroFailsOnSchemaError(t *testing.T) {
 	}
 }
 
-// TestSerializeDeserializeAvroFailsOnWireFormatError tests serialization and deserialization of Avro messages and fails on wire format error.
+// TestSerializeDeserializeAvroFailsOnWireFormatError tests serialization and
+// deserialization of Avro messages and fails on wire format error.
 func TestSerializeDeserializeAvroFailsOnWireFormatError(t *testing.T) {
 	schema := `{}`
 
@@ -84,7 +90,8 @@ func TestSerializeDeserializeAvroFailsOnWireFormatError(t *testing.T) {
 	}
 }
 
-// TestSerializeDeserializeAvroFailsOnEncodeDecodeError tests serialization and deserialization of Avro messages and fails on encode/decode error.
+// TestSerializeDeserializeAvroFailsOnEncodeDecodeError tests serialization and
+// deserialization of Avro messages and fails on encode/decode error.
 func TestSerializeDeserializeAvroFailsOnEncodeDecodeError(t *testing.T) {
 	data := `{"nonExistingField":"value"}`
 
@@ -116,7 +123,11 @@ func TestAvroSerializeTopicNameStrategy(t *testing.T) {
 		},
 	}
 
-	schema := `{"type":"record","name":"TestAvroSerializeTopicNameStrategyIsDefaultStrategy","namespace":"io.confluent.kafka.avro","fields":[{"name":"field","type":"string"}]}`
+	schema := `{
+		"type":"record",
+		"name":"TestAvroSerializeTopicNameStrategyIsDefaultStrategy",
+		"namespace":"io.confluent.kafka.avro",
+		"fields":[{"name":"field","type":"string"}]}`
 
 	serialized, err := SerializeAvro(config, topic, data, Value, schema, 0)
 	assert.Nil(t, err)
@@ -129,7 +140,8 @@ func TestAvroSerializeTopicNameStrategy(t *testing.T) {
 	assert.NotNil(t, schemaResult)
 }
 
-// TestAvroSerializeTopicNameStrategyIsDefaultStrategy tests serialization of Avro messages with the default topic name strategy.
+// TestAvroSerializeTopicNameStrategyIsDefaultStrategy tests serialization of
+// Avro messages with the default topic name strategy.
 func TestAvroSerializeTopicNameStrategyIsDefaultStrategy(t *testing.T) {
 	topic := "TestAvroSerializeTopicNameStrategyIsDefaultStrategy-topic"
 	config := Configuration{
@@ -141,7 +153,11 @@ func TestAvroSerializeTopicNameStrategyIsDefaultStrategy(t *testing.T) {
 		},
 	}
 
-	schema := `{"type":"record","name":"TestAvroSerializeTopicNameStrategyIsDefaultStrategy","namespace":"io.confluent.kafka.avro","fields":[{"name":"field","type":"string"}]}`
+	schema := `{
+		"type":"record",
+		"name":"TestAvroSerializeTopicNameStrategyIsDefaultStrategy",
+		"namespace":"io.confluent.kafka.avro",
+		"fields":[{"name":"field","type":"string"}]}`
 
 	serialized, err := SerializeAvro(config, topic, data, Value, schema, 0)
 	assert.Nil(t, err)
@@ -154,7 +170,8 @@ func TestAvroSerializeTopicNameStrategyIsDefaultStrategy(t *testing.T) {
 	assert.NotNil(t, schemaResult)
 }
 
-// TestAvroSerializeTopicRecordNameStrategy tests serialization of Avro messages with the given topic record name strategy.
+// TestAvroSerializeTopicRecordNameStrategy tests serialization of Avro messages
+// with the given topic record name strategy.
 func TestAvroSerializeTopicRecordNameStrategy(t *testing.T) {
 	topic := "TestAvroSerializeTopicRecordNameStrategy-topic"
 	config := Configuration{
@@ -166,7 +183,11 @@ func TestAvroSerializeTopicRecordNameStrategy(t *testing.T) {
 			URL: "http://localhost:8081",
 		},
 	}
-	schema := `{"type":"record","name":"TestAvroSerializeTopicRecordNameStrategy","namespace":"io.confluent.kafka.avro","fields":[{"name":"field","type":"string"}]}`
+	schema := `{
+		"type":"record",
+		"name":"TestAvroSerializeTopicRecordNameStrategy",
+		"namespace":"io.confluent.kafka.avro",
+		"fields":[{"name":"field","type":"string"}]}`
 
 	serialized, err := SerializeAvro(config, topic, data, Value, schema, 0)
 	assert.Nil(t, err)
@@ -179,7 +200,8 @@ func TestAvroSerializeTopicRecordNameStrategy(t *testing.T) {
 	assert.NotNil(t, schemaResult)
 }
 
-// TestAvroSerializeRecordNameStrategy tests serialization of Avro messages with the given record name strategy.
+// TestAvroSerializeRecordNameStrategy tests serialization of Avro messages
+// with the given record name strategy.
 func TestAvroSerializeRecordNameStrategy(t *testing.T) {
 	topic := "TestAvroSerializeRecordNameStrategy-topic"
 	config := Configuration{
@@ -191,7 +213,11 @@ func TestAvroSerializeRecordNameStrategy(t *testing.T) {
 			URL: "http://localhost:8081",
 		},
 	}
-	schema := `{"type":"record","name":"TestAvroSerializeRecordNameStrategy","namespace":"io.confluent.kafka.avro","fields":[{"name":"field","type":"string"}]}`
+	schema := `{
+		"type":"record",
+		"name":"TestAvroSerializeRecordNameStrategy",
+		"namespace":"io.confluent.kafka.avro",
+		"fields":[{"name":"field","type":"string"}]}`
 
 	serialized, err := SerializeAvro(config, topic, data, Value, schema, 0)
 	assert.Nil(t, err)
@@ -204,7 +230,8 @@ func TestAvroSerializeRecordNameStrategy(t *testing.T) {
 	assert.NotNil(t, resultSchema)
 }
 
-// TestAvroDeserializeUsingMagicPrefix tests deserialization of Avro messages with the given magic prefix.
+// TestAvroDeserializeUsingMagicPrefix tests deserialization of Avro messages
+// with the given magic prefix.
 func TestAvroDeserializeUsingMagicPrefix(t *testing.T) {
 	topic := "TestAvroDeserializeUsingMagicPrefix-topic"
 	config := Configuration{
@@ -219,7 +246,11 @@ func TestAvroDeserializeUsingMagicPrefix(t *testing.T) {
 			URL: "http://localhost:8081",
 		},
 	}
-	schema := `{"type":"record","name":"TestAvroDeserializeUsingMagicPrefix","namespace":"io.confluent.kafka.avro","fields":[{"name":"field","type":"string"}]}`
+	schema := `{
+		"type":"record",
+		"name":"TestAvroDeserializeUsingMagicPrefix",
+		"namespace":"io.confluent.kafka.avro",
+		"fields":[{"name":"field","type":"string"}]}`
 
 	serialized, err := SerializeAvro(config, topic, data, Value, schema, 0)
 	assert.Nil(t, err)
@@ -229,7 +260,8 @@ func TestAvroDeserializeUsingMagicPrefix(t *testing.T) {
 	assert.Nil(t, dErr)
 }
 
-// TestAvroDeserializeUsingDefaultSubjectNameStrategy tests deserialization of Avro messages with the default topic name strategy.
+// TestAvroDeserializeUsingDefaultSubjectNameStrategy tests deserialization of
+// Avro messages with the default topic name strategy.
 func TestAvroDeserializeUsingDefaultSubjectNameStrategy(t *testing.T) {
 	topic := "TestAvroDeserializeUsingDefaultSubjectNameStrategy-topic"
 	config := Configuration{
@@ -243,7 +275,11 @@ func TestAvroDeserializeUsingDefaultSubjectNameStrategy(t *testing.T) {
 			URL: "http://localhost:8081",
 		},
 	}
-	schema := `{"type":"record","name":"TestAvroDeserializeUsingDefaultSubjectNameStrategy","namespace":"io.confluent.kafka.avro","fields":[{"name":"field","type":"string"}]}`
+	schema := `{
+		"type":"record",
+		"name":"TestAvroDeserializeUsingDefaultSubjectNameStrategy",
+		"namespace":"io.confluent.kafka.avro",
+		"fields":[{"name":"field","type":"string"}]}`
 
 	serialized, err := SerializeAvro(config, topic, data, Value, schema, 0)
 	assert.Nil(t, err)
@@ -253,7 +289,8 @@ func TestAvroDeserializeUsingDefaultSubjectNameStrategy(t *testing.T) {
 	assert.Nil(t, dErr)
 }
 
-// TestAvroDeserializeUsingSubjectNameStrategyRecordName tests deserialization of Avro messages with the given topic record name strategy.
+// TestAvroDeserializeUsingSubjectNameStrategyRecordName tests deserialization of
+// Avro messages with the given topic record name strategy.
 func TestAvroDeserializeUsingSubjectNameStrategyRecordName(t *testing.T) {
 	topic := "TestAvroDeserializeUsingSubjectNameStrategyRecordName-topic"
 	config := Configuration{
@@ -269,7 +306,11 @@ func TestAvroDeserializeUsingSubjectNameStrategyRecordName(t *testing.T) {
 			URL: "http://localhost:8081",
 		},
 	}
-	schema := `{"type":"record","name":"TestAvroDeserializeUsingSubjectNameStrategyRecordName","namespace":"io.confluent.kafka.avro","fields":[{"name":"field","type":"string"}]}`
+	schema := `{
+		"type":"record",
+		"name":"TestAvroDeserializeUsingSubjectNameStrategyRecordName",
+		"namespace":"io.confluent.kafka.avro",
+		"fields":[{"name":"field","type":"string"}]}`
 
 	serialized, err := SerializeAvro(config, topic, data, Value, schema, 0)
 	assert.Nil(t, err)
@@ -279,7 +320,8 @@ func TestAvroDeserializeUsingSubjectNameStrategyRecordName(t *testing.T) {
 	assert.Nil(t, dErr)
 }
 
-// TestAvroDeserializeUsingSubjectNameStrategyTopicRecordName tests deserialization of Avro messages with the given topic record name strategy.
+// TestAvroDeserializeUsingSubjectNameStrategyTopicRecordName tests deserialization of
+// Avro messages with the given topic record name strategy.
 func TestAvroDeserializeUsingSubjectNameStrategyTopicRecordName(t *testing.T) {
 	topic := "TestAvroDeserializeUsingSubjectNameStrategyTopicRecordName-topic"
 	config := Configuration{
@@ -295,7 +337,11 @@ func TestAvroDeserializeUsingSubjectNameStrategyTopicRecordName(t *testing.T) {
 			URL: "http://localhost:8081",
 		},
 	}
-	schema := `{"type":"record","name":"TestAvroDeserializeUsingSubjectNameStrategyTopicRecordName","namespace":"io.confluent.kafka.avro","fields":[{"name":"field","type":"string"}]}`
+	schema := `{
+		"type":"record",
+		"name":"TestAvroDeserializeUsingSubjectNameStrategyTopicRecordName",
+		"namespace":"io.confluent.kafka.avro",
+		"fields":[{"name":"field","type":"string"}]}`
 
 	serialized, err := SerializeAvro(config, topic, data, Value, schema, 0)
 	assert.Nil(t, err)
@@ -305,7 +351,8 @@ func TestAvroDeserializeUsingSubjectNameStrategyTopicRecordName(t *testing.T) {
 	assert.Nil(t, dErr)
 }
 
-// TestAvroDeserializeUsingSubjectNameStrategyTopicName tests deserialization of Avro messages with the given topic name strategy.
+// TestAvroDeserializeUsingSubjectNameStrategyTopicName tests deserialization of Avro
+// messages with the given topic name strategy.
 func TestAvroDeserializeUsingSubjectNameStrategyTopicName(t *testing.T) {
 	topic := "TestAvroDeserializeUsingSubjectNameStrategyTopicName-topic"
 	config := Configuration{
@@ -321,7 +368,11 @@ func TestAvroDeserializeUsingSubjectNameStrategyTopicName(t *testing.T) {
 			URL: "http://localhost:8081",
 		},
 	}
-	schema := `{"type":"record","name":"TestAvroDeserializeUsingSubjectNameStrategyTopicName","namespace":"io.confluent.kafka.avro","fields":[{"name":"field","type":"string"}]}`
+	schema := `{
+		"type":"record",
+		"name":"TestAvroDeserializeUsingSubjectNameStrategyTopicName",
+		"namespace":"io.confluent.kafka.avro",
+		"fields":[{"name":"field","type":"string"}]}`
 
 	serialized, err := SerializeAvro(config, topic, data, Value, schema, 0)
 	assert.Nil(t, err)

--- a/bytearray.go
+++ b/bytearray.go
@@ -16,7 +16,9 @@ const (
 // SerializeByteArray serializes the given data into a byte array and returns it.
 // If the data is not a byte array, an error is returned. The configuration, topic, element,
 // schema and version are just used to conform with the interface.
-func SerializeByteArray(configuration Configuration, topic string, data interface{}, element Element, schema string, version int) ([]byte, *Xk6KafkaError) {
+func SerializeByteArray(
+	configuration Configuration, topic string, data interface{},
+	element Element, schema string, version int) ([]byte, *Xk6KafkaError) {
 	switch data := data.(type) {
 	case []interface{}:
 		arr := make([]byte, len(data))
@@ -35,6 +37,8 @@ func SerializeByteArray(configuration Configuration, topic string, data interfac
 // DeserializeByteArray deserializes the given data from a byte array and returns it.
 // It just returns the data as is. The configuration, topic, element, schema and version
 // are just used to conform with the interface.
-func DeserializeByteArray(configuration Configuration, topic string, data []byte, element Element, schema string, version int) (interface{}, *Xk6KafkaError) {
+func DeserializeByteArray(
+	configuration Configuration, topic string, data []byte,
+	element Element, schema string, version int) (interface{}, *Xk6KafkaError) {
 	return data, nil
 }

--- a/consumer.go
+++ b/consumer.go
@@ -217,7 +217,8 @@ func (k *Kafka) reader(readerConfig *ReaderConfig) *kafkago.Reader {
 			}
 		} else {
 			err := NewXk6KafkaError(
-				failedSetOffset, "Offset and groupID are mutually exclusive options, so offset is not set, yet returning the reader.", nil)
+				failedSetOffset, "Offset and groupID are mutually exclusive options, "+
+					"so offset is not set, yet returning the reader.", nil)
 			logger.WithField("error", err).Warn(err)
 			return reader
 		}

--- a/jsonschema.go
+++ b/jsonschema.go
@@ -18,7 +18,9 @@ const (
 // encode the data. The configuration is used to configure the Schema Registry client.
 // The element is used to define the subject. The data should be a string.
 // nolint: funlen
-func SerializeJSON(configuration Configuration, topic string, data interface{}, element Element, schema string, version int) ([]byte, *Xk6KafkaError) {
+func SerializeJSON(
+	configuration Configuration, topic string, data interface{},
+	element Element, schema string, version int) ([]byte, *Xk6KafkaError) {
 	bytesData := []byte(data.(string))
 
 	client := SchemaRegistryClientWithConfiguration(configuration.SchemaRegistry)
@@ -87,7 +89,9 @@ func SerializeJSON(configuration Configuration, topic string, data interface{}, 
 // uses the given schema to manually create the codec and decode the data. The
 // configuration is used to configure the Schema Registry client. The element is
 // used to define the subject. The data should be a byte array.
-func DeserializeJSON(configuration Configuration, topic string, data []byte, element Element, schema string, version int) (interface{}, *Xk6KafkaError) {
+func DeserializeJSON(
+	configuration Configuration, topic string, data []byte,
+	element Element, schema string, version int) (interface{}, *Xk6KafkaError) {
 	_, bytesDecodedData, err := DecodeWireFormat(data)
 	if err != nil {
 		return nil, NewXk6KafkaError(failedDecodeFromWireFormat,

--- a/schema_registry_test.go
+++ b/schema_registry_test.go
@@ -157,7 +157,11 @@ func TestGetSubjectNameCanUseTopicNameStrategy(t *testing.T) {
 }
 
 func TestGetSubjectNameCanUseTopicRecordNameStrategyWithNamespace(t *testing.T) {
-	avroSchema := `{"type":"record","namespace":"com.example.person","name":"Schema","fields":[{"name":"field","type":"string"}]}`
+	avroSchema := `{
+		"type":"record",
+		"namespace":"com.example.person",
+		"name":"Schema",
+		"fields":[{"name":"field","type":"string"}]}`
 	subject, err := GetSubjectName(avroSchema, "test-topic", Value, TopicRecordNameStrategy)
 	assert.Nil(t, err)
 	assert.Equal(t, "test-topic-com.example.person.Schema", subject)
@@ -176,7 +180,11 @@ func TestGetSubjectNameCanUseRecordNameStrategyWithoutNamespace(t *testing.T) {
 }
 
 func TestGetSubjectNameCanUseRecordNameStrategyWithNamespace(t *testing.T) {
-	avroSchema := `{"type":"record","namespace":"com.example.person","name":"Schema","fields":[{"name":"field","type":"string"}]}`
+	avroSchema := `{
+		"type":"record",
+		"namespace":"com.example.person",
+		"name":"Schema",
+		"fields":[{"name":"field","type":"string"}]}`
 	subject, err := GetSubjectName(avroSchema, "test-topic", Value, RecordNameStrategy)
 	assert.Nil(t, err)
 	assert.Equal(t, "com.example.person.Schema", subject)

--- a/serde.go
+++ b/serde.go
@@ -7,8 +7,11 @@ import (
 )
 
 type (
-	Serializer   func(configuration Configuration, topic string, data interface{}, element Element, schema string, version int) ([]byte, *Xk6KafkaError)
-	Deserializer func(configuration Configuration, topic string, data []byte, element Element, schema string, version int) (interface{}, *Xk6KafkaError)
+	Serializer func(
+		configuration Configuration, topic string, data interface{},
+		element Element, schema string, version int) ([]byte, *Xk6KafkaError)
+	Deserializer func(configuration Configuration, topic string, data []byte,
+		element Element, schema string, version int) (interface{}, *Xk6KafkaError)
 )
 
 const (
@@ -23,7 +26,8 @@ func useSerializer(configuration Configuration, element Element) bool {
 		return false
 	}
 
-	if (element == Key && configuration.Producer.KeySerializer != "") || (element == Value && configuration.Producer.ValueSerializer != "") {
+	if (element == Key && configuration.Producer.KeySerializer != "") ||
+		(element == Value && configuration.Producer.ValueSerializer != "") {
 		return true
 	}
 
@@ -36,7 +40,8 @@ func useDeserializer(configuration Configuration, element Element) bool {
 		return false
 	}
 
-	if (element == Key && configuration.Consumer.KeyDeserializer != "") || (element == Value && configuration.Consumer.ValueDeserializer != "") {
+	if (element == Key && configuration.Consumer.KeyDeserializer != "") ||
+		(element == Value && configuration.Consumer.ValueDeserializer != "") {
 		return true
 	}
 
@@ -51,7 +56,8 @@ type SerdeType[T Serializer | Deserializer] struct {
 }
 
 // NewSerdes constructs a new SerdeType.
-func NewSerdes[T Serializer | Deserializer](function T, class string, schemaType srclient.SchemaType, wireFormatted bool) *SerdeType[T] {
+func NewSerdes[T Serializer | Deserializer](
+	function T, class string, schemaType srclient.SchemaType, wireFormatted bool) *SerdeType[T] {
 	return &SerdeType[T]{function, class, schemaType, wireFormatted}
 }
 

--- a/serde_registry_test.go
+++ b/serde_registry_test.go
@@ -20,10 +20,12 @@ func TestSerdesRegistry(t *testing.T) {
 
 	assert.Equal(t, 5, len(serializersRegistry.Registry))
 	assert.Equal(t, String, serializersRegistry.Registry[StringSerializer].GetSchemaType())
-	assert.Equal(t, "github.com/mostafa/xk6-kafka.SerializeString", getFuncName(serializersRegistry.Registry[StringSerializer].GetSerializer()))
+	assert.Equal(t, "github.com/mostafa/xk6-kafka.SerializeString",
+		getFuncName(serializersRegistry.Registry[StringSerializer].GetSerializer()))
 	assert.False(t, serializersRegistry.Registry[StringSerializer].IsWireFormatted())
 
 	assert.Equal(t, 5, len(deserializersRegistry.Registry))
-	assert.Equal(t, "github.com/mostafa/xk6-kafka.DeserializeString", getFuncName(deserializersRegistry.Registry[StringDeserializer].GetDeserializer()))
+	assert.Equal(t, "github.com/mostafa/xk6-kafka.DeserializeString",
+		getFuncName(deserializersRegistry.Registry[StringDeserializer].GetDeserializer()))
 	assert.False(t, deserializersRegistry.Registry[StringDeserializer].IsWireFormatted())
 }

--- a/serde_test.go
+++ b/serde_test.go
@@ -36,9 +36,12 @@ func TestUseSerializerDeserializerFails(t *testing.T) {
 		{config: Configuration{Consumer: ConsumerConfiguration{}}, element: Key, result: false},
 		{config: Configuration{Consumer: ConsumerConfiguration{}}, element: Value, result: false},
 		{config: Configuration{SchemaRegistry: SchemaRegistryConfiguration{}}, element: Key, result: false},
-		{config: Configuration{SchemaRegistry: SchemaRegistryConfiguration{}}, element: Value, result: false},
-		{config: Configuration{Producer: ProducerConfiguration{ValueSerializer: "unknown codec"}}, element: Key, result: false},
-		{config: Configuration{Producer: ProducerConfiguration{KeySerializer: "unknown codec"}}, element: Value, result: false},
+		{config: Configuration{SchemaRegistry: SchemaRegistryConfiguration{}}, element: Value,
+			result: false},
+		{config: Configuration{Producer: ProducerConfiguration{ValueSerializer: "unknown codec"}},
+			element: Key, result: false},
+		{config: Configuration{Producer: ProducerConfiguration{KeySerializer: "unknown codec"}},
+			element: Value, result: false},
 	}
 
 	for _, param := range params {

--- a/stats.go
+++ b/stats.go
@@ -95,11 +95,13 @@ func registerMetrics(vu modules.VU) (kafkaMetrics, error) {
 		return m, err
 	}
 
-	if m.ReaderFetchSize, err = registry.NewMetric("kafka.reader.fetch.size", metrics.Counter); err != nil {
+	if m.ReaderFetchSize, err = registry.NewMetric(
+		"kafka.reader.fetch.size", metrics.Counter); err != nil {
 		return m, err
 	}
 
-	if m.ReaderFetchBytes, err = registry.NewMetric("kafka.reader.fetch.bytes", metrics.Counter, metrics.Data); err != nil {
+	if m.ReaderFetchBytes, err = registry.NewMetric(
+		"kafka.reader.fetch.bytes", metrics.Counter, metrics.Data); err != nil {
 		return m, err
 	}
 
@@ -159,35 +161,43 @@ func registerMetrics(vu modules.VU) (kafkaMetrics, error) {
 		return m, err
 	}
 
-	if m.WriterBatchSize, err = registry.NewMetric("kafka.writer.batch.size", metrics.Counter); err != nil {
+	if m.WriterBatchSize, err = registry.NewMetric(
+		"kafka.writer.batch.size", metrics.Counter); err != nil {
 		return m, err
 	}
 
-	if m.WriterBatchBytes, err = registry.NewMetric("kafka.writer.batch.bytes", metrics.Counter, metrics.Data); err != nil {
+	if m.WriterBatchBytes, err = registry.NewMetric(
+		"kafka.writer.batch.bytes", metrics.Counter, metrics.Data); err != nil {
 		return m, err
 	}
 
-	if m.WriterMaxAttempts, err = registry.NewMetric("kafka.writer.attempts.max", metrics.Gauge); err != nil {
+	if m.WriterMaxAttempts, err = registry.NewMetric(
+		"kafka.writer.attempts.max", metrics.Gauge); err != nil {
 		return m, err
 	}
 
-	if m.WriterMaxBatchSize, err = registry.NewMetric("kafka.writer.batch.max", metrics.Gauge); err != nil {
+	if m.WriterMaxBatchSize, err = registry.NewMetric(
+		"kafka.writer.batch.max", metrics.Gauge); err != nil {
 		return m, err
 	}
 
-	if m.WriterBatchTimeout, err = registry.NewMetric("kafka.writer.batch.timeout", metrics.Gauge, metrics.Time); err != nil {
+	if m.WriterBatchTimeout, err = registry.NewMetric(
+		"kafka.writer.batch.timeout", metrics.Gauge, metrics.Time); err != nil {
 		return m, err
 	}
 
-	if m.WriterReadTimeout, err = registry.NewMetric("kafka.writer.read.timeout", metrics.Gauge, metrics.Time); err != nil {
+	if m.WriterReadTimeout, err = registry.NewMetric(
+		"kafka.writer.read.timeout", metrics.Gauge, metrics.Time); err != nil {
 		return m, err
 	}
 
-	if m.WriterWriteTimeout, err = registry.NewMetric("kafka.writer.write.timeout", metrics.Gauge, metrics.Time); err != nil {
+	if m.WriterWriteTimeout, err = registry.NewMetric(
+		"kafka.writer.write.timeout", metrics.Gauge, metrics.Time); err != nil {
 		return m, err
 	}
 
-	if m.WriterRequiredAcks, err = registry.NewMetric("kafka.writer.acks.required", metrics.Gauge); err != nil {
+	if m.WriterRequiredAcks, err = registry.NewMetric(
+		"kafka.writer.acks.required", metrics.Gauge); err != nil {
 		return m, err
 	}
 

--- a/string.go
+++ b/string.go
@@ -14,7 +14,9 @@ const (
 )
 
 // SerializeString serializes a string to bytes.
-func SerializeString(configuration Configuration, topic string, data interface{}, element Element, schema string, version int) ([]byte, *Xk6KafkaError) {
+func SerializeString(
+	configuration Configuration, topic string, data interface{},
+	element Element, schema string, version int) ([]byte, *Xk6KafkaError) {
 	switch data := data.(type) {
 	case string:
 		return []byte(data), nil
@@ -27,6 +29,8 @@ func SerializeString(configuration Configuration, topic string, data interface{}
 }
 
 // DeserializeString deserializes a string from bytes.
-func DeserializeString(configuration Configuration, topic string, data []byte, element Element, schema string, version int) (interface{}, *Xk6KafkaError) {
+func DeserializeString(
+	configuration Configuration, topic string, data []byte,
+	element Element, schema string, version int) (interface{}, *Xk6KafkaError) {
 	return string(data), nil
 }

--- a/string_test.go
+++ b/string_test.go
@@ -19,7 +19,8 @@ func TestSerializeStringFails(t *testing.T) {
 	originalData := 123
 	_, err := SerializeString(Configuration{}, "", originalData, "", "", 0)
 	assert.EqualErrorf(
-		t, err, "Invalid data type provided for string serializer (requires string), OriginalError: %!w(*errors.errorString=&{Expected: string, got: int})",
+		t, err, "Invalid data type provided for string serializer (requires string), "+
+			"OriginalError: %!w(*errors.errorString=&{Expected: string, got: int})",
 		"Expected error message is correct")
 }
 

--- a/topic_test.go
+++ b/topic_test.go
@@ -20,7 +20,8 @@ func TestGetKafkaControllerConnection(t *testing.T) {
 	})
 }
 
-// TestGetKafkaControllerConnectionFails tests whether a connection can be established to a kafka broker and fails if the given broker is not reachable.
+// TestGetKafkaControllerConnectionFails tests whether a connection can be established
+// to a kafka broker and fails if the given broker is not reachable.
 func TestGetKafkaControllerConnectionFails(t *testing.T) {
 	test := GetTestModuleInstance(t)
 


### PR DESCRIPTION
Addresses:
- #109 (No. 10)

Command:
```bash
golangci-lint run --disable-all -E lll
```