### PR TITLE
Fix maligned errors

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -30,32 +30,32 @@ var (
 )
 
 type ReaderConfig struct {
-	Brokers                []string      `json:"brokers"`
-	GroupID                string        `json:"groupID"`
-	GroupTopics            []string      `json:"groupTopics"`
-	Topic                  string        `json:"topic"`
+	WatchPartitionChanges  bool          `json:"watchPartitionChanges"`
+	ConnectLogger          bool          `json:"connectLogger"`
 	Partition              int           `json:"partition"`
 	QueueCapacity          int           `json:"queueCapacity"`
 	MinBytes               int           `json:"minBytes"`
 	MaxBytes               int           `json:"maxBytes"`
+	MaxAttempts            int           `json:"maxAttempts"`
+	GroupID                string        `json:"groupID"`
+	Topic                  string        `json:"topic"`
+	IsolationLevel         string        `json:"isolationLevel"`
+	StartOffset            int64         `json:"startOffset"`
+	Offset                 int64         `json:"offset"`
+	Brokers                []string      `json:"brokers"`
+	GroupTopics            []string      `json:"groupTopics"`
+	GroupBalancers         []string      `json:"groupBalancers"`
 	MaxWait                time.Duration `json:"maxWait"`
 	ReadLagInterval        time.Duration `json:"readLagInterval"`
-	GroupBalancers         []string      `json:"groupBalancers"`
 	HeartbeatInterval      time.Duration `json:"heartbeatInterval"`
 	CommitInterval         time.Duration `json:"commitInterval"`
 	PartitionWatchInterval time.Duration `json:"partitionWatchInterval"`
-	WatchPartitionChanges  bool          `json:"watchPartitionChanges"`
 	SessionTimeout         time.Duration `json:"sessionTimeout"`
 	RebalanceTimeout       time.Duration `json:"rebalanceTimeout"`
 	JoinGroupBackoff       time.Duration `json:"joinGroupBackoff"`
 	RetentionTime          time.Duration `json:"retentionTime"`
-	StartOffset            int64         `json:"startOffset"`
 	ReadBackoffMin         time.Duration `json:"readBackoffMin"`
 	ReadBackoffMax         time.Duration `json:"readBackoffMax"`
-	ConnectLogger          bool          `json:"connectLogger"`
-	MaxAttempts            int           `json:"maxAttempts"`
-	IsolationLevel         string        `json:"isolationLevel"`
-	Offset                 int64         `json:"offset"`
 	SASL                   SASLConfig    `json:"sasl"`
 	TLS                    TLSConfig     `json:"tls"`
 }

--- a/producer.go
+++ b/producer.go
@@ -49,21 +49,21 @@ func freeze(o *goja.Object) {
 }
 
 type WriterConfig struct {
-	Brokers         []string      `json:"brokers"`
-	Topic           string        `json:"topic"`
 	AutoCreateTopic bool          `json:"autoCreateTopic"`
-	Balancer        string        `json:"balancer"`
+	ConnectLogger   bool          `json:"connectLogger"`
 	MaxAttempts     int           `json:"maxAttempts"`
 	BatchSize       int           `json:"batchSize"`
 	BatchBytes      int           `json:"batchBytes"`
+	RequiredAcks    int           `json:"requiredAcks"`
+	Topic           string        `json:"topic"`
+	Balancer        string        `json:"balancer"`
+	Compression     string        `json:"compression"`
+	Brokers         []string      `json:"brokers"`
 	BatchTimeout    time.Duration `json:"batchTimeout"`
 	ReadTimeout     time.Duration `json:"readTimeout"`
 	WriteTimeout    time.Duration `json:"writeTimeout"`
-	RequiredAcks    int           `json:"requiredAcks"`
-	Compression     string        `json:"compression"`
 	SASL            SASLConfig    `json:"sasl"`
 	TLS             TLSConfig     `json:"tls"`
-	ConnectLogger   bool          `json:"connectLogger"`
 }
 
 type Message struct {


### PR DESCRIPTION
Addresses:
- #109 (No. 11)

Command:
```bash
golangci-lint run --disable-all -E maligned
```

Reference:
[Memory Layouts](https://go101.org/article/memory-layout.html)