### PR TITLE
Fix `if` statement complexity errors by uwrapping the `if` statements

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"time"
 
@@ -72,14 +73,16 @@ type ConsumeConfig struct {
 func (k *Kafka) XReader(call goja.ConstructorCall) *goja.Object {
 	rt := k.vu.Runtime()
 	var readerConfig *ReaderConfig
-	if len(call.Arguments) > 0 {
-		if params, ok := call.Argument(0).Export().(map[string]interface{}); ok {
-			if b, err := json.Marshal(params); err != nil {
+	if len(call.Arguments) <= 0 {
+		common.Throw(rt, errors.New("new Reader() requires at least one argument"))
+	}
+
+	if params, ok := call.Argument(0).Export().(map[string]interface{}); ok {
+		if b, err := json.Marshal(params); err != nil {
+			common.Throw(rt, err)
+		} else {
+			if err = json.Unmarshal(b, &readerConfig); err != nil {
 				common.Throw(rt, err)
-			} else {
-				if err = json.Unmarshal(b, &readerConfig); err != nil {
-					common.Throw(rt, err)
-				}
 			}
 		}
 	}
@@ -94,14 +97,16 @@ func (k *Kafka) XReader(call goja.ConstructorCall) *goja.Object {
 
 	err := readerObject.Set("consume", func(call goja.FunctionCall) goja.Value {
 		var consumeConfig *ConsumeConfig
-		if len(call.Arguments) > 0 {
-			if params, ok := call.Argument(0).Export().(map[string]interface{}); ok {
-				if b, err := json.Marshal(params); err != nil {
+		if len(call.Arguments) <= 0 {
+			common.Throw(rt, errors.New("consume() requires at least one argument"))
+		}
+
+		if params, ok := call.Argument(0).Export().(map[string]interface{}); ok {
+			if b, err := json.Marshal(params); err != nil {
+				common.Throw(rt, err)
+			} else {
+				if err = json.Unmarshal(b, &consumeConfig); err != nil {
 					common.Throw(rt, err)
-				} else {
-					if err = json.Unmarshal(b, &consumeConfig); err != nil {
-						common.Throw(rt, err)
-					}
 				}
 			}
 		}

--- a/producer.go
+++ b/producer.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"time"
 
@@ -95,13 +96,15 @@ func (k *Kafka) XWriter(call goja.ConstructorCall) *goja.Object {
 	rt := k.vu.Runtime()
 	var writerConfig *WriterConfig
 	if len(call.Arguments) > 0 {
-		if params, ok := call.Argument(0).Export().(map[string]interface{}); ok {
-			if b, err := json.Marshal(params); err != nil {
+		common.Throw(rt, errors.New("new Writer() requires at least one argument"))
+	}
+
+	if params, ok := call.Argument(0).Export().(map[string]interface{}); ok {
+		if b, err := json.Marshal(params); err != nil {
+			common.Throw(rt, err)
+		} else {
+			if err = json.Unmarshal(b, &writerConfig); err != nil {
 				common.Throw(rt, err)
-			} else {
-				if err = json.Unmarshal(b, &writerConfig); err != nil {
-					common.Throw(rt, err)
-				}
 			}
 		}
 	}
@@ -117,15 +120,17 @@ func (k *Kafka) XWriter(call goja.ConstructorCall) *goja.Object {
 	err := writerObject.Set("produce", func(call goja.FunctionCall) goja.Value {
 		var producerConfig *ProduceConfig
 		if len(call.Arguments) > 0 {
-			if params, ok := call.Argument(0).Export().(map[string]interface{}); ok {
-				b, err := json.Marshal(params)
-				if err != nil {
-					common.Throw(rt, err)
-				}
-				err = json.Unmarshal(b, &producerConfig)
-				if err != nil {
-					common.Throw(rt, err)
-				}
+			common.Throw(rt, errors.New("produce() requires at least one argument"))
+		}
+
+		if params, ok := call.Argument(0).Export().(map[string]interface{}); ok {
+			b, err := json.Marshal(params)
+			if err != nil {
+				common.Throw(rt, err)
+			}
+			err = json.Unmarshal(b, &producerConfig)
+			if err != nil {
+				common.Throw(rt, err)
 			}
 		}
 

--- a/producer.go
+++ b/producer.go
@@ -95,7 +95,7 @@ type ProduceConfig struct {
 func (k *Kafka) XWriter(call goja.ConstructorCall) *goja.Object {
 	rt := k.vu.Runtime()
 	var writerConfig *WriterConfig
-	if len(call.Arguments) > 0 {
+	if len(call.Arguments) <= 0 {
 		common.Throw(rt, errors.New("new Writer() requires at least one argument"))
 	}
 
@@ -119,7 +119,7 @@ func (k *Kafka) XWriter(call goja.ConstructorCall) *goja.Object {
 
 	err := writerObject.Set("produce", func(call goja.FunctionCall) goja.Value {
 		var producerConfig *ProduceConfig
-		if len(call.Arguments) > 0 {
+		if len(call.Arguments) <= 0 {
 			common.Throw(rt, errors.New("produce() requires at least one argument"))
 		}
 

--- a/topic.go
+++ b/topic.go
@@ -24,7 +24,7 @@ type ConnectionConfig struct {
 func (k *Kafka) XConnection(call goja.ConstructorCall) *goja.Object {
 	rt := k.vu.Runtime()
 	var connectionConfig *ConnectionConfig
-	if len(call.Arguments) > 0 {
+	if len(call.Arguments) <= 0 {
 		common.Throw(rt, errors.New("new Connection() requires at least one argument"))
 	}
 
@@ -48,7 +48,7 @@ func (k *Kafka) XConnection(call goja.ConstructorCall) *goja.Object {
 
 	err := connectionObject.Set("createTopic", func(call goja.FunctionCall) goja.Value {
 		var topicConfig *kafkago.TopicConfig
-		if len(call.Arguments) > 0 {
+		if len(call.Arguments) <= 0 {
 			common.Throw(rt, errors.New("createTopic() requires at least one argument"))
 		}
 

--- a/topic.go
+++ b/topic.go
@@ -2,6 +2,7 @@ package kafka
 
 import (
 	"encoding/json"
+	"errors"
 	"net"
 	"strconv"
 
@@ -24,13 +25,15 @@ func (k *Kafka) XConnection(call goja.ConstructorCall) *goja.Object {
 	rt := k.vu.Runtime()
 	var connectionConfig *ConnectionConfig
 	if len(call.Arguments) > 0 {
-		if params, ok := call.Argument(0).Export().(map[string]interface{}); ok {
-			if b, err := json.Marshal(params); err != nil {
+		common.Throw(rt, errors.New("new Connection() requires at least one argument"))
+	}
+
+	if params, ok := call.Argument(0).Export().(map[string]interface{}); ok {
+		if b, err := json.Marshal(params); err != nil {
+			common.Throw(rt, err)
+		} else {
+			if err = json.Unmarshal(b, &connectionConfig); err != nil {
 				common.Throw(rt, err)
-			} else {
-				if err = json.Unmarshal(b, &connectionConfig); err != nil {
-					common.Throw(rt, err)
-				}
 			}
 		}
 	}
@@ -46,13 +49,15 @@ func (k *Kafka) XConnection(call goja.ConstructorCall) *goja.Object {
 	err := connectionObject.Set("createTopic", func(call goja.FunctionCall) goja.Value {
 		var topicConfig *kafkago.TopicConfig
 		if len(call.Arguments) > 0 {
-			if params, ok := call.Argument(0).Export().(map[string]interface{}); ok {
-				if b, err := json.Marshal(params); err != nil {
+			common.Throw(rt, errors.New("createTopic() requires at least one argument"))
+		}
+
+		if params, ok := call.Argument(0).Export().(map[string]interface{}); ok {
+			if b, err := json.Marshal(params); err != nil {
+				common.Throw(rt, err)
+			} else {
+				if err = json.Unmarshal(b, &topicConfig); err != nil {
 					common.Throw(rt, err)
-				} else {
-					if err = json.Unmarshal(b, &topicConfig); err != nil {
-						common.Throw(rt, err)
-					}
 				}
 			}
 		}


### PR DESCRIPTION
Addresses:
- #109 (No. 12)

Command:
```bash
golangci-lint run --disable-all -E nestif
golangci-lint run --disable-all -E revive
golangci-lint run --disable-all -E wsl
```