### PR TITLE
Use static error messages to fix err133 linter errors

### DIFF
--- a/auth_test.go
+++ b/auth_test.go
@@ -1,7 +1,6 @@
 package kafka
 
 import (
-	"errors"
 	"os"
 	"testing"
 	"time"
@@ -189,7 +188,7 @@ func TestTlsConfigFails(t *testing.T) {
 				Code: failedLoadX509KeyPair,
 				Message: "Error creating x509 key pair from \"fixtures/invalid-client.cer\" " +
 					"and \"fixtures/invalid-client.pem\".",
-				OriginalError: errors.New("tls: failed to find any PEM data in certificate input"),
+				OriginalError: ErrorInvalidPEMData,
 			},
 		},
 		{

--- a/bytearray.go
+++ b/bytearray.go
@@ -1,8 +1,6 @@
 package kafka
 
 import (
-	"fmt"
-
 	"github.com/riferrei/srclient"
 )
 
@@ -31,10 +29,7 @@ func SerializeByteArray(
 		}
 		return arr, nil
 	default:
-		return nil, NewXk6KafkaError(
-			invalidDataType,
-			"Invalid data type provided for byte array serializer (requires []byte)",
-			fmt.Errorf("Expected: []byte, got: %T", data))
+		return nil, ErrorInvalidDataType
 	}
 }
 

--- a/bytearray_test.go
+++ b/bytearray_test.go
@@ -24,7 +24,7 @@ func TestSerializeByteArray(t *testing.T) {
 func TestSerializeByteArrayFails(t *testing.T) {
 	_, err := SerializeByteArray(Configuration{}, "", originalData, "", "", 0)
 	assert.NotNil(t, err)
-	assert.Equal(t, err.Message, "Invalid data type provided for byte array serializer (requires []byte)")
+	assert.Equal(t, err.Message, "Invalid data type provided for serializer/deserializer")
 	assert.Equal(t, err.Code, invalidDataType)
 }
 

--- a/consumer.go
+++ b/consumer.go
@@ -3,7 +3,6 @@ package kafka
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"time"
 
@@ -74,7 +73,7 @@ func (k *Kafka) XReader(call goja.ConstructorCall) *goja.Object {
 	rt := k.vu.Runtime()
 	var readerConfig *ReaderConfig
 	if len(call.Arguments) <= 0 {
-		common.Throw(rt, errors.New("new Reader() requires at least one argument"))
+		common.Throw(rt, ErrorNotEnoughArguments)
 	}
 
 	if params, ok := call.Argument(0).Export().(map[string]interface{}); ok {
@@ -98,7 +97,7 @@ func (k *Kafka) XReader(call goja.ConstructorCall) *goja.Object {
 	err := readerObject.Set("consume", func(call goja.FunctionCall) goja.Value {
 		var consumeConfig *ConsumeConfig
 		if len(call.Arguments) <= 0 {
-			common.Throw(rt, errors.New("consume() requires at least one argument"))
+			common.Throw(rt, ErrorNotEnoughArguments)
 		}
 
 		if params, ok := call.Argument(0).Export().(map[string]interface{}); ok {

--- a/error_codes.go
+++ b/error_codes.go
@@ -1,6 +1,9 @@
 package kafka
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 type errCode uint32
 
@@ -57,11 +60,24 @@ const (
 	failedReadPartitions errCode = 7003
 )
 
-// ErrorForbiddenInInitContext is used when a Kafka producer was used in the init context.
-var ErrorForbiddenInInitContext = NewXk6KafkaError(
-	kafkaForbiddenInInitContext,
-	"Producing Kafka messages in the init context is not supported",
-	nil)
+var (
+	// ErrorForbiddenInInitContext is used when a Kafka producer was used in the init context.
+	ErrorForbiddenInInitContext = NewXk6KafkaError(
+		kafkaForbiddenInInitContext,
+		"Producing Kafka messages in the init context is not supported",
+		nil)
+
+	// ErrorInvalidDataType is used when a data type is not supported.
+	ErrorInvalidDataType = NewXk6KafkaError(
+		invalidDataType,
+		"Invalid data type provided for serializer/deserializer",
+		nil)
+
+	// ErrorNotEnoughArguments is used when a function is called with too few arguments.
+	ErrorNotEnoughArguments = errors.New("Not enough arguments. It requires at least one argument.")
+
+	ErrorInvalidPEMData = errors.New("tls: failed to find any PEM data in certificate input")
+)
 
 type Xk6KafkaError struct {
 	Code          errCode

--- a/producer.go
+++ b/producer.go
@@ -96,7 +96,7 @@ func (k *Kafka) XWriter(call goja.ConstructorCall) *goja.Object {
 	rt := k.vu.Runtime()
 	var writerConfig *WriterConfig
 	if len(call.Arguments) <= 0 {
-		common.Throw(rt, errors.New("new Writer() requires at least one argument"))
+		common.Throw(rt, ErrorNotEnoughArguments)
 	}
 
 	if params, ok := call.Argument(0).Export().(map[string]interface{}); ok {
@@ -120,7 +120,7 @@ func (k *Kafka) XWriter(call goja.ConstructorCall) *goja.Object {
 	err := writerObject.Set("produce", func(call goja.FunctionCall) goja.Value {
 		var producerConfig *ProduceConfig
 		if len(call.Arguments) <= 0 {
-			common.Throw(rt, errors.New("produce() requires at least one argument"))
+			common.Throw(rt, ErrorNotEnoughArguments)
 		}
 
 		if params, ok := call.Argument(0).Export().(map[string]interface{}); ok {
@@ -297,7 +297,7 @@ func (k *Kafka) produce(writer *kafkago.Writer, produceConfig *ProduceConfig) {
 	k.reportWriterStats(writer.Stats())
 
 	if originalErr != nil {
-		if originalErr == k.vu.Context().Err() {
+		if errors.Is(originalErr, k.vu.Context().Err()) {
 			logger.WithField("error", k.vu.Context().Err()).Error(k.vu.Context().Err())
 			common.Throw(k.vu.Runtime(),
 				NewXk6KafkaError(contextCancelled, "Context cancelled.", originalErr))

--- a/string.go
+++ b/string.go
@@ -1,8 +1,6 @@
 package kafka
 
 import (
-	"fmt"
-
 	"github.com/riferrei/srclient"
 )
 
@@ -21,10 +19,7 @@ func SerializeString(
 	case string:
 		return []byte(data), nil
 	default:
-		return nil, NewXk6KafkaError(
-			invalidDataType,
-			"Invalid data type provided for string serializer (requires string)",
-			fmt.Errorf("Expected: string, got: %T", data))
+		return nil, ErrorInvalidDataType
 	}
 }
 

--- a/string_test.go
+++ b/string_test.go
@@ -19,8 +19,7 @@ func TestSerializeStringFails(t *testing.T) {
 	originalData := 123
 	_, err := SerializeString(Configuration{}, "", originalData, "", "", 0)
 	assert.EqualErrorf(
-		t, err, "Invalid data type provided for string serializer (requires string), "+
-			"OriginalError: %!w(*errors.errorString=&{Expected: string, got: int})",
+		t, err, "Invalid data type provided for serializer/deserializer",
 		"Expected error message is correct")
 }
 

--- a/topic.go
+++ b/topic.go
@@ -2,7 +2,6 @@ package kafka
 
 import (
 	"encoding/json"
-	"errors"
 	"net"
 	"strconv"
 
@@ -25,7 +24,7 @@ func (k *Kafka) XConnection(call goja.ConstructorCall) *goja.Object {
 	rt := k.vu.Runtime()
 	var connectionConfig *ConnectionConfig
 	if len(call.Arguments) <= 0 {
-		common.Throw(rt, errors.New("new Connection() requires at least one argument"))
+		common.Throw(rt, ErrorNotEnoughArguments)
 	}
 
 	if params, ok := call.Argument(0).Export().(map[string]interface{}); ok {
@@ -49,7 +48,7 @@ func (k *Kafka) XConnection(call goja.ConstructorCall) *goja.Object {
 	err := connectionObject.Set("createTopic", func(call goja.FunctionCall) goja.Value {
 		var topicConfig *kafkago.TopicConfig
 		if len(call.Arguments) <= 0 {
-			common.Throw(rt, errors.New("createTopic() requires at least one argument"))
+			common.Throw(rt, ErrorNotEnoughArguments)
 		}
 
 		if params, ok := call.Argument(0).Export().(map[string]interface{}); ok {
@@ -72,7 +71,7 @@ func (k *Kafka) XConnection(call goja.ConstructorCall) *goja.Object {
 	err = connectionObject.Set("deleteTopic", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) > 0 {
 			if topic, ok := call.Argument(0).Export().(string); !ok {
-				common.Throw(rt, errors.New("deleteTopic() requires a string argument"))
+				common.Throw(rt, ErrorNotEnoughArguments)
 			} else {
 				k.DeleteTopic(connection, topic)
 			}


### PR DESCRIPTION
Addresses:
- #109 (No. 18)

Command:
```bash
golangci-lint run --disable-all -E goerr113
```