### PR TITLE
Fix length of the variable names

### DIFF
--- a/consumer.go
+++ b/consumer.go
@@ -76,67 +76,67 @@ type ConsumeConfig struct {
 // XReader is a wrapper around kafkago.Reader and acts as a JS constructor
 // for this extension, thus it must be called with new operator, e.g. new Reader(...).
 func (k *Kafka) XReader(call goja.ConstructorCall) *goja.Object {
-	rt := k.vu.Runtime()
+	runtime := k.vu.Runtime()
 	var readerConfig *ReaderConfig
 	if len(call.Arguments) <= 0 {
-		common.Throw(rt, ErrorNotEnoughArguments)
+		common.Throw(runtime, ErrorNotEnoughArguments)
 	}
 
 	if params, ok := call.Argument(0).Export().(map[string]interface{}); ok {
 		if b, err := json.Marshal(params); err != nil {
-			common.Throw(rt, err)
+			common.Throw(runtime, err)
 		} else {
 			if err = json.Unmarshal(b, &readerConfig); err != nil {
-				common.Throw(rt, err)
+				common.Throw(runtime, err)
 			}
 		}
 	}
 
 	reader := k.reader(readerConfig)
 
-	readerObject := rt.NewObject()
+	readerObject := runtime.NewObject()
 	// This is the reader object itself
 	if err := readerObject.Set("This", reader); err != nil {
-		common.Throw(rt, err)
+		common.Throw(runtime, err)
 	}
 
 	err := readerObject.Set("consume", func(call goja.FunctionCall) goja.Value {
 		var consumeConfig *ConsumeConfig
 		if len(call.Arguments) <= 0 {
-			common.Throw(rt, ErrorNotEnoughArguments)
+			common.Throw(runtime, ErrorNotEnoughArguments)
 		}
 
 		if params, ok := call.Argument(0).Export().(map[string]interface{}); ok {
 			if b, err := json.Marshal(params); err != nil {
-				common.Throw(rt, err)
+				common.Throw(runtime, err)
 			} else {
 				if err = json.Unmarshal(b, &consumeConfig); err != nil {
-					common.Throw(rt, err)
+					common.Throw(runtime, err)
 				}
 			}
 		}
 
-		return rt.ToValue(k.consume(reader, consumeConfig))
+		return runtime.ToValue(k.consume(reader, consumeConfig))
 	})
 	if err != nil {
-		common.Throw(rt, err)
+		common.Throw(runtime, err)
 	}
 
 	// This is unnecessary, but it's here for reference purposes
 	err = readerObject.Set("close", func(call goja.FunctionCall) goja.Value {
 		if err := reader.Close(); err != nil {
-			common.Throw(rt, err)
+			common.Throw(runtime, err)
 		}
 
 		return goja.Undefined()
 	})
 	if err != nil {
-		common.Throw(rt, err)
+		common.Throw(runtime, err)
 	}
 
 	freeze(readerObject)
 
-	return rt.ToValue(readerObject).ToObject(rt)
+	return runtime.ToValue(readerObject).ToObject(runtime)
 }
 
 // reader creates a Kafka reader with the given configuration

--- a/kafka_helpers_test.go
+++ b/kafka_helpers_test.go
@@ -26,28 +26,28 @@ type kafkaTest struct {
 // nolint: golint
 func GetTestModuleInstance(tb testing.TB) *kafkaTest {
 	tb.Helper()
-	rt := goja.New()
-	rt.SetFieldNameMapper(common.FieldNameMapper{})
+	runtime := goja.New()
+	runtime.SetFieldNameMapper(common.FieldNameMapper{})
 
 	ctx, cancel := context.WithCancel(context.Background())
 	tb.Cleanup(cancel)
 
 	root := New()
 	mockVU := &modulestest.VU{
-		RuntimeField: rt,
+		RuntimeField: runtime,
 		InitEnvField: &common.InitEnvironment{
 			Registry: metrics.NewRegistry(),
 		},
 		CtxField: ctx,
 	}
-	mi, ok := root.NewModuleInstance(mockVU).(*Module)
+	moduleInstance, ok := root.NewModuleInstance(mockVU).(*Module)
 	require.True(tb, ok)
 
-	require.NoError(tb, rt.Set("kafka", mi.Exports().Default))
+	require.NoError(tb, runtime.Set("kafka", moduleInstance.Exports().Default))
 
 	return &kafkaTest{
-		rt:            rt,
-		module:        mi,
+		rt:            runtime,
+		module:        moduleInstance,
 		vu:            mockVU,
 		cancelContext: cancel,
 	}

--- a/stats.go
+++ b/stats.go
@@ -53,157 +53,182 @@ type kafkaMetrics struct {
 func registerMetrics(vu modules.VU) (kafkaMetrics, error) {
 	var err error
 	registry := vu.InitEnv().Registry
-	m := kafkaMetrics{}
+	kafkaMetrics := kafkaMetrics{}
 
-	if m.ReaderDials, err = registry.NewMetric("kafka.reader.dial.count", metrics.Counter); err != nil {
-		return m, err
+	if kafkaMetrics.ReaderDials, err = registry.NewMetric(
+		"kafka.reader.dial.count", metrics.Counter); err != nil {
+		return kafkaMetrics, err
 	}
 
-	if m.ReaderFetches, err = registry.NewMetric("kafka.reader.fetches.count", metrics.Counter); err != nil {
-		return m, err
+	if kafkaMetrics.ReaderFetches, err = registry.NewMetric(
+		"kafka.reader.fetches.count", metrics.Counter); err != nil {
+		return kafkaMetrics, err
 	}
 
-	if m.ReaderMessages, err = registry.NewMetric("kafka.reader.message.count", metrics.Counter); err != nil {
-		return m, err
+	if kafkaMetrics.ReaderMessages, err = registry.NewMetric(
+		"kafka.reader.message.count", metrics.Counter); err != nil {
+		return kafkaMetrics, err
 	}
 
-	if m.ReaderBytes, err = registry.NewMetric("kafka.reader.message.bytes", metrics.Counter, metrics.Data); err != nil {
-		return m, err
+	if kafkaMetrics.ReaderBytes, err = registry.NewMetric(
+		"kafka.reader.message.bytes", metrics.Counter, metrics.Data); err != nil {
+		return kafkaMetrics, err
 	}
 
-	if m.ReaderRebalances, err = registry.NewMetric("kafka.reader.rebalance.count", metrics.Counter); err != nil {
-		return m, err
+	if kafkaMetrics.ReaderRebalances, err = registry.NewMetric(
+		"kafka.reader.rebalance.count", metrics.Counter); err != nil {
+		return kafkaMetrics, err
 	}
 
-	if m.ReaderTimeouts, err = registry.NewMetric("kafka.reader.timeouts.count", metrics.Counter); err != nil {
-		return m, err
+	if kafkaMetrics.ReaderTimeouts, err = registry.NewMetric(
+		"kafka.reader.timeouts.count", metrics.Counter); err != nil {
+		return kafkaMetrics, err
 	}
 
-	if m.ReaderErrors, err = registry.NewMetric("kafka.reader.error.count", metrics.Counter); err != nil {
-		return m, err
+	if kafkaMetrics.ReaderErrors, err = registry.NewMetric(
+		"kafka.reader.error.count", metrics.Counter); err != nil {
+		return kafkaMetrics, err
 	}
 
-	if m.ReaderDialTime, err = registry.NewMetric("kafka.reader.dial.seconds", metrics.Trend, metrics.Time); err != nil {
-		return m, err
+	if kafkaMetrics.ReaderDialTime, err = registry.NewMetric(
+		"kafka.reader.dial.seconds", metrics.Trend, metrics.Time); err != nil {
+		return kafkaMetrics, err
 	}
 
-	if m.ReaderReadTime, err = registry.NewMetric("kafka.reader.read.seconds", metrics.Trend, metrics.Time); err != nil {
-		return m, err
+	if kafkaMetrics.ReaderReadTime, err = registry.NewMetric(
+		"kafka.reader.read.seconds", metrics.Trend, metrics.Time); err != nil {
+		return kafkaMetrics, err
 	}
 
-	if m.ReaderWaitTime, err = registry.NewMetric("kafka.reader.wait.seconds", metrics.Trend, metrics.Time); err != nil {
-		return m, err
+	if kafkaMetrics.ReaderWaitTime, err = registry.NewMetric(
+		"kafka.reader.wait.seconds", metrics.Trend, metrics.Time); err != nil {
+		return kafkaMetrics, err
 	}
 
-	if m.ReaderFetchSize, err = registry.NewMetric(
+	if kafkaMetrics.ReaderFetchSize, err = registry.NewMetric(
 		"kafka.reader.fetch.size", metrics.Counter); err != nil {
-		return m, err
+		return kafkaMetrics, err
 	}
 
-	if m.ReaderFetchBytes, err = registry.NewMetric(
+	if kafkaMetrics.ReaderFetchBytes, err = registry.NewMetric(
 		"kafka.reader.fetch.bytes", metrics.Counter, metrics.Data); err != nil {
-		return m, err
+		return kafkaMetrics, err
 	}
 
-	if m.ReaderOffset, err = registry.NewMetric("kafka.reader.offset", metrics.Gauge); err != nil {
-		return m, err
+	if kafkaMetrics.ReaderOffset, err = registry.NewMetric(
+		"kafka.reader.offset", metrics.Gauge); err != nil {
+		return kafkaMetrics, err
 	}
 
-	if m.ReaderLag, err = registry.NewMetric("kafka.reader.lag", metrics.Gauge); err != nil {
-		return m, err
+	if kafkaMetrics.ReaderLag, err = registry.NewMetric(
+		"kafka.reader.lag", metrics.Gauge); err != nil {
+		return kafkaMetrics, err
 	}
 
-	if m.ReaderMinBytes, err = registry.NewMetric("kafka.reader.fetch_bytes.min", metrics.Gauge); err != nil {
-		return m, err
+	if kafkaMetrics.ReaderMinBytes, err = registry.NewMetric(
+		"kafka.reader.fetch_bytes.min", metrics.Gauge); err != nil {
+		return kafkaMetrics, err
 	}
 
-	if m.ReaderMaxBytes, err = registry.NewMetric("kafka.reader.fetch_bytes.max", metrics.Gauge); err != nil {
-		return m, err
+	if kafkaMetrics.ReaderMaxBytes, err = registry.NewMetric(
+		"kafka.reader.fetch_bytes.max", metrics.Gauge); err != nil {
+		return kafkaMetrics, err
 	}
 
-	if m.ReaderMaxWait, err = registry.NewMetric("kafka.reader.fetch_wait.max", metrics.Gauge, metrics.Time); err != nil {
-		return m, err
+	if kafkaMetrics.ReaderMaxWait, err = registry.NewMetric(
+		"kafka.reader.fetch_wait.max", metrics.Gauge, metrics.Time); err != nil {
+		return kafkaMetrics, err
 	}
 
-	if m.ReaderQueueLength, err = registry.NewMetric("kafka.reader.queue.length", metrics.Gauge); err != nil {
-		return m, err
+	if kafkaMetrics.ReaderQueueLength, err = registry.NewMetric(
+		"kafka.reader.queue.length", metrics.Gauge); err != nil {
+		return kafkaMetrics, err
 	}
 
-	if m.ReaderQueueCapacity, err = registry.NewMetric("kafka.reader.queue.capacity", metrics.Gauge); err != nil {
-		return m, err
+	if kafkaMetrics.ReaderQueueCapacity, err = registry.NewMetric(
+		"kafka.reader.queue.capacity", metrics.Gauge); err != nil {
+		return kafkaMetrics, err
 	}
 
-	if m.WriterWrites, err = registry.NewMetric("kafka.writer.write.count", metrics.Counter); err != nil {
-		return m, err
+	if kafkaMetrics.WriterWrites, err = registry.NewMetric(
+		"kafka.writer.write.count", metrics.Counter); err != nil {
+		return kafkaMetrics, err
 	}
 
-	if m.WriterMessages, err = registry.NewMetric("kafka.writer.message.count", metrics.Counter); err != nil {
-		return m, err
+	if kafkaMetrics.WriterMessages, err = registry.NewMetric(
+		"kafka.writer.message.count", metrics.Counter); err != nil {
+		return kafkaMetrics, err
 	}
 
-	if m.WriterBytes, err = registry.NewMetric("kafka.writer.message.bytes", metrics.Counter, metrics.Data); err != nil {
-		return m, err
+	if kafkaMetrics.WriterBytes, err = registry.NewMetric(
+		"kafka.writer.message.bytes", metrics.Counter, metrics.Data); err != nil {
+		return kafkaMetrics, err
 	}
 
-	if m.WriterErrors, err = registry.NewMetric("kafka.writer.error.count", metrics.Counter); err != nil {
-		return m, err
+	if kafkaMetrics.WriterErrors, err = registry.NewMetric(
+		"kafka.writer.error.count", metrics.Counter); err != nil {
+		return kafkaMetrics, err
 	}
 
-	if m.WriterWriteTime, err = registry.NewMetric("kafka.writer.write.seconds", metrics.Trend, metrics.Time); err != nil {
-		return m, err
+	if kafkaMetrics.WriterWriteTime, err = registry.NewMetric(
+		"kafka.writer.write.seconds", metrics.Trend, metrics.Time); err != nil {
+		return kafkaMetrics, err
 	}
 
-	if m.WriterWaitTime, err = registry.NewMetric("kafka.writer.wait.seconds", metrics.Trend, metrics.Time); err != nil {
-		return m, err
+	if kafkaMetrics.WriterWaitTime, err = registry.NewMetric(
+		"kafka.writer.wait.seconds", metrics.Trend, metrics.Time); err != nil {
+		return kafkaMetrics, err
 	}
 
-	if m.WriterRetries, err = registry.NewMetric("kafka.writer.retries.count", metrics.Counter); err != nil {
-		return m, err
+	if kafkaMetrics.WriterRetries, err = registry.NewMetric(
+		"kafka.writer.retries.count", metrics.Counter); err != nil {
+		return kafkaMetrics, err
 	}
 
-	if m.WriterBatchSize, err = registry.NewMetric(
+	if kafkaMetrics.WriterBatchSize, err = registry.NewMetric(
 		"kafka.writer.batch.size", metrics.Counter); err != nil {
-		return m, err
+		return kafkaMetrics, err
 	}
 
-	if m.WriterBatchBytes, err = registry.NewMetric(
+	if kafkaMetrics.WriterBatchBytes, err = registry.NewMetric(
 		"kafka.writer.batch.bytes", metrics.Counter, metrics.Data); err != nil {
-		return m, err
+		return kafkaMetrics, err
 	}
 
-	if m.WriterMaxAttempts, err = registry.NewMetric(
+	if kafkaMetrics.WriterMaxAttempts, err = registry.NewMetric(
 		"kafka.writer.attempts.max", metrics.Gauge); err != nil {
-		return m, err
+		return kafkaMetrics, err
 	}
 
-	if m.WriterMaxBatchSize, err = registry.NewMetric(
+	if kafkaMetrics.WriterMaxBatchSize, err = registry.NewMetric(
 		"kafka.writer.batch.max", metrics.Gauge); err != nil {
-		return m, err
+		return kafkaMetrics, err
 	}
 
-	if m.WriterBatchTimeout, err = registry.NewMetric(
+	if kafkaMetrics.WriterBatchTimeout, err = registry.NewMetric(
 		"kafka.writer.batch.timeout", metrics.Gauge, metrics.Time); err != nil {
-		return m, err
+		return kafkaMetrics, err
 	}
 
-	if m.WriterReadTimeout, err = registry.NewMetric(
+	if kafkaMetrics.WriterReadTimeout, err = registry.NewMetric(
 		"kafka.writer.read.timeout", metrics.Gauge, metrics.Time); err != nil {
-		return m, err
+		return kafkaMetrics, err
 	}
 
-	if m.WriterWriteTimeout, err = registry.NewMetric(
+	if kafkaMetrics.WriterWriteTimeout, err = registry.NewMetric(
 		"kafka.writer.write.timeout", metrics.Gauge, metrics.Time); err != nil {
-		return m, err
+		return kafkaMetrics, err
 	}
 
-	if m.WriterRequiredAcks, err = registry.NewMetric(
+	if kafkaMetrics.WriterRequiredAcks, err = registry.NewMetric(
 		"kafka.writer.acks.required", metrics.Gauge); err != nil {
-		return m, err
+		return kafkaMetrics, err
 	}
 
-	if m.WriterAsync, err = registry.NewMetric("kafka.writer.async", metrics.Rate); err != nil {
-		return m, err
+	if kafkaMetrics.WriterAsync, err = registry.NewMetric(
+		"kafka.writer.async", metrics.Rate); err != nil {
+		return kafkaMetrics, err
 	}
 
-	return m, nil
+	return kafkaMetrics, nil
 }

--- a/topic.go
+++ b/topic.go
@@ -21,42 +21,42 @@ type ConnectionConfig struct {
 // e.g. new Connection(...).
 // nolint: funlen
 func (k *Kafka) XConnection(call goja.ConstructorCall) *goja.Object {
-	rt := k.vu.Runtime()
+	runtime := k.vu.Runtime()
 	var connectionConfig *ConnectionConfig
 	if len(call.Arguments) <= 0 {
-		common.Throw(rt, ErrorNotEnoughArguments)
+		common.Throw(runtime, ErrorNotEnoughArguments)
 	}
 
 	if params, ok := call.Argument(0).Export().(map[string]interface{}); ok {
 		if b, err := json.Marshal(params); err != nil {
-			common.Throw(rt, err)
+			common.Throw(runtime, err)
 		} else {
 			if err = json.Unmarshal(b, &connectionConfig); err != nil {
-				common.Throw(rt, err)
+				common.Throw(runtime, err)
 			}
 		}
 	}
 
 	connection := k.GetKafkaControllerConnection(connectionConfig)
 
-	connectionObject := rt.NewObject()
+	connectionObject := runtime.NewObject()
 	// This is the connection object itself
 	if err := connectionObject.Set("This", connection); err != nil {
-		common.Throw(rt, err)
+		common.Throw(runtime, err)
 	}
 
 	err := connectionObject.Set("createTopic", func(call goja.FunctionCall) goja.Value {
 		var topicConfig *kafkago.TopicConfig
 		if len(call.Arguments) <= 0 {
-			common.Throw(rt, ErrorNotEnoughArguments)
+			common.Throw(runtime, ErrorNotEnoughArguments)
 		}
 
 		if params, ok := call.Argument(0).Export().(map[string]interface{}); ok {
 			if b, err := json.Marshal(params); err != nil {
-				common.Throw(rt, err)
+				common.Throw(runtime, err)
 			} else {
 				if err = json.Unmarshal(b, &topicConfig); err != nil {
-					common.Throw(rt, err)
+					common.Throw(runtime, err)
 				}
 			}
 		}
@@ -65,13 +65,13 @@ func (k *Kafka) XConnection(call goja.ConstructorCall) *goja.Object {
 		return goja.Undefined()
 	})
 	if err != nil {
-		common.Throw(rt, err)
+		common.Throw(runtime, err)
 	}
 
 	err = connectionObject.Set("deleteTopic", func(call goja.FunctionCall) goja.Value {
 		if len(call.Arguments) > 0 {
 			if topic, ok := call.Argument(0).Export().(string); !ok {
-				common.Throw(rt, ErrorNotEnoughArguments)
+				common.Throw(runtime, ErrorNotEnoughArguments)
 			} else {
 				k.DeleteTopic(connection, topic)
 			}
@@ -80,26 +80,26 @@ func (k *Kafka) XConnection(call goja.ConstructorCall) *goja.Object {
 		return goja.Undefined()
 	})
 	if err != nil {
-		common.Throw(rt, err)
+		common.Throw(runtime, err)
 	}
 
 	err = connectionObject.Set("listTopics", func(call goja.FunctionCall) goja.Value {
 		topics := k.ListTopics(connection)
-		return rt.ToValue(topics)
+		return runtime.ToValue(topics)
 	})
 	if err != nil {
-		common.Throw(rt, err)
+		common.Throw(runtime, err)
 	}
 
 	err = connectionObject.Set("close", func(call goja.FunctionCall) goja.Value {
 		if err := connection.Close(); err != nil {
-			common.Throw(rt, err)
+			common.Throw(runtime, err)
 		}
 
 		return goja.Undefined()
 	})
 	if err != nil {
-		common.Throw(rt, err)
+		common.Throw(runtime, err)
 	}
 
 	return connectionObject


### PR DESCRIPTION
Addresses:
- #109 (No. 27)

Command:
```bash
golangci-lint run --disable-all -E varnamelen
```