### PR TITLE
Update schema_registry.go

### DIFF
--- a/schema_registry.go
+++ b/schema_registry.go
@@ -103,9 +103,7 @@ func GetSchema(
 	var err error
 	// Default version of the schema is the latest version.
 
-	value, isMapContainsKey := cache[subject]
-
-	if isMapContainsKey {
+	if value, exists := cache[subject]; exists {
 		return value, nil
 	}
 

--- a/schema_registry.go
+++ b/schema_registry.go
@@ -115,9 +115,7 @@ func GetSchema(
 
 	if err == nil {
 		cache[subject] = schemaInfo
-	}
-
-	if err != nil {
+	} else {
 		return nil, NewXk6KafkaError(schemaNotFound,
 			"Failed to get schema from schema registry", err)
 	}


### PR DESCRIPTION
When calling to retrieve the schemaInfo the library github.com/riferrei/srclient v0.5.4  calls this code which calls to Rlock, creating a performance problem  in the library, the following code is a workaround to avoid calling to that cache always

// RLock locks rw for reading.
//
// It should not be used for recursive read locking; a blocked Lock
// call excludes new readers from acquiring the lock. See the
// documentation on the RWMutex type

````
func (client *SchemaRegistryClient) getVersion(subject string, version string) (*Schema, error) {

	if client.getCachingEnabled() {
		cacheKey := cacheKey(subject, version)
		client.subjectSchemaCacheLock.RLock()
		cachedResult := client.subjectSchemaCache[cacheKey]
		client.subjectSchemaCacheLock.RUnlock()
		if cachedResult != nil {
			return cachedResult, nil
		}
	}
````