### PR TITLE
Save files from JKS

### DIFF
--- a/error_codes.go
+++ b/error_codes.go
@@ -50,6 +50,9 @@ const (
 	failedDecodePrivateKey        errCode = 4008
 	failedDecodeServerCa          errCode = 4009
 	failedConfigureJKS            errCode = 4010
+	failedWriteCertFile           errCode = 4011
+	failedWriteKeyFile            errCode = 4012
+	failedWriteServerCaFile       errCode = 4013
 
 	// schema registry.
 	messageTooShort                     errCode = 5000

--- a/jks.go
+++ b/jks.go
@@ -69,11 +69,6 @@ func (*Kafka) loadJKS(jksConfig *JKSConfig) (*JKS, *Xk6KafkaError) {
 				fmt.Sprintf("Failed to decode client's private key: %s", jksConfig.Path), err)
 	}
 
-	clientCertsChain := make([]string, 0, len(clientKey.CertificateChain))
-	for _, cert := range clientKey.CertificateChain {
-		clientCertsChain = append(clientCertsChain, string(cert.Content))
-	}
-
 	clientKeyPemFilenames := make([]string, 0, len(clientKey.CertificateChain))
 	for idx, cert := range clientKey.CertificateChain {
 		filename := fmt.Sprintf("client-cert-%d.pem", idx)

--- a/scripts/test_tls_with_jks.js
+++ b/scripts/test_tls_with_jks.js
@@ -7,10 +7,13 @@
  * ⚠️ The PKCS#12 format is not supported.
  */
 
-import { LoadJKS, TLS_1_2 } from "k6/x/kafka";
+import { LoadJKS, TLS_1_2 } from "k6/x/kafka"
 
 // If server and client keystore are separate, then you must
 // call LoadJKS twice, once for each keystore.
+// This will load the certificates and keys from the keystore
+// and write them to the disk, so that they can be used in
+// the TLS configuration.
 const jks = LoadJKS({
   path: "fixtures/kafka-keystore.jks",
   password: "password",
@@ -18,20 +21,26 @@ const jks = LoadJKS({
   clientKeyAlias: "localhost",
   clientKeyPassword: "password",
   serverCaAlias: "caroot",
-});
+})
 const tlsConfig = {
   enableTls: true,
   insecureSkipTlsVerify: false,
   minVersion: TLS_1_2,
 
   // The certificates and keys can be loaded from a JKS keystore:
+  // clientCertsPem is an array of PEM-encoded certificates, and the filenames
+  // will be named "client-cert-0.pem", "client-cert-1.pem", etc.
+  // clientKeyPem is the PEM-encoded private key and the filename will be
+  // named "client-key.pem".
+  // serverCaPem is the PEM-encoded CA certificate and the filename will be
+  // named "server-ca.pem".
   clientCertPem: jks["clientCertsPem"][0], // The first certificate in the chain
   clientKeyPem: jks["clientKeyPem"],
   serverCaPem: jks["serverCaPem"],
-};
+}
 
 export default function () {
-  console.log(Object.keys(jks));
-  console.log(jks);
-  console.log(tlsConfig);
+  console.log(Object.keys(jks))
+  console.log(jks)
+  console.log(tlsConfig)
 }

--- a/scripts/test_tls_with_jks.js
+++ b/scripts/test_tls_with_jks.js
@@ -7,7 +7,7 @@
  * ⚠️ The PKCS#12 format is not supported.
  */
 
-import { LoadJKS, TLS_1_2 } from "k6/x/kafka"
+import { LoadJKS, TLS_1_2 } from "k6/x/kafka";
 
 // If server and client keystore are separate, then you must
 // call LoadJKS twice, once for each keystore.
@@ -21,7 +21,7 @@ const jks = LoadJKS({
   clientKeyAlias: "localhost",
   clientKeyPassword: "password",
   serverCaAlias: "caroot",
-})
+});
 const tlsConfig = {
   enableTls: true,
   insecureSkipTlsVerify: false,
@@ -37,10 +37,10 @@ const tlsConfig = {
   clientCertPem: jks["clientCertsPem"][0], // The first certificate in the chain
   clientKeyPem: jks["clientKeyPem"],
   serverCaPem: jks["serverCaPem"],
-}
+};
 
 export default function () {
-  console.log(Object.keys(jks))
-  console.log(jks)
-  console.log(tlsConfig)
+  console.log(Object.keys(jks));
+  console.log(jks);
+  console.log(tlsConfig);
 }


### PR DESCRIPTION
Previously the `LoadJKS` function would load the certificates and keys as a string. On the other hand, the `TLSConfig` only accepts filenames, which caused inconsistencies in using JKS with TLS.

In this PR, I added a feature to save the certificates and keys from the JKS keystore into separate files, and return the filenames as a result. Then these filenames can be passed to the TLSConfig as usual.

Closes #212.