### PR TITLE
Update jks.go

### DIFF
--- a/jks.go
+++ b/jks.go
@@ -134,7 +134,7 @@ func (k *Kafka) loadJKSFunction(call goja.FunctionCall) goja.Value {
 	}
 
 	jks, err := k.loadJKS(jksConfig)
-	if err != nil {
+	if jks !=nil && err != nil {
 		common.Throw(runtime, err)
 	}
 


### PR DESCRIPTION
From this comment of the code - https://github.com/mostafa/xk6-kafka/pull/224/files#diff-9290cd1c8d3e4a6a3a0dbbdb7ab98a4d30a81b6328f2ccd4d9a3b47acc62aaecL62
it allows users not to set ClientCertsPem 

But when we didn't set it, we will still get exception - "Failed to decode client's private key"
Seems as long as the err is not nil, it will throw the exception and has no chance of return the JKS
```
if err != nil {
		common.Throw(runtime, err)
	}
```