### PR TITLE
Fix string representation of error

### DIFF
--- a/error_codes.go
+++ b/error_codes.go
@@ -2,7 +2,6 @@ package kafka
 
 import (
 	"errors"
-	"fmt"
 )
 
 type errCode uint32
@@ -130,7 +129,7 @@ func (e Xk6KafkaError) Error() string {
 	if e.OriginalError == nil {
 		return e.Message
 	}
-	return fmt.Sprintf(e.Message+", OriginalError: %w", e.OriginalError)
+	return e.Message + ", OriginalError: " + e.OriginalError.Error()
 }
 
 // Unwrap implements the `xerrors.Wrapper` interface, so Xk6KafkaError are a bit


### PR DESCRIPTION
This PR fixes the incorrect error output.

was:
`
ERRO[0000] GoError: Error writing messages., OriginalError: %!w(*net.OpError=&{read tcp 0xc001284000 0xc001284030 0xc0010c80a0})
`

fixed:
`
ERRO[0000] GoError: Error writing messages., OriginalError: read tcp 127.0.0.1:52879->127.0.0.1:9092: read: connection reset by peer
`
