### PR TITLE
Add name for requests in stats

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mostafa/xk6-kafka
+module github.com/daylikon/xk6-kafka
 
 go 1.21
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/daylikon/xk6-kafka
+module github.com/mostafa/xk6-kafka
 
 go 1.21
 


### PR DESCRIPTION
Hi, @mostafa

Is it possible to add this to the plugin? 
Or, for example, make a similar implementation for passing `name` to tags.

Ref: https://github.com/mostafa/xk6-kafka/issues/271

Thank you