### PR TITLE
Keep original error in reader

### DIFF
--- a/reader.go
+++ b/reader.go
@@ -342,7 +342,7 @@ func (k *Kafka) consume(
 		if err != nil {
 			k.reportReaderStats(reader.Stats())
 
-			err = NewXk6KafkaError(failedReadMessage, "Unable to read messages.", nil)
+			err = NewXk6KafkaError(failedReadMessage, "Unable to read messages.", err)
 			logger.WithField("error", err).Error(err)
 			common.Throw(k.vu.Runtime(), err)
 		}


### PR DESCRIPTION
Previously, when the reader fails to consume a message, the only error shown is "Unable to read messages" with the original error as nil.

Now the error is kept in the log.