### PR TITLE
Update writer.go to support partition by key

### DIFF
--- a/writer.go
+++ b/writer.go
@@ -175,6 +175,12 @@ func (k *Kafka) writer(writerConfig *WriterConfig) *kafkago.Writer {
 		},
 		AllowAutoTopicCreation: writerConfig.AutoCreateTopic,
 	}
+    	
+	if balancer, ok := Balancers[writerConfig.Balancer]; ok {
+        	writer.Balancer = balancer
+    	} else {
+        	writer.Balancer = Balancers[balancerHash] // Default to key-based balancer if not provided
+    	}
 
 	if balancer, ok := Balancers[writerConfig.Balancer]; ok {
 		writer.Balancer = balancer


### PR DESCRIPTION
Hi @mostafa,

Would it be possible to add support for specifying the balancer when creating the Kafka producer? This would allow us to partition messages by key, which is crucial for certain use cases.

For example, something like this:
`const kafkaProducer = new KafkaWriter({
    brokers: __ENV.KAFKA_BROKER_URLS.split(','),
    topic: __ENV.M2M_KAFKA_UPH_TOPIC,
    balancer: 'balancer_hash', // Specify a key-based balancer (e.g., hash or crc32)
});
`

This change would give us the flexibility to use a key-based balancer (like hash or crc32) for partitioning, enabling more control over message distribution across Kafka partitions.

Thanks in advance for considering this!