### PR TITLE
Test suite can run multiple times

### DIFF
--- a/reader_test.go
+++ b/reader_test.go
@@ -16,14 +16,15 @@ import (
 // The reader should not hang
 func TestConsumerMaxWaitExceeded(t *testing.T) {
 	test := getTestModuleInstance(t)
-	writer := test.newWriter("test-topic")
+	test.createTopic()
+	writer := test.newWriter()
 	defer writer.Close()
 
 	// Create a reader to consume messages.
 	assert.NotPanics(t, func() {
 		reader := test.module.Kafka.reader(&ReaderConfig{
 			Brokers: []string{"localhost:9092"},
-			Topic:   "test-topic",
+			Topic:   test.topicName,
 			MaxWait: Duration{time.Second * 3},
 		})
 		assert.NotNil(t, reader)
@@ -52,17 +53,17 @@ func TestConsumerMaxWaitExceeded(t *testing.T) {
 // nolint: funlen
 func TestConsume(t *testing.T) {
 	test := getTestModuleInstance(t)
-	test.createTopic("test-topic")
-	writer := test.newWriter("test-topic")
+	test.createTopic()
+	writer := test.newWriter()
 	defer writer.Close()
 
-	assert.True(t, test.topicExists("test-topic"))
+	assert.True(t, test.topicExists())
 
 	// Create a reader to consume messages.
 	assert.NotPanics(t, func() {
 		reader := test.module.Kafka.reader(&ReaderConfig{
 			Brokers: []string{"localhost:9092"},
-			Topic:   "test-topic",
+			Topic:   test.topicName,
 		})
 		assert.NotNil(t, reader)
 		defer reader.Close()
@@ -139,7 +140,8 @@ func TestConsume(t *testing.T) {
 // TestConsumeWithoutKey tests the consume function without a key.
 func TestConsumeWithoutKey(t *testing.T) {
 	test := getTestModuleInstance(t)
-	writer := test.newWriter("test-topic")
+	test.createTopic()
+	writer := test.newWriter()
 	defer writer.Close()
 
 	// Create a reader to consume messages.
@@ -164,7 +166,6 @@ func TestConsumeWithoutKey(t *testing.T) {
 							Data:       "value1",
 							SchemaType: String,
 						}),
-						Offset: 1,
 					},
 				},
 			})
@@ -198,7 +199,8 @@ func TestConsumeWithoutKey(t *testing.T) {
 // TestConsumerContextCancelled tests the consume function and fails on a cancelled context.
 func TestConsumerContextCancelled(t *testing.T) {
 	test := getTestModuleInstance(t)
-	writer := test.newWriter("test-topic")
+	test.createTopic()
+	writer := test.newWriter()
 	defer writer.Close()
 
 	// Create a reader to consume messages.
@@ -232,8 +234,7 @@ func TestConsumerContextCancelled(t *testing.T) {
 
 		// Consume a message in the VU function.
 		assert.Panics(t, func() {
-			messages := test.module.Kafka.consume(reader, &ConsumeConfig{Limit: 1})
-			assert.Empty(t, messages)
+			test.module.Kafka.consume(reader, &ConsumeConfig{Limit: 1})
 		})
 	})
 
@@ -249,7 +250,8 @@ func TestConsumerContextCancelled(t *testing.T) {
 // TestConsumeJSON tests the consume function with a JSON value.
 func TestConsumeJSON(t *testing.T) {
 	test := getTestModuleInstance(t)
-	writer := test.newWriter("test-topic")
+	test.createTopic()
+	writer := test.newWriter()
 	defer writer.Close()
 
 	// Create a reader to consume messages.
@@ -273,8 +275,7 @@ func TestConsumeJSON(t *testing.T) {
 			test.module.Kafka.produce(writer, &ProduceConfig{
 				Messages: []Message{
 					{
-						Value:  serialized,
-						Offset: 3,
+						Value: serialized,
 					},
 				},
 			})
@@ -309,8 +310,8 @@ func TestReaderClass(t *testing.T) {
 	test := getTestModuleInstance(t)
 
 	require.NoError(t, test.moveToVUCode())
-	test.createTopic("test-reader-class")
-	writer := test.newWriter("test-reader-class")
+	test.createTopic()
+	writer := test.newWriter()
 	defer writer.Close()
 
 	test.module.Kafka.produce(writer, &ProduceConfig{
@@ -334,7 +335,7 @@ func TestReaderClass(t *testing.T) {
 				test.module.vu.Runtime().ToValue(
 					map[string]interface{}{
 						"brokers": []string{"localhost:9092"},
-						"topic":   "test-reader-class",
+						"topic":   test.topicName,
 						"maxWait": "3s",
 					},
 				),
@@ -344,7 +345,7 @@ func TestReaderClass(t *testing.T) {
 		this := reader.Get("This").Export().(*kafkago.Reader)
 		assert.NotNil(t, this)
 		assert.Equal(t, this.Config().Brokers, []string{"localhost:9092"})
-		assert.Equal(t, this.Config().Topic, "test-reader-class")
+		assert.Equal(t, this.Config().Topic, test.topicName)
 		assert.Equal(t, this.Config().MaxWait, time.Second*3)
 
 		consume := reader.Get("consume").Export().(func(sobek.FunctionCall) sobek.Value)

--- a/reader_test.go
+++ b/reader_test.go
@@ -144,16 +144,15 @@ func TestConsumeWithoutKey(t *testing.T) {
 	writer := test.newWriter()
 	defer writer.Close()
 
+	reader := test.module.Kafka.reader(&ReaderConfig{
+		Brokers: []string{"localhost:9092"},
+		Topic:   test.topicName,
+	})
+	assert.NotNil(t, reader)
+	defer reader.Close()
+
 	// Create a reader to consume messages.
 	assert.NotPanics(t, func() {
-		reader := test.module.Kafka.reader(&ReaderConfig{
-			Brokers: []string{"localhost:9092"},
-			Topic:   "test-topic",
-			Offset:  1,
-		})
-		assert.NotNil(t, reader)
-		defer reader.Close()
-
 		// Switch to VU code.
 		require.NoError(t, test.moveToVUCode())
 
@@ -203,15 +202,15 @@ func TestConsumerContextCancelled(t *testing.T) {
 	writer := test.newWriter()
 	defer writer.Close()
 
+	reader := test.module.Kafka.reader(&ReaderConfig{
+		Brokers: []string{"localhost:9092"},
+		Topic:   test.topicName,
+	})
+	assert.NotNil(t, reader)
+	defer reader.Close()
+
 	// Create a reader to consume messages.
 	assert.NotPanics(t, func() {
-		reader := test.module.Kafka.reader(&ReaderConfig{
-			Brokers: []string{"localhost:9092"},
-			Topic:   "test-topic",
-		})
-		assert.NotNil(t, reader)
-		defer reader.Close()
-
 		// Switch to VU code.
 		require.NoError(t, test.moveToVUCode())
 
@@ -254,16 +253,15 @@ func TestConsumeJSON(t *testing.T) {
 	writer := test.newWriter()
 	defer writer.Close()
 
+	reader := test.module.Kafka.reader(&ReaderConfig{
+		Brokers: []string{"localhost:9092"},
+		Topic:   test.topicName,
+	})
+	assert.NotNil(t, reader)
+	defer reader.Close()
+
 	// Create a reader to consume messages.
 	assert.NotPanics(t, func() {
-		reader := test.module.Kafka.reader(&ReaderConfig{
-			Brokers: []string{"localhost:9092"},
-			Topic:   "test-topic",
-			Offset:  3,
-		})
-		assert.NotNil(t, reader)
-		defer reader.Close()
-
 		// Switch to VU code.
 		require.NoError(t, test.moveToVUCode())
 

--- a/schema_registry_test.go
+++ b/schema_registry_test.go
@@ -103,7 +103,7 @@ func TestGetLatestSchemaFails(t *testing.T) {
 	srClient := test.module.Kafka.schemaRegistryClient(&srConfig)
 	assert.Panics(t, func() {
 		schema := test.module.Kafka.getSchema(srClient, &Schema{
-			Subject: "test-subject",
+			Subject: "no-such-subject",
 			Version: 0,
 		})
 		assert.Equal(t, schema, nil)
@@ -125,7 +125,7 @@ func TestGetSchemaFails(t *testing.T) {
 	srClient := test.module.Kafka.schemaRegistryClient(&srConfig)
 	assert.Panics(t, func() {
 		schema := test.module.Kafka.getSchema(srClient, &Schema{
-			Subject: "test-subject",
+			Subject: "no-such-subject",
 			Version: 0,
 		})
 		assert.Equal(t, schema, nil)
@@ -147,7 +147,7 @@ func TestCreateSchemaFails(t *testing.T) {
 	srClient := test.module.Kafka.schemaRegistryClient(&srConfig)
 	assert.Panics(t, func() {
 		schema := test.module.Kafka.getSchema(srClient, &Schema{
-			Subject: "test-subject",
+			Subject: "no-such-subject",
 			Version: 0,
 		})
 		assert.Equal(t, schema, nil)

--- a/serdes_test.go
+++ b/serdes_test.go
@@ -15,10 +15,10 @@ import (
 func TestSerdes(t *testing.T) {
 	test := getTestModuleInstance(t)
 
-	test.createTopic("test-serdes-topic")
-	writer := test.newWriter("test-serdes-topic")
+	test.createTopic()
+	writer := test.newWriter()
 	defer writer.Close()
-	reader := test.newReader("test-serdes-topic")
+	reader := test.newReader()
 	defer reader.Close()
 
 	// Switch to VU code.

--- a/writer_test.go
+++ b/writer_test.go
@@ -14,12 +14,12 @@ import (
 // nolint: funlen
 func TestProduce(t *testing.T) {
 	test := getTestModuleInstance(t)
-	assert.True(t, test.topicExists("test-topic"))
+	test.createTopic()
 
 	assert.NotPanics(t, func() {
 		writer := test.module.Kafka.writer(&WriterConfig{
 			Brokers: []string{"localhost:9092"},
-			Topic:   "test-topic",
+			Topic:   test.topicName,
 		})
 		assert.NotNil(t, writer)
 		defer writer.Close()
@@ -106,6 +106,7 @@ func TestProduce(t *testing.T) {
 // TestProduceWithoutKey tests the produce function without a key.
 func TestProduceWithoutKey(t *testing.T) {
 	test := getTestModuleInstance(t)
+	test.createTopic()
 
 	assert.NotPanics(t, func() {
 		writer := test.module.Kafka.writer(&WriterConfig{
@@ -125,7 +126,7 @@ func TestProduceWithoutKey(t *testing.T) {
 							Data:       "value1",
 							SchemaType: String,
 						}),
-						Topic:  "test-topic",
+						Topic:  test.topicName,
 						Offset: 0,
 						Time:   time.Now(),
 					},
@@ -134,7 +135,7 @@ func TestProduceWithoutKey(t *testing.T) {
 							Data:       "value2",
 							SchemaType: String,
 						}),
-						Topic: "test-topic",
+						Topic: test.topicName,
 					},
 				},
 			})
@@ -153,11 +154,12 @@ func TestProduceWithoutKey(t *testing.T) {
 // TestProducerContextCancelled tests the produce function with a cancelled context.
 func TestProducerContextCancelled(t *testing.T) {
 	test := getTestModuleInstance(t)
+	test.createTopic()
 
 	assert.NotPanics(t, func() {
 		writer := test.module.Kafka.writer(&WriterConfig{
 			Brokers: []string{"localhost:9092"},
-			Topic:   "test-topic",
+			Topic:   test.topicName,
 		})
 		assert.NotNil(t, writer)
 		defer writer.Close()
@@ -208,11 +210,12 @@ func TestProducerContextCancelled(t *testing.T) {
 // TestProduceJSON tests the produce function with a JSON value.
 func TestProduceJSON(t *testing.T) {
 	test := getTestModuleInstance(t)
+	test.createTopic()
 
 	assert.NotPanics(t, func() {
 		writer := test.module.Kafka.writer(&WriterConfig{
 			Brokers: []string{"localhost:9092"},
-			Topic:   "test-topic",
+			Topic:   test.topicName,
 		})
 		assert.NotNil(t, writer)
 		defer writer.Close()
@@ -247,7 +250,7 @@ func TestWriterClass(t *testing.T) {
 	test := getTestModuleInstance(t)
 
 	require.NoError(t, test.moveToVUCode())
-	test.createTopic("test-writer-class")
+	test.createTopic()
 
 	assert.NotPanics(t, func() {
 		writer := test.module.writerClass(sobek.ConstructorCall{
@@ -255,7 +258,7 @@ func TestWriterClass(t *testing.T) {
 				test.module.vu.Runtime().ToValue(
 					map[string]interface{}{
 						"brokers": []string{"localhost:9092"},
-						"topic":   "test-writer-class",
+						"topic":   test.topicName,
 					},
 				),
 			},


### PR DESCRIPTION
I wanted to work on #311 but I could not reliably get the tests to pass, so I have changed the test suite so that each test uses a unique topic. Each test now has a pristine topic to work with, removing the risk for pollution from previous runs and obviates fiddling offsets. This is one of many ways you can organize such test infrastructure. I'm not wedded to this exact shape; it was simply the version I could come up with that produced the most readable diff.

Additionally, the schema tests wanted to ensure that unknown subjects resulted in panic, but seems to use a subject that is also used for test that verifies positive function. The PR changes those tests to use a subject not used for other things.

Finally, a number of readers were created in one "assert closure" but was then used inside another. This works, but is iffy, particularly when the first closure does `defer reader.Close()`. I *think* there were intermittent failures as a result of this placement, but I never managed to figure out exactly why they failed. Regardless, the PR moves the creation of those readers outside their closure for more readable code. I have not managed to get the same failures with this flow.