### PR TITLE
Add option to set AWS profile in SASL config

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,9 +479,11 @@ The example scripts are available as `test_<format/feature>.js` with more code a
     If you have a nested Avro schema and you want to test it against your data, I created a small tool for it, called [nested-avro-schema](https://github.com/mostafa/nested-avro-schema). This tool will help you to find discrepancies and errors in your schema data, so that you can fix them before you run [xk6-kafka](https://github.com/mostafa/xk6-kafka) tests. Refer to [this comment](https://github.com/mostafa/xk6-kafka/issues/266) for more information.
 
 13. What is the difference between hard-coded schemas in the script and the ones fetched from the Schema Registry?
+
     Read [this comment](https://github.com/mostafa/xk6-kafka/issues/298#issuecomment-2165246467).
 
 14. I want to specify the offset of a message when consuming from a topic. How can I do that?
+
     To specify the offset of a message while consuming from a topic, use the following options based on your consumption setup:
 
     1. **When consuming from a group:**
@@ -508,7 +510,8 @@ The example scripts are available as `test_<format/feature>.js` with more code a
         ```
 
     2. **When consuming from a topic:**
-    Use the `offset` option instead of `startOffset`. The `offset` option is a number that directly specifies the offset of the message you want to consume, unlike `startOffset`, which is a string.
+
+        Use the `offset` option instead of `startOffset`. The `offset` option is a number that directly specifies the offset of the message you want to consume, unlike `startOffset`, which is a string.
 
         ```javascript
         import { Reader } from "k6/x/kafka";
@@ -521,7 +524,12 @@ The example scripts are available as `test_<format/feature>.js` with more code a
         ```
 
 15. How can I use Avro union types in my Avro schema?
+
     Read [this comment](https://github.com/mostafa/xk6-kafka/issues/220#issuecomment-1564061967).
+
+16. What if I want to use a custom profile for the SASL authentication with AWS IAM instead of the default profile?
+
+    You can use the `AWS_PROFILE` environment variable to specify the profile name or use the `awsProfile` option in the `SASLConfig` [object](api-docs/docs/interfaces/SASLConfig.md).
 
 ## Contributions, Issues and Feedback
 

--- a/api-docs/docs/README.md
+++ b/api-docs/docs/README.md
@@ -92,4 +92,4 @@ const jks = LoadJKS({
 
 #### Defined in
 
-[index.d.ts:550](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L550)
+[index.d.ts:551](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L551)

--- a/api-docs/docs/classes/Connection.md
+++ b/api-docs/docs/classes/Connection.md
@@ -44,7 +44,7 @@ connection.close();
 
 #### Defined in
 
-[index.d.ts:407](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L407)
+[index.d.ts:408](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L408)
 
 ## Methods
 
@@ -64,7 +64,7 @@ connection.close();
 
 #### Defined in
 
-[index.d.ts:433](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L433)
+[index.d.ts:434](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L434)
 
 ---
 
@@ -89,7 +89,7 @@ Create a new topic.
 
 #### Defined in
 
-[index.d.ts:414](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L414)
+[index.d.ts:415](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L415)
 
 ---
 
@@ -114,7 +114,7 @@ Delete a topic.
 
 #### Defined in
 
-[index.d.ts:421](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L421)
+[index.d.ts:422](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L422)
 
 ---
 
@@ -133,4 +133,4 @@ List topics.
 
 #### Defined in
 
-[index.d.ts:427](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L427)
+[index.d.ts:428](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L428)

--- a/api-docs/docs/classes/Reader.md
+++ b/api-docs/docs/classes/Reader.md
@@ -43,7 +43,7 @@ reader.close();
 
 #### Defined in
 
-[index.d.ts:366](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L366)
+[index.d.ts:367](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L367)
 
 ## Methods
 
@@ -63,7 +63,7 @@ reader.close();
 
 #### Defined in
 
-[index.d.ts:379](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L379)
+[index.d.ts:380](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L380)
 
 ---
 
@@ -88,4 +88,4 @@ Read messages from Kafka.
 
 #### Defined in
 
-[index.d.ts:373](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L373)
+[index.d.ts:374](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L374)

--- a/api-docs/docs/classes/SchemaRegistry.md
+++ b/api-docs/docs/classes/SchemaRegistry.md
@@ -79,7 +79,7 @@ writer.produce({
 
 #### Defined in
 
-[index.d.ts:495](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L495)
+[index.d.ts:496](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L496)
 
 ## Methods
 
@@ -104,7 +104,7 @@ Create or update a schema on Schema Registry.
 
 #### Defined in
 
-[index.d.ts:509](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L509)
+[index.d.ts:510](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L510)
 
 ---
 
@@ -129,7 +129,7 @@ Deserializes the given data and schema into its original form.
 
 #### Defined in
 
-[index.d.ts:530](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L530)
+[index.d.ts:531](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L531)
 
 ---
 
@@ -154,7 +154,7 @@ Get a schema from Schema Registry by version and subject.
 
 #### Defined in
 
-[index.d.ts:502](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L502)
+[index.d.ts:503](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L503)
 
 ---
 
@@ -179,7 +179,7 @@ Returns the subject name for the given SubjectNameConfig.
 
 #### Defined in
 
-[index.d.ts:516](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L516)
+[index.d.ts:517](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L517)
 
 ---
 
@@ -204,4 +204,4 @@ Serializes the given data and schema into a byte array.
 
 #### Defined in
 
-[index.d.ts:523](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L523)
+[index.d.ts:524](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L524)

--- a/api-docs/docs/classes/Writer.md
+++ b/api-docs/docs/classes/Writer.md
@@ -51,7 +51,7 @@ writer.close();
 
 #### Defined in
 
-[index.d.ts:324](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L324)
+[index.d.ts:325](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L325)
 
 ## Methods
 
@@ -71,7 +71,7 @@ writer.close();
 
 #### Defined in
 
-[index.d.ts:337](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L337)
+[index.d.ts:338](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L338)
 
 ---
 
@@ -96,4 +96,4 @@ Write messages to Kafka.
 
 #### Defined in
 
-[index.d.ts:331](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L331)
+[index.d.ts:332](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L332)

--- a/api-docs/docs/interfaces/BasicAuth.md
+++ b/api-docs/docs/interfaces/BasicAuth.md
@@ -15,7 +15,7 @@
 
 #### Defined in
 
-[index.d.ts:154](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L154)
+[index.d.ts:155](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L155)
 
 ---
 
@@ -25,4 +25,4 @@
 
 #### Defined in
 
-[index.d.ts:153](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L153)
+[index.d.ts:154](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L154)

--- a/api-docs/docs/interfaces/ConfigEntry.md
+++ b/api-docs/docs/interfaces/ConfigEntry.md
@@ -15,7 +15,7 @@
 
 #### Defined in
 
-[index.d.ts:230](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L230)
+[index.d.ts:231](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L231)
 
 ---
 
@@ -25,4 +25,4 @@
 
 #### Defined in
 
-[index.d.ts:231](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L231)
+[index.d.ts:232](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L232)

--- a/api-docs/docs/interfaces/ConnectionConfig.md
+++ b/api-docs/docs/interfaces/ConnectionConfig.md
@@ -16,7 +16,7 @@
 
 #### Defined in
 
-[index.d.ts:217](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L217)
+[index.d.ts:218](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L218)
 
 ---
 
@@ -26,7 +26,7 @@
 
 #### Defined in
 
-[index.d.ts:218](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L218)
+[index.d.ts:219](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L219)
 
 ---
 
@@ -36,4 +36,4 @@
 
 #### Defined in
 
-[index.d.ts:219](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L219)
+[index.d.ts:220](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L220)

--- a/api-docs/docs/interfaces/ConsumeConfig.md
+++ b/api-docs/docs/interfaces/ConsumeConfig.md
@@ -21,7 +21,7 @@ passed.
 
 #### Defined in
 
-[index.d.ts:212](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L212)
+[index.d.ts:213](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L213)
 
 ---
 
@@ -33,7 +33,7 @@ collect this many messages before returning.
 
 #### Defined in
 
-[index.d.ts:205](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L205)
+[index.d.ts:206](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L206)
 
 ---
 
@@ -45,4 +45,4 @@ If true, returned message RFC3339 timestamps carry nanosecond precision.
 
 #### Defined in
 
-[index.d.ts:207](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L207)
+[index.d.ts:208](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L208)

--- a/api-docs/docs/interfaces/Container.md
+++ b/api-docs/docs/interfaces/Container.md
@@ -16,7 +16,7 @@
 
 #### Defined in
 
-[index.d.ts:270](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L270)
+[index.d.ts:271](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L271)
 
 ---
 
@@ -26,7 +26,7 @@
 
 #### Defined in
 
-[index.d.ts:271](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L271)
+[index.d.ts:272](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L272)
 
 ---
 
@@ -36,4 +36,4 @@
 
 #### Defined in
 
-[index.d.ts:272](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L272)
+[index.d.ts:273](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L273)

--- a/api-docs/docs/interfaces/JKS.md
+++ b/api-docs/docs/interfaces/JKS.md
@@ -16,7 +16,7 @@
 
 #### Defined in
 
-[index.d.ts:285](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L285)
+[index.d.ts:286](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L286)
 
 ---
 
@@ -26,7 +26,7 @@
 
 #### Defined in
 
-[index.d.ts:286](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L286)
+[index.d.ts:287](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L287)
 
 ---
 
@@ -36,4 +36,4 @@
 
 #### Defined in
 
-[index.d.ts:287](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L287)
+[index.d.ts:288](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L288)

--- a/api-docs/docs/interfaces/JKSConfig.md
+++ b/api-docs/docs/interfaces/JKSConfig.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[index.d.ts:278](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L278)
+[index.d.ts:279](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L279)
 
 ---
 
@@ -29,7 +29,7 @@
 
 #### Defined in
 
-[index.d.ts:279](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L279)
+[index.d.ts:280](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L280)
 
 ---
 
@@ -39,7 +39,7 @@
 
 #### Defined in
 
-[index.d.ts:280](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L280)
+[index.d.ts:281](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L281)
 
 ---
 
@@ -49,7 +49,7 @@
 
 #### Defined in
 
-[index.d.ts:277](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L277)
+[index.d.ts:278](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L278)
 
 ---
 
@@ -59,7 +59,7 @@
 
 #### Defined in
 
-[index.d.ts:276](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L276)
+[index.d.ts:277](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L277)
 
 ---
 
@@ -69,4 +69,4 @@
 
 #### Defined in
 
-[index.d.ts:281](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L281)
+[index.d.ts:282](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L282)

--- a/api-docs/docs/interfaces/Message.md
+++ b/api-docs/docs/interfaces/Message.md
@@ -25,7 +25,7 @@ Message format for producing messages to a topic.
 
 #### Defined in
 
-[index.d.ts:147](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L147)
+[index.d.ts:148](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L148)
 
 ---
 
@@ -35,7 +35,7 @@ Message format for producing messages to a topic.
 
 #### Defined in
 
-[index.d.ts:144](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L144)
+[index.d.ts:145](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L145)
 
 ---
 
@@ -45,7 +45,7 @@ Message format for producing messages to a topic.
 
 #### Defined in
 
-[index.d.ts:145](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L145)
+[index.d.ts:146](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L146)
 
 ---
 
@@ -55,7 +55,7 @@ Message format for producing messages to a topic.
 
 #### Defined in
 
-[index.d.ts:143](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L143)
+[index.d.ts:144](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L144)
 
 ---
 
@@ -65,7 +65,7 @@ Message format for producing messages to a topic.
 
 #### Defined in
 
-[index.d.ts:142](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L142)
+[index.d.ts:143](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L143)
 
 ---
 
@@ -75,7 +75,7 @@ Message format for producing messages to a topic.
 
 #### Defined in
 
-[index.d.ts:148](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L148)
+[index.d.ts:149](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L149)
 
 ---
 
@@ -85,7 +85,7 @@ Message format for producing messages to a topic.
 
 #### Defined in
 
-[index.d.ts:141](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L141)
+[index.d.ts:142](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L142)
 
 ---
 
@@ -95,4 +95,4 @@ Message format for producing messages to a topic.
 
 #### Defined in
 
-[index.d.ts:146](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L146)
+[index.d.ts:147](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L147)

--- a/api-docs/docs/interfaces/ProduceConfig.md
+++ b/api-docs/docs/interfaces/ProduceConfig.md
@@ -14,4 +14,4 @@
 
 #### Defined in
 
-[index.d.ts:166](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L166)
+[index.d.ts:167](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L167)

--- a/api-docs/docs/interfaces/ReaderConfig.md
+++ b/api-docs/docs/interfaces/ReaderConfig.md
@@ -42,7 +42,7 @@
 
 #### Defined in
 
-[index.d.ts:171](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L171)
+[index.d.ts:172](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L172)
 
 ---
 
@@ -52,7 +52,7 @@
 
 #### Defined in
 
-[index.d.ts:184](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L184)
+[index.d.ts:185](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L185)
 
 ---
 
@@ -62,7 +62,7 @@
 
 #### Defined in
 
-[index.d.ts:194](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L194)
+[index.d.ts:195](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L195)
 
 ---
 
@@ -72,7 +72,7 @@
 
 #### Defined in
 
-[index.d.ts:182](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L182)
+[index.d.ts:183](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L183)
 
 ---
 
@@ -82,7 +82,7 @@
 
 #### Defined in
 
-[index.d.ts:172](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L172)
+[index.d.ts:173](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L173)
 
 ---
 
@@ -92,7 +92,7 @@
 
 #### Defined in
 
-[index.d.ts:173](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L173)
+[index.d.ts:174](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L174)
 
 ---
 
@@ -102,7 +102,7 @@
 
 #### Defined in
 
-[index.d.ts:183](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L183)
+[index.d.ts:184](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L184)
 
 ---
 
@@ -112,7 +112,7 @@
 
 #### Defined in
 
-[index.d.ts:196](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L196)
+[index.d.ts:197](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L197)
 
 ---
 
@@ -122,7 +122,7 @@
 
 #### Defined in
 
-[index.d.ts:189](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L189)
+[index.d.ts:190](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L190)
 
 ---
 
@@ -132,7 +132,7 @@
 
 #### Defined in
 
-[index.d.ts:195](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L195)
+[index.d.ts:196](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L196)
 
 ---
 
@@ -142,7 +142,7 @@
 
 #### Defined in
 
-[index.d.ts:178](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L178)
+[index.d.ts:179](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L179)
 
 ---
 
@@ -152,7 +152,7 @@
 
 #### Defined in
 
-[index.d.ts:180](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L180)
+[index.d.ts:181](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L181)
 
 ---
 
@@ -162,7 +162,7 @@
 
 #### Defined in
 
-[index.d.ts:177](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L177)
+[index.d.ts:178](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L178)
 
 ---
 
@@ -172,7 +172,7 @@
 
 #### Defined in
 
-[index.d.ts:197](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L197)
+[index.d.ts:198](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L198)
 
 ---
 
@@ -182,7 +182,7 @@
 
 #### Defined in
 
-[index.d.ts:175](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L175)
+[index.d.ts:176](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L176)
 
 ---
 
@@ -192,7 +192,7 @@
 
 #### Defined in
 
-[index.d.ts:185](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L185)
+[index.d.ts:186](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L186)
 
 ---
 
@@ -202,7 +202,7 @@
 
 #### Defined in
 
-[index.d.ts:176](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L176)
+[index.d.ts:177](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L177)
 
 ---
 
@@ -212,7 +212,7 @@
 
 #### Defined in
 
-[index.d.ts:193](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L193)
+[index.d.ts:194](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L194)
 
 ---
 
@@ -222,7 +222,7 @@
 
 #### Defined in
 
-[index.d.ts:192](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L192)
+[index.d.ts:193](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L193)
 
 ---
 
@@ -232,7 +232,7 @@
 
 #### Defined in
 
-[index.d.ts:179](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L179)
+[index.d.ts:180](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L180)
 
 ---
 
@@ -242,7 +242,7 @@
 
 #### Defined in
 
-[index.d.ts:181](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L181)
+[index.d.ts:182](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L182)
 
 ---
 
@@ -252,7 +252,7 @@
 
 #### Defined in
 
-[index.d.ts:188](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L188)
+[index.d.ts:189](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L189)
 
 ---
 
@@ -262,7 +262,7 @@
 
 #### Defined in
 
-[index.d.ts:190](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L190)
+[index.d.ts:191](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L191)
 
 ---
 
@@ -272,7 +272,7 @@
 
 #### Defined in
 
-[index.d.ts:198](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L198)
+[index.d.ts:199](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L199)
 
 ---
 
@@ -282,7 +282,7 @@
 
 #### Defined in
 
-[index.d.ts:187](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L187)
+[index.d.ts:188](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L188)
 
 ---
 
@@ -292,7 +292,7 @@
 
 #### Defined in
 
-[index.d.ts:191](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L191)
+[index.d.ts:192](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L192)
 
 ---
 
@@ -302,7 +302,7 @@
 
 #### Defined in
 
-[index.d.ts:199](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L199)
+[index.d.ts:200](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L200)
 
 ---
 
@@ -312,7 +312,7 @@
 
 #### Defined in
 
-[index.d.ts:174](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L174)
+[index.d.ts:175](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L175)
 
 ---
 
@@ -322,4 +322,4 @@
 
 #### Defined in
 
-[index.d.ts:186](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L186)
+[index.d.ts:187](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L187)

--- a/api-docs/docs/interfaces/Reference.md
+++ b/api-docs/docs/interfaces/Reference.md
@@ -16,7 +16,7 @@
 
 #### Defined in
 
-[index.d.ts:246](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L246)
+[index.d.ts:247](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L247)
 
 ---
 
@@ -26,7 +26,7 @@
 
 #### Defined in
 
-[index.d.ts:247](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L247)
+[index.d.ts:248](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L248)
 
 ---
 
@@ -36,4 +36,4 @@
 
 #### Defined in
 
-[index.d.ts:248](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L248)
+[index.d.ts:249](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L249)

--- a/api-docs/docs/interfaces/ReplicaAssignment.md
+++ b/api-docs/docs/interfaces/ReplicaAssignment.md
@@ -15,7 +15,7 @@
 
 #### Defined in
 
-[index.d.ts:224](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L224)
+[index.d.ts:225](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L225)
 
 ---
 
@@ -25,4 +25,4 @@
 
 #### Defined in
 
-[index.d.ts:225](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L225)
+[index.d.ts:226](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L226)

--- a/api-docs/docs/interfaces/SASLConfig.md
+++ b/api-docs/docs/interfaces/SASLConfig.md
@@ -5,6 +5,7 @@
 ### Properties
 
 - [algorithm](SASLConfig.md#algorithm)
+- [awsProfile](SASLConfig.md#awsprofile)
 - [password](SASLConfig.md#password)
 - [username](SASLConfig.md#username)
 
@@ -17,6 +18,16 @@
 #### Defined in
 
 [index.d.ts:104](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L104)
+
+---
+
+### awsProfile
+
+• **awsProfile**: `string`
+
+#### Defined in
+
+[index.d.ts:105](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L105)
 
 ---
 

--- a/api-docs/docs/interfaces/Schema.md
+++ b/api-docs/docs/interfaces/Schema.md
@@ -20,7 +20,7 @@
 
 #### Defined in
 
-[index.d.ts:253](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L253)
+[index.d.ts:254](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L254)
 
 ---
 
@@ -30,7 +30,7 @@
 
 #### Defined in
 
-[index.d.ts:254](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L254)
+[index.d.ts:255](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L255)
 
 ---
 
@@ -40,7 +40,7 @@
 
 #### Defined in
 
-[index.d.ts:258](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L258)
+[index.d.ts:259](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L259)
 
 ---
 
@@ -50,7 +50,7 @@
 
 #### Defined in
 
-[index.d.ts:255](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L255)
+[index.d.ts:256](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L256)
 
 ---
 
@@ -60,7 +60,7 @@
 
 #### Defined in
 
-[index.d.ts:256](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L256)
+[index.d.ts:257](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L257)
 
 ---
 
@@ -70,7 +70,7 @@
 
 #### Defined in
 
-[index.d.ts:259](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L259)
+[index.d.ts:260](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L260)
 
 ---
 
@@ -80,4 +80,4 @@
 
 #### Defined in
 
-[index.d.ts:257](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L257)
+[index.d.ts:258](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L258)

--- a/api-docs/docs/interfaces/SchemaRegistryConfig.md
+++ b/api-docs/docs/interfaces/SchemaRegistryConfig.md
@@ -16,7 +16,7 @@
 
 #### Defined in
 
-[index.d.ts:160](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L160)
+[index.d.ts:161](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L161)
 
 ---
 
@@ -26,7 +26,7 @@
 
 #### Defined in
 
-[index.d.ts:161](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L161)
+[index.d.ts:162](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L162)
 
 ---
 
@@ -36,4 +36,4 @@
 
 #### Defined in
 
-[index.d.ts:159](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L159)
+[index.d.ts:160](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L160)

--- a/api-docs/docs/interfaces/SubjectNameConfig.md
+++ b/api-docs/docs/interfaces/SubjectNameConfig.md
@@ -17,7 +17,7 @@
 
 #### Defined in
 
-[index.d.ts:265](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L265)
+[index.d.ts:266](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L266)
 
 ---
 
@@ -27,7 +27,7 @@
 
 #### Defined in
 
-[index.d.ts:263](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L263)
+[index.d.ts:264](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L264)
 
 ---
 
@@ -37,7 +37,7 @@
 
 #### Defined in
 
-[index.d.ts:266](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L266)
+[index.d.ts:267](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L267)
 
 ---
 
@@ -47,4 +47,4 @@
 
 #### Defined in
 
-[index.d.ts:264](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L264)
+[index.d.ts:265](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L265)

--- a/api-docs/docs/interfaces/TLSConfig.md
+++ b/api-docs/docs/interfaces/TLSConfig.md
@@ -19,7 +19,7 @@
 
 #### Defined in
 
-[index.d.ts:112](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L112)
+[index.d.ts:113](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L113)
 
 ---
 
@@ -29,7 +29,7 @@
 
 #### Defined in
 
-[index.d.ts:113](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L113)
+[index.d.ts:114](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L114)
 
 ---
 
@@ -39,7 +39,7 @@
 
 #### Defined in
 
-[index.d.ts:109](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L109)
+[index.d.ts:110](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L110)
 
 ---
 
@@ -49,7 +49,7 @@
 
 #### Defined in
 
-[index.d.ts:110](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L110)
+[index.d.ts:111](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L111)
 
 ---
 
@@ -59,7 +59,7 @@
 
 #### Defined in
 
-[index.d.ts:111](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L111)
+[index.d.ts:112](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L112)
 
 ---
 
@@ -69,4 +69,4 @@
 
 #### Defined in
 
-[index.d.ts:114](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L114)
+[index.d.ts:115](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L115)

--- a/api-docs/docs/interfaces/TopicConfig.md
+++ b/api-docs/docs/interfaces/TopicConfig.md
@@ -18,7 +18,7 @@
 
 #### Defined in
 
-[index.d.ts:240](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L240)
+[index.d.ts:241](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L241)
 
 ---
 
@@ -28,7 +28,7 @@
 
 #### Defined in
 
-[index.d.ts:237](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L237)
+[index.d.ts:238](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L238)
 
 ---
 
@@ -38,7 +38,7 @@
 
 #### Defined in
 
-[index.d.ts:239](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L239)
+[index.d.ts:240](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L240)
 
 ---
 
@@ -48,7 +48,7 @@
 
 #### Defined in
 
-[index.d.ts:238](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L238)
+[index.d.ts:239](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L239)
 
 ---
 
@@ -58,4 +58,4 @@
 
 #### Defined in
 
-[index.d.ts:236](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L236)
+[index.d.ts:237](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L237)

--- a/api-docs/docs/interfaces/WriterConfig.md
+++ b/api-docs/docs/interfaces/WriterConfig.md
@@ -28,7 +28,7 @@
 
 #### Defined in
 
-[index.d.ts:121](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L121)
+[index.d.ts:122](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L122)
 
 ---
 
@@ -38,7 +38,7 @@
 
 #### Defined in
 
-[index.d.ts:122](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L122)
+[index.d.ts:123](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L123)
 
 ---
 
@@ -48,7 +48,7 @@
 
 #### Defined in
 
-[index.d.ts:125](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L125)
+[index.d.ts:126](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L126)
 
 ---
 
@@ -58,7 +58,7 @@
 
 #### Defined in
 
-[index.d.ts:124](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L124)
+[index.d.ts:125](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L125)
 
 ---
 
@@ -68,7 +68,7 @@
 
 #### Defined in
 
-[index.d.ts:126](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L126)
+[index.d.ts:127](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L127)
 
 ---
 
@@ -78,7 +78,7 @@
 
 #### Defined in
 
-[index.d.ts:119](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L119)
+[index.d.ts:120](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L120)
 
 ---
 
@@ -88,7 +88,7 @@
 
 #### Defined in
 
-[index.d.ts:130](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L130)
+[index.d.ts:131](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L131)
 
 ---
 
@@ -98,7 +98,7 @@
 
 #### Defined in
 
-[index.d.ts:133](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L133)
+[index.d.ts:134](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L134)
 
 ---
 
@@ -108,7 +108,7 @@
 
 #### Defined in
 
-[index.d.ts:123](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L123)
+[index.d.ts:124](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L124)
 
 ---
 
@@ -118,7 +118,7 @@
 
 #### Defined in
 
-[index.d.ts:127](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L127)
+[index.d.ts:128](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L128)
 
 ---
 
@@ -128,7 +128,7 @@
 
 #### Defined in
 
-[index.d.ts:128](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L128)
+[index.d.ts:129](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L129)
 
 ---
 
@@ -138,7 +138,7 @@
 
 #### Defined in
 
-[index.d.ts:131](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L131)
+[index.d.ts:132](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L132)
 
 ---
 
@@ -148,7 +148,7 @@
 
 #### Defined in
 
-[index.d.ts:132](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L132)
+[index.d.ts:133](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L133)
 
 ---
 
@@ -158,7 +158,7 @@
 
 #### Defined in
 
-[index.d.ts:120](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L120)
+[index.d.ts:121](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L121)
 
 ---
 
@@ -168,4 +168,4 @@
 
 #### Defined in
 
-[index.d.ts:129](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L129)
+[index.d.ts:130](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/index.d.ts#L130)

--- a/api-docs/index.d.ts
+++ b/api-docs/index.d.ts
@@ -102,6 +102,7 @@ export interface SASLConfig {
   username: string;
   password: string;
   algorithm: SASL_MECHANISMS;
+  awsProfile: string;
 }
 
 /* TLS configurations for creating a secure communication channel with Kafka. */


### PR DESCRIPTION
This PR adds a parameter to SASLConfig called `awsProfile` to fix #337, which can be used to set a custom AWS profile to authenticate against AWS IAM instead of the default one.