### PR TITLE
fix: Use system cert pool for TLS connections if no explicit server CA has been provided

### DIFF
--- a/auth.go
+++ b/auth.go
@@ -144,6 +144,11 @@ func GetTLSConfig(tlsConfig TLSConfig) (*tls.Config, *Xk6KafkaError) {
 
 	if tlsConfig.EnableTLS {
 		if tlsConfig.ServerCaPem == "" {
+			pool, err := x509.SystemCertPool()
+			if err != nil {
+				return nil, NewXk6KafkaError(failedLoadSystemCertPool, "Unable to load system cert pool", err)
+			}
+			tlsObject.RootCAs = pool
 			return tlsObject, nil
 		}
 	} else {

--- a/error_codes.go
+++ b/error_codes.go
@@ -53,6 +53,7 @@ const (
 	failedWriteCertFile           errCode = 4011
 	failedWriteKeyFile            errCode = 4012
 	failedWriteServerCaFile       errCode = 4013
+	failedLoadSystemCertPool      errCode = 4014
 
 	// schema registry.
 	messageTooShort                     errCode = 5000


### PR DESCRIPTION
This should inject the system's cert pool into a new TLS connection's `RootCAs` pool if no server CA has been specified.

I haven't had time to test it as I have no good idea how to unit-test this, nor the leisure to spin up a Kafka cluster that matches a public root certificate (e.g. AWS MSK) to test against. Therefore it's a draft for now.

Closes #344 