### PR TITLE
docs(usage) : Add documentation for managing readers and writers with xk6-kafka

### DIFF
--- a/docs/readers.md
+++ b/docs/readers.md
@@ -1,0 +1,138 @@
+# 📥 Manage Readers (Consumers) with xk6-kafka
+
+## What is the Reader?
+
+The reader is a Kafka consumer that allows you to **read/consume messages from Kafka topics** during a load or functional test using k6. Readers are useful for validating that a system under test is
+producing expected events, or to simulate consuming behavior in performance scenarios.
+
+Each reader listens to a specific topic and can be configured with several options like offset, partitions, group ID, and message limits.
+
+---
+
+## 🛠️ Reader Configuration
+
+### Create a Single Reader
+
+```javascript
+const reader = new Reader({
+    brokers, // Array of Kafka broker addresses
+    topic: topicName, // The topic to consume from
+    groupId: "my-consumer-group", // Consumer group ID
+    partition: 0, // Optional: partition to read from
+    minBytes: 1, // Minimum bytes per fetch request
+    maxBytes: 1048576, // Maximum bytes per fetch request
+    offset: 0, // Optional: Start at specific offset (default: latest)
+    tls: tlsConfig // TLS configuration, if needed
+});
+```
+
+_tips : here you can find more options for your reader:_
+
+```golang
+type ReaderConfig struct {
+	WatchPartitionChanges  bool          `json:"watchPartitionChanges"`
+	ConnectLogger          bool          `json:"connectLogger"`
+	Partition              int           `json:"partition"`
+	QueueCapacity          int           `json:"queueCapacity"`
+	MinBytes               int           `json:"minBytes"`
+	MaxBytes               int           `json:"maxBytes"`
+	MaxAttempts            int           `json:"maxAttempts"`
+	GroupID                string        `json:"groupId"`
+	Topic                  string        `json:"topic"`
+	IsolationLevel         string        `json:"isolationLevel"`
+	StartOffset            string        `json:"startOffset"`
+	Offset                 int64         `json:"offset"`
+	Brokers                []string      `json:"brokers"`
+	GroupTopics            []string      `json:"groupTopics"`
+	GroupBalancers         []string      `json:"groupBalancers"`
+	MaxWait                Duration      `json:"maxWait"`
+	ReadBatchTimeout       time.Duration `json:"readBatchTimeout"`
+	ReadLagInterval        time.Duration `json:"readLagInterval"`
+	HeartbeatInterval      time.Duration `json:"heartbeatInterval"`
+	CommitInterval         time.Duration `json:"commitInterval"`
+	PartitionWatchInterval time.Duration `json:"partitionWatchInterval"`
+	SessionTimeout         time.Duration `json:"sessionTimeout"`
+	RebalanceTimeout       time.Duration `json:"rebalanceTimeout"`
+	JoinGroupBackoff       time.Duration `json:"joinGroupBackoff"`
+	RetentionTime          time.Duration `json:"retentionTime"`
+	ReadBackoffMin         time.Duration `json:"readBackoffMin"`
+	ReadBackoffMax         time.Duration `json:"readBackoffMax"`
+	OffsetOutOfRangeError  bool          `json:"offsetOutOfRangeError"` // deprecated, do not use
+	SASL                   SASLConfig    `json:"sasl"`
+	TLS                    TLSConfig     `json:"tls"`
+} 
+```
+
+_All the parameters are named following the camelCase notation style_
+
+---
+
+### Read Messages
+
+Once you’ve created the reader, you can consume messages using the `consume()` method.
+
+```javascript
+const messages = reader.consume({
+    limit: 10, // Max number of messages to consume
+    expectedTimeout: "2s"// Max time to wait
+});
+```
+
+---
+
+## 🧵 Managing Multiple Readers
+
+If you need to consume from several topics simultaneously, you can manage multiple readers in a `Map`.
+
+```javascript
+function createKafkaReaders(brokers, topicNamesList, tlsConfig) {
+    const readers = new Map();
+    Object.values(topicNamesList).forEach(topicName => {
+        readers.set(topicName, new Reader({
+            brokers,
+            topic: topicName,
+            groupId: "my-group",
+            offset: 0,
+            tls: tlsConfig,
+        }));
+    });
+    return readers;
+}
+```
+
+You can then use them like this:
+
+```javascript
+const readers = createKafkaReaders(brokers, topicNamesList, tlsConfig);
+const messages = readers.get("my-topic").consume({
+    limit: 5,
+    expectedTimeout: "2s"
+});
+```
+
+Returned `messages` is an array of consumed messages, each with properties such as `key`, `value`, `timestamp`, `offset`, etc.
+
+---
+
+## Deserializing Messages
+
+If you are using a schema registry, you'll have to deserialize the messages after consuming them. Here’s how you can do it:
+You need first to create a `SchemaRegistry` instance. Please refer to the [Schema Registry documentation](./schema-registry.md) for more details on how to set it up.
+In order to perform deserialization, you can use the `schemaRegistry.deserialize` method:
+```javascript
+const readers = createKafkaReaders(brokers, topicNamesList, tlsConfig);
+const messages = readers.get("my-topic").consume({
+    limit: 5,
+    expectedTimeout: "2s"
+});
+```
+
+---
+
+## ✅ Notes
+
+- The `offset` can be set to:
+    - `0` to start from the beginning
+    - `-1` to start from the latest message
+- `groupId` ensures offset tracking and distribution in real Kafka clusters.
+- Be careful when consuming a high volume — make sure the `expectedTimeout` and `limit` values are tuned properly for your tests.

--- a/docs/schema-registry.md
+++ b/docs/schema-registry.md
@@ -1,0 +1,201 @@
+# Schema Registry usage with xk6-kafka
+
+## What is Schema Registry?
+
+Schema Registry is a service that provides a centralized repository for managing and validating schemas used in data serialization formats like Avro, JSON, and Protobuf.
+It ensures that the data produced and consumed by Kafka producers and consumers adheres to a defined schema, enabling compatibility and evolution of data structures over time.
+It is highly recommended to use Schema Registry when working with Kafka, in order to ensure that your messages conform to the expected structure and types.
+
+## How to Use Schema Registry with xk6-kafka
+
+### Create a Schema Registry Client
+
+To use Schema Registry with xk6-kafka,
+you need to create a Schema Registry client that will handle the communication with the Schema Registry service.
+
+#### No authentication
+
+```javascript
+const schemaRegistry = new SchemaRegistry({
+    url: "http://localhost:8081",
+});
+```
+
+#### Basic authentication
+
+```javascript
+const schemaRegistry = new SchemaRegistry({
+    url: "http://localhost:8081",
+    basicAuth: {
+        username: "my-username",
+        password: "my-password"
+    }
+});
+```
+
+### Create a new Schema into your Schema Registry
+
+If you have not already created a schema in your Schema Registry, you can do so using the following steps
+to let your load test create it for you.
+
+```javascript
+const keySchema = `{
+  "name": "KeySchema",
+  "type": "record",
+  "namespace": "com.example.key",
+  "fields": [
+    {
+      "name": "ssn",
+      "type": "string"
+    }
+  ]
+}
+`;
+const valueSchema = `{
+  "name": "ValueSchema",
+  "type": "record",
+  "namespace": "com.example.value",
+  "fields": [
+    {
+      "name": "firstName",
+      "type": "string"
+    },
+    {
+      "name": "lastName",
+      "type": "string"
+    }
+  ]
+}`;
+
+const keySchemaObject = schemaRegistry.createSchema({
+    subject: "my-key-schema-name",
+    schema: keySchema,
+    schemaType: SCHEMA_TYPE_AVRO,
+});
+
+const valueSchemaObject = schemaRegistry.createSchema({
+    subject: "my-value-schema-name",
+    schema: valueSchema,
+    schemaType: SCHEMA_TYPE_AVRO,
+});
+```
+
+_Optional : Retrieve the subject name directly from the schema_
+```javascript
+const keySubjectName = schemaRegistry.getSubjectName({
+    topic: topic,
+    element: KEY,
+    subjectNameStrategy: TOPIC_NAME_STRATEGY, // or RECORD_NAME_STRATEGY depending on your needs
+    schema: keySchema,
+});
+
+const valueSubjectName = schemaRegistry.getSubjectName({
+    topic: topic,
+    element: VALUE,
+    subjectNameStrategy: RECORD_NAME_STRATEGY, // or TOPIC_NAME_STRATEGY depending on your needs
+    schema: valueSchema,
+});
+```
+
+You can then use these schemas in your load test to produce and consume messages.
+
+```javascript
+const messages = [
+    {
+        key: schemaRegistry.serialize({
+            data: {
+                ssn: "123-45-6789",
+            },
+            schema: keySchemaObject,
+            schemaType: SCHEMA_TYPE_AVRO,
+        }),
+        value: schemaRegistry.serialize({
+            data: {
+                firstName: "John",
+                lastName: "Doe",
+            },
+            schema: valueSchemaObject,
+            schemaType: SCHEMA_TYPE_AVRO,
+        }),
+        headers: {
+            mykey: "myvalue",
+        },
+        offset: 0,
+        partition: 0,
+        time: new Date()
+    }
+];
+```
+
+### Load an existing Schema from your Schema Registry
+
+If you already have a schema registered in your Schema Registry, you can load it using the following method:
+
+```javascript
+const keySchemaObject = schemaRegistry.getSchema({
+    subject: "my-key-schema-name"
+});
+
+const valueSchemaObject = schemaRegistry.getSchema({
+    subject: "my-value-schema-name"
+});
+
+const messages = [
+    {
+        key: schemaRegistry.serialize({
+            data: {
+                ssn: "123-45-6789",
+            },
+            schema: keySchemaObject,
+            schemaType: SCHEMA_TYPE_AVRO,
+        }),
+        value: schemaRegistry.serialize({
+            data: {
+                firstName: "John",
+                lastName: "Doe",
+            },
+            schema: valueSchemaObject,
+            schemaType: SCHEMA_TYPE_AVRO,
+        }),
+        headers: {
+            mykey: "myvalue",
+        },
+        offset: 0,
+        partition: 0,
+        time: new Date()
+    }
+];
+```
+
+### Complex schemas : Manage union types
+
+When dealing with complex schemas, especially those involving union types, you'll have to ensure that the data you serialize matches the expected schema structure.
+Union types in Avro allow a field to hold values of different types, which can complicate serialization and deserialization.
+For example, if you have a union type schema like this:
+
+```json
+{
+  "name": "MyUnionSchema",
+  "type": "record",
+  "fields": [
+    {
+      "name": "myField",
+      "type": ["null", "string"]
+    }
+  ]
+}
+```
+
+Here `myField` can either be a string or null. When serializing data for this schema, you need to ensure that the value you provide matches one of the types in the union.
+Your object must respect the goavro serialization rules, which means you need to provide the correct type for `myField`:
+
+```javascript
+export const productionOrder = {
+    myField: { string: "My awesome value" }
+};
+```
+
+Here you have to define the type explicitly as `string` to match the schema.
+**Be careful**, in your schema, you'll have to define the _null_ value first in the union type, otherwise the serialization will fail.
+
+In order to help you with complex schemas, you can use the [nested-avro-schema](https://github.com/mostafa/nested-avro-schema) project, which provides a way to define complex Avro schemas in a more structured way.

--- a/docs/writers.md
+++ b/docs/writers.md
@@ -1,0 +1,145 @@
+# Manage writers (producers) with xk6-kafka
+
+## What is the Writer?
+
+The writer is a Kafka producer that allows you to send messages to Kafka topics in a load test using k6. It is configured based on the environment and application settings.
+Once you've created the writer, you can use it to produce messages to Kafka topics.
+Writers are unique for each topic, if you want to produce messages to multiple topics, you need to create a writer for each topic.
+
+## Writers Configuration
+### Create single writer
+```javascript
+const producer = new Writer({
+    brokers, // The broker addresses as array, e.g., ["localhost:9092"]
+    topic: topicName, // The topic name to produce messages to
+    autoCreateTopic: false, // Should the topic be created automatically if it doesn't exist?
+    compression: CODEC_SNAPPY, // Optional: Compression codec to use for messages
+    tls: tlsConfig
+});// Config object for TLS settings, if needed
+
+
+producer.produce({
+    messages: messagesToProduce
+});
+```
+
+_tips : here you can find more options for your writer:_
+
+```golang
+type WriterConfig struct {
+	AutoCreateTopic bool          `json:"autoCreateTopic"`
+	ConnectLogger   bool          `json:"connectLogger"`
+	MaxAttempts     int           `json:"maxAttempts"`
+	BatchSize       int           `json:"batchSize"`
+	BatchBytes      int           `json:"batchBytes"`
+	RequiredAcks    int           `json:"requiredAcks"`
+	Topic           string        `json:"topic"`
+	Balancer        string        `json:"balancer"`
+	Compression     string        `json:"compression"`
+	Brokers         []string      `json:"brokers"`
+	BatchTimeout    time.Duration `json:"batchTimeout"`
+	ReadTimeout     time.Duration `json:"readTimeout"`
+	WriteTimeout    time.Duration `json:"writeTimeout"`
+	SASL            SASLConfig    `json:"sasl"`
+	TLS             TLSConfig     `json:"tls"`
+}
+```
+
+_All the parameters are named following the camelCase notation style_
+
+
+### Manage multiple writers for various topics
+A lot of times, you will need to produce messages to multiple topics. In this case, you can create a writer for each topic and manage them in an object or a map.
+```javascript
+function createKafkaWriters(brokers, topicNamesList, tlsConfig)  {
+    const writers = new Map();
+    Object.values(topicNamesList).forEach(topicName => {
+        writers.set(topicName, new Writer({
+            brokers,
+            topic: topicName,
+            autoCreateTopic: false,
+            compression: CODEC_SNAPPY,
+            tls: tlsConfig,
+        }));
+    });
+    return writers;
+}
+```
+You can then use the `writers` map to produce messages to the topics:
+```javascript
+const producers = createKafkaWriters(brokers, topicNamesList, tlsConfig);
+producers.get(topicName).produce({
+    messages: messagesToProduce
+});
+```
+
+## Message Production
+
+You can see above that the `produce` method is used to send messages to the Kafka topic. 
+The `messages` parameter is an array of messages you want to send. 
+Each message can be a simple string or an object, depending on your Kafka topic configuration.
+
+You can here find an example of how to create a messages:
+
+### Create a JSON message
+
+```javascript
+let messages = [
+    {
+        // The data type of the key is JSON
+        key: schemaRegistry.serialize({
+            data: {
+                correlationId: "test-id-abc-" + index,
+            },
+            schemaType: SCHEMA_TYPE_JSON,
+        }),
+        // The data type of the value is JSON
+        value: schemaRegistry.serialize({
+            data: {
+                name: "xk6-kafka",
+                version: "0.9.0",
+                author: "Mostafa Moradian",
+                description:
+                    "k6 extension to load test Apache Kafka with support for Avro messages",
+                index: index,
+            },
+            schemaType: SCHEMA_TYPE_JSON,
+        }),
+        headers: {
+            mykey: "myvalue",
+        },
+        offset: index,
+        partition: 0,
+        time: new Date(), // Will be converted to timestamp automatically
+    }
+]
+```
+
+### Create an AVRO message
+For this usage, you'll need to have the Avro schema registered in your Schema Registry.
+Please refer to the [Schema Registry documentation](./schema-registry.md) for more details on how to register schemas.
+```javascript
+let messages = [
+    {
+        key: schemaRegistry.serialize({
+            data: {
+                correlationId: "test-id-abc-" + index,
+            },
+            schema: myAvroKeySchema, // The Javascript object containing Avro schema for the key
+            schemaType: SCHEMA_TYPE_AVRO,
+        }),
+        value: schemaRegistry.serialize({
+            data: {
+                name: "xk6-kafka",
+                version: "0.9.0",
+                author: "Mostafa Moradian",
+                description:
+                    "k6 extension to load test Apache Kafka with support for Avro messages",
+                index: index,
+            },
+            schema: myAvroValueSchema, // The Javascript object containing Avro schema for the key
+            schemaType: SCHEMA_TYPE_AVRO,
+        })// Will be converted to timestamp automatically
+    }
+]
+```

--- a/scripts/test_avro_with_auth_schema_registry.js
+++ b/scripts/test_avro_with_auth_schema_registry.js
@@ -1,0 +1,134 @@
+import {check} from "k6";
+import {
+    Writer,
+    Reader,
+    Connection,
+    SchemaRegistry,
+    KEY,
+    VALUE,
+    TOPIC_NAME_STRATEGY,
+    RECORD_NAME_STRATEGY,
+    SCHEMA_TYPE_AVRO,
+} from "k6/x/kafka"; // import kafka extension
+
+const brokers = ["localhost:9092"];
+const topic = "com.example.person";
+
+// Kafka writer and reader
+const writer = new Writer({
+    brokers,
+    topic,
+    autoCreateTopic: true,
+});
+
+const reader = new Reader({
+    brokers,
+    topic,
+});
+
+const connection = new Connection({
+    address: brokers[0],
+});
+
+// Schema registry with authentication (basic auth)
+const schemaRegistry = new SchemaRegistry({
+    url: "http://localhost:8081",
+    username: "your-username", // 🔐 Replace with your actual username
+    password: "your-password", // 🔐 Replace with your actual password
+});
+
+// Only VU 0 creates the topic
+if (__VU == 0) {
+    connection.createTopic({topic});
+}
+
+// Define schemas
+const keySchema = `{
+  "name": "KeySchema",
+  "type": "record",
+  "namespace": "com.example.key",
+  "fields": [
+    { "name": "ssn", "type": "string" }
+  ]
+}`;
+
+const valueSchema = `{
+  "name": "ValueSchema",
+  "type": "record",
+  "namespace": "com.example.value",
+  "fields": [
+    { "name": "firstName", "type": "string" },
+    { "name": "lastName", "type": "string" }
+  ]
+}`;
+
+// Get subject names using strategies
+const keySubjectName = schemaRegistry.getSubjectName({
+    topic,
+    element: KEY,
+    subjectNameStrategy: TOPIC_NAME_STRATEGY,
+    schema: keySchema,
+});
+
+const valueSubjectName = schemaRegistry.getSubjectName({
+    topic,
+    element: VALUE,
+    subjectNameStrategy: RECORD_NAME_STRATEGY,
+    schema: valueSchema,
+});
+
+// Fetch schema objects from registry (must be pre-registered!)
+const keySchemaObject = schemaRegistry.getSchema({subject: keySubjectName});
+const valueSchemaObject = schemaRegistry.getSchema({subject: valueSubjectName});
+
+export default function () {
+    for (let index = 0; index < 100; index++) {
+        const messages = [
+            {
+                key: schemaRegistry.serialize({
+                    data: {ssn: "ssn-" + index},
+                    schema: keySchemaObject,
+                    schemaType: SCHEMA_TYPE_AVRO,
+                }),
+                value: schemaRegistry.serialize({
+                    data: {
+                        firstName: "firstName-" + index,
+                        lastName: "lastName-" + index,
+                    },
+                    schema: valueSchemaObject,
+                    schemaType: SCHEMA_TYPE_AVRO,
+                }),
+            },
+        ];
+        writer.produce({messages});
+    }
+
+    const messages = reader.consume({limit: 20});
+
+    check(messages, {
+        "20 messages returned": (msgs) => msgs.length === 20,
+        "key starts with 'ssn-'": (msgs) =>
+            schemaRegistry.deserialize({
+                data: msgs[0].key,
+                schema: keySchemaObject,
+                schemaType: SCHEMA_TYPE_AVRO,
+            }).ssn.startsWith("ssn-"),
+        "value contains correct fields": (msgs) => {
+            const value = schemaRegistry.deserialize({
+                data: msgs[0].value,
+                schema: valueSchemaObject,
+                schemaType: SCHEMA_TYPE_AVRO,
+            });
+            return value.firstName.startsWith("firstName-") && value.lastName.startsWith("lastName-");
+        },
+    });
+}
+
+export function teardown() {
+    if (__VU == 0) {
+        connection.deleteTopic(topic);
+    }
+    writer.close();
+    reader.close();
+    connection.close();
+}

--- a/scripts/test_avro_with_multiple_topics.js
+++ b/scripts/test_avro_with_multiple_topics.js
@@ -1,0 +1,72 @@
+import { check } from "k6";
+import {
+    Writer,
+    Reader,
+    Connection,
+} from "k6/x/kafka";
+
+const brokers = ["localhost:9092"];
+const topics = ["topicA", "topicB"];
+
+// Create Kafka connection
+const connection = new Connection({ address: brokers[0] });
+
+// Create topics (only once for VU 0)
+if (__VU === 0) {
+    for (const topic of topics) {
+        connection.createTopic({ topic });
+    }
+}
+
+// Create writers and readers for each topic
+const writers = new Map();
+const readers = new Map();
+
+topics.forEach((topic) => {
+    writers.set(topic, new Writer({
+        brokers,
+        topic,
+        autoCreateTopic: false,
+    }));
+
+    readers.set(topic, new Reader({
+        brokers,
+        topic,
+    }));
+});
+
+export default function () {
+    for (const topic of topics) {
+        const writer = writers.get(topic);
+
+        // Produce 5 messages to each topic
+        const messages = Array.from({ length: 5 }, (_, i) => ({
+            key: `key-${topic}-${i}`,
+            value: `value-${topic}-${i}`,
+        }));
+
+        writer.produce({ messages });
+
+        // Read back 5 messages from each topic
+        const reader = readers.get(topic);
+        const consumed = reader.consume({ limit: 5 });
+
+        check(consumed, {
+            [`${topic}: 5 messages read`]: (msgs) => msgs.length === 5,
+            [`${topic}: first key correct`]: (msgs) => msgs[0].key.includes(`key-${topic}`),
+        });
+    }
+}
+
+export function teardown() {
+    if (__VU === 0) {
+        for (const topic of topics) {
+            connection.deleteTopic(topic);
+        }
+    }
+
+    // Close all clients
+    writers.forEach((w) => w.close());
+    readers.forEach((r) => r.close());
+    connection.close();
+}


### PR DESCRIPTION
This PR introduces documentation updates that explain how to configure and manage Kafka writers (producers) and readers (consumers) when using xk6-kafka in our load testing framework. The goal is to provide clear usage patterns for sending and consuming messages, handling multiple topics, and working with Avro or JSON schemas.

✅ What's included:
New documentation for:
- Creating and managing writers per topic
- Creating and managing readers per topic
- Producing and consuming JSON and Avro messages
- Using Schema Registry with authentication

Code examples for:
- Multi-topic producer/consumer setups
- Serializing and deserializing messages using Schema Registry with Auth

📌 Notes:
- Schema Registry authentication is now illustrated in the examples
- Follows the existing pattern for environment-specific configurations