### PR TITLE
fix: add avro.Fixed type serialization support

### DIFF
--- a/avro.go
+++ b/avro.go
@@ -69,7 +69,7 @@ func convertPrimitiveType(data any, schema avro.Schema) (any, error) {
 			if len(arr) != size {
 				return nil, fmt.Errorf("%w: expected %d elements, got %d", ErrCannotConvertToByte, size, len(arr))
 			}
-			fixedBytes := reflect.New(reflect.ArrayOf(size, reflect.TypeOf(uint8(0)))).Elem()
+			fixedBytes := reflect.New(reflect.ArrayOf(size, reflect.TypeFor[uint8]())).Elem()
 			for i, v := range arr {
 				convertedByte, err := convertNumericValueToByte(v)
 				if err != nil {

--- a/avro.go
+++ b/avro.go
@@ -368,9 +368,10 @@ func convertUnionField(fieldValue any, unionSchema *avro.UnionSchema) (any, erro
 			}
 			// Other named types, try converting first
 			converted, err := convertFloat64ToIntForIntegerFields(fieldValue, actualType)
-			if err == nil {
-				return map[string]any{namedSchema.FullName(): converted}, nil
+			if err != nil {
+				continue
 			}
+			return map[string]any{namedSchema.FullName(): converted}, nil
 		}
 	}
 

--- a/avro.go
+++ b/avro.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"reflect"
 	"strings"
 
 	"github.com/hamba/avro/v2"
@@ -58,6 +59,27 @@ func convertNumericValueToByte(value any) (byte, error) {
 // Handles float64->int32/int64 conversion and array->bytes conversion.
 func convertPrimitiveType(data any, schema avro.Schema) (any, error) {
 	switch schema.Type() {
+	case avro.Fixed:
+		fixedSchema, ok := schema.(*avro.FixedSchema)
+		if !ok {
+			return data, nil
+		}
+		size := fixedSchema.Size()
+		if arr, ok := data.([]any); ok {
+			if len(arr) != size {
+				return nil, fmt.Errorf("%w: expected %d elements, got %d", ErrCannotConvertToByte, size, len(arr))
+			}
+			fixedBytes := reflect.New(reflect.ArrayOf(size, reflect.TypeOf(uint8(0)))).Elem()
+			for i, v := range arr {
+				convertedByte, err := convertNumericValueToByte(v)
+				if err != nil {
+					return nil, fmt.Errorf("%w at index %d: %T", ErrCannotConvertToByte, i, v)
+				}
+				fixedBytes.Index(i).SetUint(uint64(convertedByte))
+			}
+			return fixedBytes.Interface(), nil
+		}
+		return data, nil
 	case avro.Bytes:
 		// Convert array of numbers to []byte for bytes fields
 		if arr, ok := data.([]any); ok {
@@ -92,7 +114,7 @@ func convertPrimitiveType(data any, schema avro.Schema) (any, error) {
 		}
 		return data, nil
 	case avro.Record, avro.Error, avro.Ref, avro.Enum, avro.Array, avro.Map,
-		avro.Union, avro.Fixed, avro.String, avro.Float, avro.Double,
+		avro.Union, avro.String, avro.Float, avro.Double,
 		avro.Boolean, avro.Null:
 		fallthrough
 	default:
@@ -370,7 +392,7 @@ func convertFloat64ToIntForIntegerFields(data any, schema avro.Schema) (any, err
 	}
 
 	switch schema.Type() {
-	case avro.Bytes, avro.Int, avro.Long:
+	case avro.Bytes, avro.Int, avro.Long, avro.Fixed:
 		return convertPrimitiveType(data, schema)
 	case avro.Record:
 		return convertRecordFields(data, schema, func(fieldValue any, fieldType avro.Schema) (any, error) {
@@ -427,7 +449,7 @@ func convertFloat64ToIntForIntegerFields(data any, schema avro.Schema) (any, err
 			return data, nil
 		}
 		return convertUnionField(data, unionSchema)
-	case avro.Error, avro.Ref, avro.Enum, avro.Fixed, avro.String,
+	case avro.Error, avro.Ref, avro.Enum, avro.String,
 		avro.Float, avro.Double, avro.Boolean, avro.Null:
 		fallthrough
 	default:

--- a/avro_conversion_test.go
+++ b/avro_conversion_test.go
@@ -203,8 +203,13 @@ func TestConvertPrimitiveType_Fixed(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name:    "array of float64",
-			data:    []any{float64(1), float64(2), float64(3), float64(4), float64(5), float64(6), float64(7), float64(8), float64(9), float64(10), float64(11), float64(12), float64(13), float64(14), float64(15), float64(16)},
+			name: "array of float64",
+			data: []any{
+				float64(1), float64(2), float64(3), float64(4),
+				float64(5), float64(6), float64(7), float64(8),
+				float64(9), float64(10), float64(11), float64(12),
+				float64(13), float64(14), float64(15), float64(16),
+			},
 			wantErr: false,
 		},
 		{
@@ -218,8 +223,14 @@ func TestConvertPrimitiveType_Fixed(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name:    "wrong size - too many",
-			data:    []any{float64(1), float64(2), float64(3), float64(4), float64(5), float64(6), float64(7), float64(8), float64(9), float64(10), float64(11), float64(12), float64(13), float64(14), float64(15), float64(16), float64(17), float64(18)},
+			name: "wrong size - too many",
+			data: []any{
+				float64(1), float64(2), float64(3), float64(4),
+				float64(5), float64(6), float64(7), float64(8),
+				float64(9), float64(10), float64(11), float64(12),
+				float64(13), float64(14), float64(15), float64(16),
+				float64(17), float64(18),
+			},
 			wantErr: true,
 		},
 		{

--- a/avro_conversion_test.go
+++ b/avro_conversion_test.go
@@ -193,6 +193,54 @@ func TestConvertPrimitiveType_Long(t *testing.T) {
 	}
 }
 
+func TestConvertPrimitiveType_Fixed(t *testing.T) {
+	schema, err := avro.Parse(`{"type": "fixed", "name": "MD5", "size": 16}`)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name    string
+		data    any
+		wantErr bool
+	}{
+		{
+			name:    "array of float64",
+			data:    []any{float64(1), float64(2), float64(3), float64(4), float64(5), float64(6), float64(7), float64(8), float64(9), float64(10), float64(11), float64(12), float64(13), float64(14), float64(15), float64(16)},
+			wantErr: false,
+		},
+		{
+			name:    "array of int",
+			data:    []any{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16},
+			wantErr: false,
+		},
+		{
+			name:    "wrong size - too few",
+			data:    []any{float64(1), float64(2), float64(3)},
+			wantErr: true,
+		},
+		{
+			name:    "wrong size - too many",
+			data:    []any{float64(1), float64(2), float64(3), float64(4), float64(5), float64(6), float64(7), float64(8), float64(9), float64(10), float64(11), float64(12), float64(13), float64(14), float64(15), float64(16), float64(17), float64(18)},
+			wantErr: true,
+		},
+		{
+			name:    "value out of byte range",
+			data:    []any{float64(256)},
+			wantErr: true,
+		},
+	}
+
+	for _, testCase := range tests {
+		t.Run(testCase.name, func(t *testing.T) {
+			_, err := convertPrimitiveType(testCase.data, schema)
+			if testCase.wantErr {
+				assert.Error(t, err)
+			} else {
+				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
 func TestConvertUnionField_Null(t *testing.T) {
 	schema, err := avro.Parse(`["null", "string"]`)
 	require.NoError(t, err)

--- a/scripts/test_avro_complex_schema.js
+++ b/scripts/test_avro_complex_schema.js
@@ -120,7 +120,22 @@ export function setup() {
     schemaType: SCHEMA_TYPE_AVRO,
   });
 
-  // 4. Register UserPreferences record
+  // 4. Register SHA256 fixed type (for testing fixed type serialization)
+  const sha256Schema = `{
+    "name": "SHA256",
+    "type": "fixed",
+    "namespace": "com.example.complex",
+    "size": 32
+  }`;
+
+  const sha256Subject = "com.example.complex.SHA256";
+  const sha256SchemaObject = schemaRegistry.createSchema({
+    subject: sha256Subject,
+    schema: sha256Schema,
+    schemaType: SCHEMA_TYPE_AVRO,
+  });
+
+  // 5. Register UserPreferences record
   const userPreferencesSchema = `{
     "name": "UserPreferences",
     "type": "record",
@@ -372,6 +387,11 @@ export function setup() {
         subject: coordinatesSubject,
         version: coordinatesSchemaObject.version || 1, // Use version 1 if version is 0
       },
+      {
+        name: "com.example.complex.SHA256",
+        subject: sha256Subject,
+        version: sha256SchemaObject.version || 1, // Use version 1 if version is 0
+      },
     ],
   });
 
@@ -462,6 +482,11 @@ const valueSchema = `{
     {
       "name": "data",
       "type": ["null", "bytes"],
+      "default": null
+    },
+    {
+      "name": "hash",
+      "type": ["null", "com.example.complex.SHA256"],
       "default": null
     }
   ]
@@ -556,6 +581,8 @@ export default function (data) {
       // For Avro bytes, use array of numbers (0-255) representing byte values
       // In JSON encoding, bytes are typically base64 strings, but arrays work too
       data: index % 5 === 0 ? null : [1, 2, 3, 4, 5, index], // Nullable bytes as array of numbers
+      // For Fixed type (SHA256), use array of 32 numbers representing byte values
+      hash: index % 3 === 0 ? null : Array.from({ length: 32 }, (_, i) => (i + index) % 256),
     };
 
     let messages = [

--- a/scripts/test_avro_complex_schema.js
+++ b/scripts/test_avro_complex_schema.js
@@ -582,7 +582,10 @@ export default function (data) {
       // In JSON encoding, bytes are typically base64 strings, but arrays work too
       data: index % 5 === 0 ? null : [1, 2, 3, 4, 5, index], // Nullable bytes as array of numbers
       // For Fixed type (SHA256), use array of 32 numbers representing byte values
-      hash: index % 3 === 0 ? null : Array.from({ length: 32 }, (_, i) => (i + index) % 256),
+      hash:
+        index % 3 === 0
+          ? null
+          : Array.from({ length: 32 }, (_, i) => (i + index) % 256),
     };
 
     let messages = [


### PR DESCRIPTION
Adds support for Avro Fixed type fields in k6 scripts. When producing Avro messages with Fixed type fields (e.g., SHA-256 hashes, UUIDs), the data now correctly converts `[]any` to `[N]byte` arrays that hamba/avro accepts.

Changes:
- Add `avro.Fixed` case in `convertPrimitiveType` using `reflect.ArrayOf` to create fixed-size byte arrays
- Update `convertFloat64ToIntForIntegerFields` to route Fixed types for conversion
- Add unit tests for Fixed type conversion
- Add SHA256 Fixed type to integration test script

Fixes #384