### PR TITLE
Add v2 protobuf serde support and docs

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -34,7 +34,9 @@
 
 - Custom writer balancer configuration is not supported on the Confluent compatibility path. Scripts that rely on `balancer` or a custom balancer callback should stay on the v1 surface until a replacement is implemented.
 - `AdminClient.listTopics()` returns structured topic metadata. The deprecated `Connection.listTopics()` alias keeps the old `string[]` shape.
-- `SCHEMA_TYPE_PROTOBUF` remains exported, but Protobuf Schema Registry serialization and deserialization are not implemented in `v2.0.0`. The supported Schema Registry formats in `v2.0.0` are Avro and JSON, and the Protobuf serde path is planned for `v2.1`.
+- `SCHEMA_TYPE_PROTOBUF` is implemented in `v2.1.0` for `SchemaRegistry.serialize()` and `SchemaRegistry.deserialize()` in both Schema Registry and standalone flows.
+- New schema metadata for Protobuf: `messageName` and `dependencies` (standalone import map).
+- New container metadata for Protobuf: `protobufFormat` with `"object"` (default) and `"bytes"` modes.
 
 ## Metric Compatibility Appendix
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ If you want to learn more about the extension, read the [article](https://grafan
 ## Supported Features
 
 - **v2.0.0 Performance**: Up to ~383,000 msgs/sec (unacked) with 50 VUs using new `Producer`/`Consumer` constructors with `confluentinc/confluent-kafka-go` (**~3.3x faster than the current v1.x.x/main branch**, which reaches ~115,637 msgs/sec on the same `scripts/test_json.js` benchmark and machine)
-- Produce/consume messages as [String](https://github.com/mostafa/xk6-kafka/blob/main/scripts/test_string.js), [JSON](https://github.com/mostafa/xk6-kafka/blob/main/scripts/test_json.js), [ByteArray](https://github.com/mostafa/xk6-kafka/blob/main/scripts/test_bytes.js), [Avro](https://github.com/mostafa/xk6-kafka/blob/main/scripts/test_avro_with_schema_registry.js) and [JSON Schema](https://github.com/mostafa/xk6-kafka/blob/main/scripts/test_jsonschema_with_schema_registry.js) formats
+- Produce/consume messages as [String](https://github.com/mostafa/xk6-kafka/blob/main/scripts/test_string.js), [JSON](https://github.com/mostafa/xk6-kafka/blob/main/scripts/test_json.js), [ByteArray](https://github.com/mostafa/xk6-kafka/blob/main/scripts/test_bytes.js), [Avro](https://github.com/mostafa/xk6-kafka/blob/main/scripts/test_avro_with_schema_registry.js), [JSON Schema](https://github.com/mostafa/xk6-kafka/blob/main/scripts/test_jsonschema_with_schema_registry.js), and [Protobuf](https://github.com/mostafa/xk6-kafka/blob/main/scripts/test_protobuf_with_schema_registry.js) formats
 - Support for user-provided [Avro](https://github.com/mostafa/xk6-kafka/blob/main/scripts/test_avro_no_schema_registry.js) and JSON Schema key and value schemas in the script
 - Authentication with [SASL PLAIN, SCRAM, SSL and AWS IAM](https://github.com/mostafa/xk6-kafka/blob/main/scripts/test_sasl_auth.js)
 - Create, list and delete [topics](https://github.com/mostafa/xk6-kafka/blob/main/scripts/test_topics.js)
@@ -29,9 +29,6 @@ If you want to learn more about the extension, read the [article](https://grafan
 - Support for [headers](https://github.com/mostafa/xk6-kafka/blob/main/scripts/test_json.js) on produced and consumed messages
 - Lots of exported metrics, as shown in the list of [emitted metrics](https://github.com/mostafa/xk6-kafka/blob/main/README.md#emitted-metrics)
 - TypeScript definitions available in [api-docs/v2/index.d.ts](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts)
-
-> [!NOTE]
-> `SCHEMA_TYPE_PROTOBUF` remains exported for the planned v2 Schema Registry API, but Protobuf Schema Registry serdes are not implemented in `v2.0.0`. The supported Schema Registry formats in `v2.0.0` are Avro and JSON, and the Protobuf serde path is planned for `v2.1`.
 
 > [!WARNING]
 > The v2 API is going to take over the v1 API in the future. So, please migrate to the v2 API as soon as possible, as the v1 API will be deprecated soon.

--- a/api-docs/index.d.ts
+++ b/api-docs/index.d.ts
@@ -84,9 +84,7 @@ export enum GROUP_BALANCERS {
   GROUP_BALANCER_RACK_AFFINITY = "group_balancer_rack_affinity",
 }
 
-/* Schema types used in identifying schema and data type in serdes.
-SCHEMA_TYPE_PROTOBUF remains exported, but Schema Registry Protobuf serdes
-are planned for v2.1 and are not available in v2.0.0. */
+/* Schema types used in identifying schema and data type in serdes. */
 export enum SCHEMA_TYPES {
   SCHEMA_TYPE_STRING = "STRING",
   SCHEMA_TYPE_BYTES = "BYTES",
@@ -300,6 +298,8 @@ export interface Schema {
   version: number;
   references: Reference[];
   subject: string;
+  messageName?: string;
+  dependencies?: Record<string, string>;
 }
 
 export interface SubjectNameConfig {
@@ -307,12 +307,14 @@ export interface SubjectNameConfig {
   topic: string;
   element: ELEMENT_TYPES;
   subjectNameStrategy: SUBJECT_NAME_STRATEGY;
+  messageName?: string;
 }
 
 export interface Container {
   data: any;
   schema: Schema;
   schemaType: SCHEMA_TYPES;
+  protobufFormat?: "object" | "bytes";
 }
 
 export interface JKSConfig {

--- a/api-docs/v2/docs/classes/AdminClient.md
+++ b/api-docs/v2/docs/classes/AdminClient.md
@@ -4,7 +4,7 @@
 
 # Class: AdminClient
 
-Defined in: [index.d.ts:467](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L467)
+Defined in: [index.d.ts:469](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L469)
 
 ## Classdesc
 
@@ -31,7 +31,7 @@ adminClient.close();
 
 > **new AdminClient**(`connectionConfig`): `AdminClient`
 
-Defined in: [index.d.ts:468](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L468)
+Defined in: [index.d.ts:470](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L470)
 
 #### Parameters
 
@@ -49,7 +49,7 @@ Defined in: [index.d.ts:468](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **close**(): `void`
 
-Defined in: [index.d.ts:473](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L473)
+Defined in: [index.d.ts:475](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L475)
 
 #### Returns
 
@@ -61,7 +61,7 @@ Defined in: [index.d.ts:473](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **createTopic**(`topicConfig`): `void`
 
-Defined in: [index.d.ts:469](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L469)
+Defined in: [index.d.ts:471](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L471)
 
 #### Parameters
 
@@ -79,7 +79,7 @@ Defined in: [index.d.ts:469](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **deleteTopic**(`topic`): `void`
 
-Defined in: [index.d.ts:470](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L470)
+Defined in: [index.d.ts:472](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L472)
 
 #### Parameters
 
@@ -97,7 +97,7 @@ Defined in: [index.d.ts:470](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **getMetadata**(`topic`): [`TopicMetadata`](../interfaces/TopicMetadata.md)
 
-Defined in: [index.d.ts:472](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L472)
+Defined in: [index.d.ts:474](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L474)
 
 #### Parameters
 
@@ -115,7 +115,7 @@ Defined in: [index.d.ts:472](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **listTopics**(): [`TopicInfo`](../interfaces/TopicInfo.md)[]
 
-Defined in: [index.d.ts:471](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L471)
+Defined in: [index.d.ts:473](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L473)
 
 #### Returns
 

--- a/api-docs/v2/docs/classes/Connection.md
+++ b/api-docs/v2/docs/classes/Connection.md
@@ -4,7 +4,7 @@
 
 # ~~Class: Connection~~
 
-Defined in: [index.d.ts:479](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L479)
+Defined in: [index.d.ts:481](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L481)
 
 ## Deprecated
 
@@ -16,7 +16,7 @@ Use `AdminClient` instead. `Connection` remains as a compatibility alias in v2.x
 
 > **new Connection**(`connectionConfig`): `Connection`
 
-Defined in: [index.d.ts:486](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L486)
+Defined in: [index.d.ts:488](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L488)
 
 #### Parameters
 
@@ -38,7 +38,7 @@ Connection configuration.
 
 > **close**(): `void`
 
-Defined in: [index.d.ts:512](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L512)
+Defined in: [index.d.ts:514](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L514)
 
 #### Returns
 
@@ -58,7 +58,7 @@ Close the connection.
 
 > **createTopic**(`topicConfig`): `void`
 
-Defined in: [index.d.ts:493](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L493)
+Defined in: [index.d.ts:495](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L495)
 
 #### Parameters
 
@@ -84,7 +84,7 @@ Create a new topic.
 
 > **deleteTopic**(`topic`): `void`
 
-Defined in: [index.d.ts:500](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L500)
+Defined in: [index.d.ts:502](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L502)
 
 #### Parameters
 
@@ -110,7 +110,7 @@ Delete a topic.
 
 > **listTopics**(): `string`[]
 
-Defined in: [index.d.ts:506](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L506)
+Defined in: [index.d.ts:508](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L508)
 
 #### Returns
 

--- a/api-docs/v2/docs/classes/Consumer.md
+++ b/api-docs/v2/docs/classes/Consumer.md
@@ -4,7 +4,7 @@
 
 # Class: Consumer
 
-Defined in: [index.d.ts:413](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L413)
+Defined in: [index.d.ts:415](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L415)
 
 ## Classdesc
 
@@ -32,7 +32,7 @@ consumer.close();
 
 > **new Consumer**(`readerConfig`): `Consumer`
 
-Defined in: [index.d.ts:414](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L414)
+Defined in: [index.d.ts:416](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L416)
 
 #### Parameters
 
@@ -50,7 +50,7 @@ Defined in: [index.d.ts:414](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **close**(): `void`
 
-Defined in: [index.d.ts:420](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L420)
+Defined in: [index.d.ts:422](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L422)
 
 #### Returns
 
@@ -62,7 +62,7 @@ Defined in: [index.d.ts:420](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **commitOffsets**(): `void`
 
-Defined in: [index.d.ts:418](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L418)
+Defined in: [index.d.ts:420](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L420)
 
 #### Returns
 
@@ -74,7 +74,7 @@ Defined in: [index.d.ts:418](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **consume**(`consumeConfig`): [`Message`](../interfaces/Message.md)[]
 
-Defined in: [index.d.ts:415](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L415)
+Defined in: [index.d.ts:417](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L417)
 
 #### Parameters
 
@@ -92,7 +92,7 @@ Defined in: [index.d.ts:415](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **position**(`partition`): `number`
 
-Defined in: [index.d.ts:417](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L417)
+Defined in: [index.d.ts:419](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L419)
 
 #### Parameters
 
@@ -110,7 +110,7 @@ Defined in: [index.d.ts:417](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **seek**(`partition`, `offset`): `void`
 
-Defined in: [index.d.ts:416](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L416)
+Defined in: [index.d.ts:418](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L418)
 
 #### Parameters
 
@@ -132,7 +132,7 @@ Defined in: [index.d.ts:416](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **stats**(): [`ConsumerStats`](../interfaces/ConsumerStats.md)
 
-Defined in: [index.d.ts:419](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L419)
+Defined in: [index.d.ts:421](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L421)
 
 #### Returns
 

--- a/api-docs/v2/docs/classes/Producer.md
+++ b/api-docs/v2/docs/classes/Producer.md
@@ -4,7 +4,7 @@
 
 # Class: Producer
 
-Defined in: [index.d.ts:360](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L360)
+Defined in: [index.d.ts:362](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L362)
 
 ## Classdesc
 
@@ -40,7 +40,7 @@ producer.close();
 
 > **new Producer**(`writerConfig`): `Producer`
 
-Defined in: [index.d.ts:361](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L361)
+Defined in: [index.d.ts:363](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L363)
 
 #### Parameters
 
@@ -58,7 +58,7 @@ Defined in: [index.d.ts:361](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **close**(): `void`
 
-Defined in: [index.d.ts:365](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L365)
+Defined in: [index.d.ts:367](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L367)
 
 #### Returns
 
@@ -70,7 +70,7 @@ Defined in: [index.d.ts:365](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **flush**(): `void`
 
-Defined in: [index.d.ts:363](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L363)
+Defined in: [index.d.ts:365](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L365)
 
 #### Returns
 
@@ -82,7 +82,7 @@ Defined in: [index.d.ts:363](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **produce**(`produceConfig`): `void`
 
-Defined in: [index.d.ts:362](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L362)
+Defined in: [index.d.ts:364](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L364)
 
 #### Parameters
 
@@ -100,7 +100,7 @@ Defined in: [index.d.ts:362](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **stats**(): [`ProducerStats`](../interfaces/ProducerStats.md)
 
-Defined in: [index.d.ts:364](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L364)
+Defined in: [index.d.ts:366](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L366)
 
 #### Returns
 

--- a/api-docs/v2/docs/classes/Reader.md
+++ b/api-docs/v2/docs/classes/Reader.md
@@ -4,7 +4,7 @@
 
 # ~~Class: Reader~~
 
-Defined in: [index.d.ts:426](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L426)
+Defined in: [index.d.ts:428](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L428)
 
 ## Deprecated
 
@@ -16,7 +16,7 @@ Use `Consumer` instead. `Reader` remains as a compatibility alias in v2.x.
 
 > **new Reader**(`readerConfig`): `Reader`
 
-Defined in: [index.d.ts:433](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L433)
+Defined in: [index.d.ts:435](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L435)
 
 #### Parameters
 
@@ -38,7 +38,7 @@ Reader configuration.
 
 > **close**(): `void`
 
-Defined in: [index.d.ts:446](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L446)
+Defined in: [index.d.ts:448](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L448)
 
 #### Returns
 
@@ -58,7 +58,7 @@ Close the reader.
 
 > **consume**(`consumeConfig`): [`Message`](../interfaces/Message.md)[]
 
-Defined in: [index.d.ts:440](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L440)
+Defined in: [index.d.ts:442](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L442)
 
 #### Parameters
 

--- a/api-docs/v2/docs/classes/SchemaRegistry.md
+++ b/api-docs/v2/docs/classes/SchemaRegistry.md
@@ -4,7 +4,7 @@
 
 # Class: SchemaRegistry
 
-Defined in: [index.d.ts:567](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L567)
+Defined in: [index.d.ts:569](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L569)
 
 ## Classdesc
 
@@ -65,7 +65,7 @@ writer.produce({
 
 > **new SchemaRegistry**(`schemaRegistryConfig`): `SchemaRegistry`
 
-Defined in: [index.d.ts:574](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L574)
+Defined in: [index.d.ts:576](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L576)
 
 #### Parameters
 
@@ -87,7 +87,7 @@ Schema Registry configuration.
 
 > **createSchema**(`schema`): [`Schema`](../interfaces/Schema.md)
 
-Defined in: [index.d.ts:588](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L588)
+Defined in: [index.d.ts:590](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L590)
 
 #### Parameters
 
@@ -113,7 +113,7 @@ Create or update a schema on Schema Registry.
 
 > **deserialize**(`container`): `any`
 
-Defined in: [index.d.ts:609](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L609)
+Defined in: [index.d.ts:611](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L611)
 
 #### Parameters
 
@@ -139,7 +139,7 @@ Deserializes the given data and schema into its original form.
 
 > **getSchema**(`schema`): [`Schema`](../interfaces/Schema.md)
 
-Defined in: [index.d.ts:581](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L581)
+Defined in: [index.d.ts:583](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L583)
 
 #### Parameters
 
@@ -165,7 +165,7 @@ Get a schema from Schema Registry by version and subject.
 
 > **getSubjectName**(`subjectNameConfig`): `string`
 
-Defined in: [index.d.ts:595](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L595)
+Defined in: [index.d.ts:597](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L597)
 
 #### Parameters
 
@@ -191,7 +191,7 @@ Returns the subject name for the given SubjectNameConfig.
 
 > **serialize**(`container`): `Uint8Array`
 
-Defined in: [index.d.ts:602](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L602)
+Defined in: [index.d.ts:604](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L604)
 
 #### Parameters
 

--- a/api-docs/v2/docs/classes/Writer.md
+++ b/api-docs/v2/docs/classes/Writer.md
@@ -4,7 +4,7 @@
 
 # ~~Class: Writer~~
 
-Defined in: [index.d.ts:371](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L371)
+Defined in: [index.d.ts:373](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L373)
 
 ## Deprecated
 
@@ -16,7 +16,7 @@ Use `Producer` instead. `Writer` remains as a compatibility alias in v2.x.
 
 > **new Writer**(`writerConfig`): `Writer`
 
-Defined in: [index.d.ts:378](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L378)
+Defined in: [index.d.ts:380](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L380)
 
 #### Parameters
 
@@ -38,7 +38,7 @@ Writer configuration.
 
 > **close**(): `void`
 
-Defined in: [index.d.ts:391](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L391)
+Defined in: [index.d.ts:393](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L393)
 
 #### Returns
 
@@ -58,7 +58,7 @@ Close the writer.
 
 > **produce**(`produceConfig`): `void`
 
-Defined in: [index.d.ts:385](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L385)
+Defined in: [index.d.ts:387](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L387)
 
 #### Parameters
 

--- a/api-docs/v2/docs/enumerations/SCHEMA_TYPES.md
+++ b/api-docs/v2/docs/enumerations/SCHEMA_TYPES.md
@@ -4,7 +4,7 @@
 
 # Enumeration: SCHEMA_TYPES
 
-Defined in: [index.d.ts:90](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L90)
+Defined in: [index.d.ts:88](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L88)
 
 ## Enumeration Members
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:90](https://github.com/mostafa/xk6-kafka/blob/main/api-d
 
 > **SCHEMA_TYPE_AVRO**: `"AVRO"`
 
-Defined in: [index.d.ts:93](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L93)
+Defined in: [index.d.ts:91](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L91)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:93](https://github.com/mostafa/xk6-kafka/blob/main/api-d
 
 > **SCHEMA_TYPE_BYTES**: `"BYTES"`
 
-Defined in: [index.d.ts:92](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L92)
+Defined in: [index.d.ts:90](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L90)
 
 ---
 
@@ -28,7 +28,7 @@ Defined in: [index.d.ts:92](https://github.com/mostafa/xk6-kafka/blob/main/api-d
 
 > **SCHEMA_TYPE_JSON**: `"JSON"`
 
-Defined in: [index.d.ts:94](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L94)
+Defined in: [index.d.ts:92](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L92)
 
 ---
 
@@ -36,7 +36,7 @@ Defined in: [index.d.ts:94](https://github.com/mostafa/xk6-kafka/blob/main/api-d
 
 > **SCHEMA_TYPE_PROTOBUF**: `"PROTOBUF"`
 
-Defined in: [index.d.ts:95](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L95)
+Defined in: [index.d.ts:93](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L93)
 
 ---
 
@@ -44,4 +44,4 @@ Defined in: [index.d.ts:95](https://github.com/mostafa/xk6-kafka/blob/main/api-d
 
 > **SCHEMA_TYPE_STRING**: `"STRING"`
 
-Defined in: [index.d.ts:91](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L91)
+Defined in: [index.d.ts:89](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L89)

--- a/api-docs/v2/docs/enumerations/TIME.md
+++ b/api-docs/v2/docs/enumerations/TIME.md
@@ -4,7 +4,7 @@
 
 # Enumeration: TIME
 
-Defined in: [index.d.ts:99](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L99)
+Defined in: [index.d.ts:97](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L97)
 
 ## Enumeration Members
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:99](https://github.com/mostafa/xk6-kafka/blob/main/api-d
 
 > **HOUR**: `3600000000000`
 
-Defined in: [index.d.ts:105](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L105)
+Defined in: [index.d.ts:103](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L103)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:105](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **MICROSECOND**: `1000`
 
-Defined in: [index.d.ts:101](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L101)
+Defined in: [index.d.ts:99](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L99)
 
 ---
 
@@ -28,7 +28,7 @@ Defined in: [index.d.ts:101](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **MILLISECOND**: `1000000`
 
-Defined in: [index.d.ts:102](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L102)
+Defined in: [index.d.ts:100](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L100)
 
 ---
 
@@ -36,7 +36,7 @@ Defined in: [index.d.ts:102](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **MINUTE**: `60000000000`
 
-Defined in: [index.d.ts:104](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L104)
+Defined in: [index.d.ts:102](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L102)
 
 ---
 
@@ -44,7 +44,7 @@ Defined in: [index.d.ts:104](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **NANOSECOND**: `1`
 
-Defined in: [index.d.ts:100](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L100)
+Defined in: [index.d.ts:98](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L98)
 
 ---
 
@@ -52,4 +52,4 @@ Defined in: [index.d.ts:100](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **SECOND**: `1000000000`
 
-Defined in: [index.d.ts:103](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L103)
+Defined in: [index.d.ts:101](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L101)

--- a/api-docs/v2/docs/functions/LoadJKS.md
+++ b/api-docs/v2/docs/functions/LoadJKS.md
@@ -6,7 +6,7 @@
 
 > **LoadJKS**(`jksConfig`): [`JKS`](../interfaces/JKS.md)
 
-Defined in: [index.d.ts:629](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L629)
+Defined in: [index.d.ts:631](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L631)
 
 **`Function`**
 

--- a/api-docs/v2/docs/interfaces/BasicAuth.md
+++ b/api-docs/v2/docs/interfaces/BasicAuth.md
@@ -4,7 +4,7 @@
 
 # Interface: BasicAuth
 
-Defined in: [index.d.ts:161](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L161)
+Defined in: [index.d.ts:159](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L159)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:161](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **password**: `string`
 
-Defined in: [index.d.ts:163](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L163)
+Defined in: [index.d.ts:161](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L161)
 
 ---
 
@@ -20,4 +20,4 @@ Defined in: [index.d.ts:163](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **username**: `string`
 
-Defined in: [index.d.ts:162](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L162)
+Defined in: [index.d.ts:160](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L160)

--- a/api-docs/v2/docs/interfaces/ConfigEntry.md
+++ b/api-docs/v2/docs/interfaces/ConfigEntry.md
@@ -4,7 +4,7 @@
 
 # Interface: ConfigEntry
 
-Defined in: [index.d.ts:244](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L244)
+Defined in: [index.d.ts:242](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L242)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:244](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **configName**: `string`
 
-Defined in: [index.d.ts:245](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L245)
+Defined in: [index.d.ts:243](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L243)
 
 ---
 
@@ -20,4 +20,4 @@ Defined in: [index.d.ts:245](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **configValue**: `string`
 
-Defined in: [index.d.ts:246](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L246)
+Defined in: [index.d.ts:244](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L244)

--- a/api-docs/v2/docs/interfaces/ConnectionConfig.md
+++ b/api-docs/v2/docs/interfaces/ConnectionConfig.md
@@ -4,7 +4,7 @@
 
 # Interface: ConnectionConfig
 
-Defined in: [index.d.ts:230](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L230)
+Defined in: [index.d.ts:228](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L228)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:230](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > `optional` **address?**: `string`
 
-Defined in: [index.d.ts:231](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L231)
+Defined in: [index.d.ts:229](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L229)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:231](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > `optional` **brokers?**: `string`[]
 
-Defined in: [index.d.ts:232](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L232)
+Defined in: [index.d.ts:230](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L230)
 
 ---
 
@@ -28,7 +28,7 @@ Defined in: [index.d.ts:232](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **sasl**: [`SASLConfig`](SASLConfig.md)
 
-Defined in: [index.d.ts:233](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L233)
+Defined in: [index.d.ts:231](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L231)
 
 ---
 
@@ -36,4 +36,4 @@ Defined in: [index.d.ts:233](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **tls**: [`TLSConfig`](TLSConfig.md)
 
-Defined in: [index.d.ts:234](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L234)
+Defined in: [index.d.ts:232](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L232)

--- a/api-docs/v2/docs/interfaces/ConsumeConfig.md
+++ b/api-docs/v2/docs/interfaces/ConsumeConfig.md
@@ -4,7 +4,7 @@
 
 # Interface: ConsumeConfig
 
-Defined in: [index.d.ts:215](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L215)
+Defined in: [index.d.ts:213](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L213)
 
 Configuration for Consume method.
 
@@ -14,7 +14,7 @@ Configuration for Consume method.
 
 > **expectTimeout**: `boolean`
 
-Defined in: [index.d.ts:226](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L226)
+Defined in: [index.d.ts:224](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L224)
 
 If true, return whatever messages have been collected when maxWait is
 passed.
@@ -25,7 +25,7 @@ passed.
 
 > `optional` **limit?**: `number`
 
-Defined in: [index.d.ts:217](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L217)
+Defined in: [index.d.ts:215](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L215)
 
 collect this many messages before returning.
 
@@ -35,7 +35,7 @@ collect this many messages before returning.
 
 > `optional` **maxMessages?**: `number`
 
-Defined in: [index.d.ts:219](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L219)
+Defined in: [index.d.ts:217](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L217)
 
 preferred v2 alias for limit.
 
@@ -45,6 +45,6 @@ preferred v2 alias for limit.
 
 > **nanoPrecision**: `boolean`
 
-Defined in: [index.d.ts:221](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L221)
+Defined in: [index.d.ts:219](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L219)
 
 If true, returned message RFC3339 timestamps carry nanosecond precision.

--- a/api-docs/v2/docs/interfaces/ConsumerStats.md
+++ b/api-docs/v2/docs/interfaces/ConsumerStats.md
@@ -4,7 +4,7 @@
 
 # Interface: ConsumerStats
 
-Defined in: [index.d.ts:262](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L262)
+Defined in: [index.d.ts:260](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L260)
 
 ## Properties
 
@@ -12,4 +12,4 @@ Defined in: [index.d.ts:262](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **assignments**: `number`
 
-Defined in: [index.d.ts:263](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L263)
+Defined in: [index.d.ts:261](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L261)

--- a/api-docs/v2/docs/interfaces/Container.md
+++ b/api-docs/v2/docs/interfaces/Container.md
@@ -4,7 +4,7 @@
 
 # Interface: Container
 
-Defined in: [index.d.ts:312](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L312)
+Defined in: [index.d.ts:313](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L313)
 
 ## Properties
 
@@ -12,7 +12,15 @@ Defined in: [index.d.ts:312](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **data**: `any`
 
-Defined in: [index.d.ts:313](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L313)
+Defined in: [index.d.ts:314](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L314)
+
+---
+
+### protobufFormat?
+
+> `optional` **protobufFormat?**: `"object"` \| `"bytes"`
+
+Defined in: [index.d.ts:317](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L317)
 
 ---
 
@@ -20,7 +28,7 @@ Defined in: [index.d.ts:313](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **schema**: [`Schema`](Schema.md)
 
-Defined in: [index.d.ts:314](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L314)
+Defined in: [index.d.ts:315](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L315)
 
 ---
 
@@ -28,4 +36,4 @@ Defined in: [index.d.ts:314](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **schemaType**: [`SCHEMA_TYPES`](../enumerations/SCHEMA_TYPES.md)
 
-Defined in: [index.d.ts:315](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L315)
+Defined in: [index.d.ts:316](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L316)

--- a/api-docs/v2/docs/interfaces/JKS.md
+++ b/api-docs/v2/docs/interfaces/JKS.md
@@ -4,7 +4,7 @@
 
 # Interface: JKS
 
-Defined in: [index.d.ts:327](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L327)
+Defined in: [index.d.ts:329](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L329)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:327](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **clientCertsPem**: `string`[]
 
-Defined in: [index.d.ts:328](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L328)
+Defined in: [index.d.ts:330](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L330)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:328](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **clientKeyPem**: `string`
 
-Defined in: [index.d.ts:329](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L329)
+Defined in: [index.d.ts:331](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L331)
 
 ---
 
@@ -28,4 +28,4 @@ Defined in: [index.d.ts:329](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **serverCaPem**: `string`
 
-Defined in: [index.d.ts:330](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L330)
+Defined in: [index.d.ts:332](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L332)

--- a/api-docs/v2/docs/interfaces/JKSConfig.md
+++ b/api-docs/v2/docs/interfaces/JKSConfig.md
@@ -4,7 +4,7 @@
 
 # Interface: JKSConfig
 
-Defined in: [index.d.ts:318](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L318)
+Defined in: [index.d.ts:320](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L320)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:318](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **clientCertAlias**: `string`
 
-Defined in: [index.d.ts:321](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L321)
+Defined in: [index.d.ts:323](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L323)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:321](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **clientKeyAlias**: `string`
 
-Defined in: [index.d.ts:322](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L322)
+Defined in: [index.d.ts:324](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L324)
 
 ---
 
@@ -28,7 +28,7 @@ Defined in: [index.d.ts:322](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **clientKeyPassword**: `string`
 
-Defined in: [index.d.ts:323](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L323)
+Defined in: [index.d.ts:325](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L325)
 
 ---
 
@@ -36,7 +36,7 @@ Defined in: [index.d.ts:323](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **password**: `string`
 
-Defined in: [index.d.ts:320](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L320)
+Defined in: [index.d.ts:322](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L322)
 
 ---
 
@@ -44,7 +44,7 @@ Defined in: [index.d.ts:320](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **path**: `string`
 
-Defined in: [index.d.ts:319](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L319)
+Defined in: [index.d.ts:321](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L321)
 
 ---
 
@@ -52,4 +52,4 @@ Defined in: [index.d.ts:319](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **serverCaAlias**: `string`
 
-Defined in: [index.d.ts:324](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L324)
+Defined in: [index.d.ts:326](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L326)

--- a/api-docs/v2/docs/interfaces/Message.md
+++ b/api-docs/v2/docs/interfaces/Message.md
@@ -4,7 +4,7 @@
 
 # Interface: Message
 
-Defined in: [index.d.ts:149](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L149)
+Defined in: [index.d.ts:147](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L147)
 
 Message format for producing messages to a topic.
 @note: The message format will be adopted by the reader at some point.
@@ -15,7 +15,7 @@ Message format for producing messages to a topic.
 
 > **headers**: `Map`\<`string`, `any`\>
 
-Defined in: [index.d.ts:156](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L156)
+Defined in: [index.d.ts:154](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L154)
 
 ---
 
@@ -23,7 +23,7 @@ Defined in: [index.d.ts:156](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **highwaterMark**: `number`
 
-Defined in: [index.d.ts:153](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L153)
+Defined in: [index.d.ts:151](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L151)
 
 ---
 
@@ -31,7 +31,7 @@ Defined in: [index.d.ts:153](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **key**: `Uint8Array`
 
-Defined in: [index.d.ts:154](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L154)
+Defined in: [index.d.ts:152](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L152)
 
 ---
 
@@ -39,7 +39,7 @@ Defined in: [index.d.ts:154](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **offset**: `number`
 
-Defined in: [index.d.ts:152](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L152)
+Defined in: [index.d.ts:150](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L150)
 
 ---
 
@@ -47,7 +47,7 @@ Defined in: [index.d.ts:152](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **partition**: `number`
 
-Defined in: [index.d.ts:151](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L151)
+Defined in: [index.d.ts:149](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L149)
 
 ---
 
@@ -55,7 +55,7 @@ Defined in: [index.d.ts:151](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **time**: `Date`
 
-Defined in: [index.d.ts:157](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L157)
+Defined in: [index.d.ts:155](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L155)
 
 ---
 
@@ -63,7 +63,7 @@ Defined in: [index.d.ts:157](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **topic**: `string`
 
-Defined in: [index.d.ts:150](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L150)
+Defined in: [index.d.ts:148](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L148)
 
 ---
 
@@ -71,4 +71,4 @@ Defined in: [index.d.ts:150](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **value**: `Uint8Array`
 
-Defined in: [index.d.ts:155](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L155)
+Defined in: [index.d.ts:153](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L153)

--- a/api-docs/v2/docs/interfaces/PartitionInfo.md
+++ b/api-docs/v2/docs/interfaces/PartitionInfo.md
@@ -4,7 +4,7 @@
 
 # Interface: PartitionInfo
 
-Defined in: [index.d.ts:272](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L272)
+Defined in: [index.d.ts:270](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L270)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:272](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **error**: `any`
 
-Defined in: [index.d.ts:277](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L277)
+Defined in: [index.d.ts:275](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L275)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:277](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **id**: `number`
 
-Defined in: [index.d.ts:273](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L273)
+Defined in: [index.d.ts:271](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L271)
 
 ---
 
@@ -28,7 +28,7 @@ Defined in: [index.d.ts:273](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **isrs**: `number`[]
 
-Defined in: [index.d.ts:276](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L276)
+Defined in: [index.d.ts:274](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L274)
 
 ---
 
@@ -36,7 +36,7 @@ Defined in: [index.d.ts:276](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **leader**: `number`
 
-Defined in: [index.d.ts:274](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L274)
+Defined in: [index.d.ts:272](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L272)
 
 ---
 
@@ -44,4 +44,4 @@ Defined in: [index.d.ts:274](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **replicas**: `number`[]
 
-Defined in: [index.d.ts:275](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L275)
+Defined in: [index.d.ts:273](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L273)

--- a/api-docs/v2/docs/interfaces/ProduceConfig.md
+++ b/api-docs/v2/docs/interfaces/ProduceConfig.md
@@ -4,7 +4,7 @@
 
 # Interface: ProduceConfig
 
-Defined in: [index.d.ts:175](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L175)
+Defined in: [index.d.ts:173](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L173)
 
 ## Properties
 
@@ -12,4 +12,4 @@ Defined in: [index.d.ts:175](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **messages**: [`Message`](Message.md)[]
 
-Defined in: [index.d.ts:176](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L176)
+Defined in: [index.d.ts:174](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L174)

--- a/api-docs/v2/docs/interfaces/ProducerStats.md
+++ b/api-docs/v2/docs/interfaces/ProducerStats.md
@@ -4,7 +4,7 @@
 
 # Interface: ProducerStats
 
-Defined in: [index.d.ts:258](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L258)
+Defined in: [index.d.ts:256](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L256)
 
 ## Properties
 
@@ -12,4 +12,4 @@ Defined in: [index.d.ts:258](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **pending**: `number`
 
-Defined in: [index.d.ts:259](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L259)
+Defined in: [index.d.ts:257](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L257)

--- a/api-docs/v2/docs/interfaces/ReaderConfig.md
+++ b/api-docs/v2/docs/interfaces/ReaderConfig.md
@@ -4,7 +4,7 @@
 
 # Interface: ReaderConfig
 
-Defined in: [index.d.ts:180](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L180)
+Defined in: [index.d.ts:178](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L178)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:180](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **brokers**: `string`[]
 
-Defined in: [index.d.ts:181](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L181)
+Defined in: [index.d.ts:179](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L179)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:181](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **commitInterval**: `number`
 
-Defined in: [index.d.ts:196](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L196)
+Defined in: [index.d.ts:194](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L194)
 
 ---
 
@@ -28,7 +28,7 @@ Defined in: [index.d.ts:196](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **connectLogger**: `boolean`
 
-Defined in: [index.d.ts:206](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L206)
+Defined in: [index.d.ts:204](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L204)
 
 ---
 
@@ -36,7 +36,7 @@ Defined in: [index.d.ts:206](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **groupBalancers**: [`GROUP_BALANCERS`](../enumerations/GROUP_BALANCERS.md)[]
 
-Defined in: [index.d.ts:194](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L194)
+Defined in: [index.d.ts:192](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L192)
 
 ---
 
@@ -44,7 +44,7 @@ Defined in: [index.d.ts:194](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **groupId**: `string`
 
-Defined in: [index.d.ts:182](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L182)
+Defined in: [index.d.ts:180](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L180)
 
 ---
 
@@ -52,7 +52,7 @@ Defined in: [index.d.ts:182](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > `optional` **groupID?**: `string`
 
-Defined in: [index.d.ts:184](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L184)
+Defined in: [index.d.ts:182](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L182)
 
 #### Deprecated
 
@@ -64,7 +64,7 @@ Use `groupId` instead.
 
 > **groupTopics**: `string`[]
 
-Defined in: [index.d.ts:185](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L185)
+Defined in: [index.d.ts:183](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L183)
 
 ---
 
@@ -72,7 +72,7 @@ Defined in: [index.d.ts:185](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **heartbeatInterval**: `number`
 
-Defined in: [index.d.ts:195](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L195)
+Defined in: [index.d.ts:193](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L193)
 
 ---
 
@@ -80,7 +80,7 @@ Defined in: [index.d.ts:195](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **isolationLevel**: [`ISOLATION_LEVEL`](../enumerations/ISOLATION_LEVEL.md)
 
-Defined in: [index.d.ts:208](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L208)
+Defined in: [index.d.ts:206](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L206)
 
 ---
 
@@ -88,7 +88,7 @@ Defined in: [index.d.ts:208](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **joinGroupBackoff**: `number`
 
-Defined in: [index.d.ts:201](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L201)
+Defined in: [index.d.ts:199](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L199)
 
 ---
 
@@ -96,7 +96,7 @@ Defined in: [index.d.ts:201](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **maxAttempts**: `number`
 
-Defined in: [index.d.ts:207](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L207)
+Defined in: [index.d.ts:205](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L205)
 
 ---
 
@@ -104,7 +104,7 @@ Defined in: [index.d.ts:207](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **maxBytes**: `number`
 
-Defined in: [index.d.ts:190](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L190)
+Defined in: [index.d.ts:188](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L188)
 
 ---
 
@@ -112,7 +112,7 @@ Defined in: [index.d.ts:190](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **maxWait**: `string`
 
-Defined in: [index.d.ts:192](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L192)
+Defined in: [index.d.ts:190](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L190)
 
 ---
 
@@ -120,7 +120,7 @@ Defined in: [index.d.ts:192](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **minBytes**: `number`
 
-Defined in: [index.d.ts:189](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L189)
+Defined in: [index.d.ts:187](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L187)
 
 ---
 
@@ -128,7 +128,7 @@ Defined in: [index.d.ts:189](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **offset**: `number`
 
-Defined in: [index.d.ts:209](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L209)
+Defined in: [index.d.ts:207](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L207)
 
 ---
 
@@ -136,7 +136,7 @@ Defined in: [index.d.ts:209](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **partition**: `number`
 
-Defined in: [index.d.ts:187](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L187)
+Defined in: [index.d.ts:185](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L185)
 
 ---
 
@@ -144,7 +144,7 @@ Defined in: [index.d.ts:187](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **partitionWatchInterval**: `number`
 
-Defined in: [index.d.ts:197](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L197)
+Defined in: [index.d.ts:195](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L195)
 
 ---
 
@@ -152,7 +152,7 @@ Defined in: [index.d.ts:197](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **queueCapacity**: `number`
 
-Defined in: [index.d.ts:188](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L188)
+Defined in: [index.d.ts:186](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L186)
 
 ---
 
@@ -160,7 +160,7 @@ Defined in: [index.d.ts:188](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **readBackoffMax**: `number`
 
-Defined in: [index.d.ts:205](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L205)
+Defined in: [index.d.ts:203](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L203)
 
 ---
 
@@ -168,7 +168,7 @@ Defined in: [index.d.ts:205](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **readBackoffMin**: `number`
 
-Defined in: [index.d.ts:204](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L204)
+Defined in: [index.d.ts:202](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L202)
 
 ---
 
@@ -176,7 +176,7 @@ Defined in: [index.d.ts:204](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **readBatchTimeout**: `number`
 
-Defined in: [index.d.ts:191](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L191)
+Defined in: [index.d.ts:189](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L189)
 
 ---
 
@@ -184,7 +184,7 @@ Defined in: [index.d.ts:191](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **readLagInterval**: `number`
 
-Defined in: [index.d.ts:193](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L193)
+Defined in: [index.d.ts:191](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L191)
 
 ---
 
@@ -192,7 +192,7 @@ Defined in: [index.d.ts:193](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **rebalanceTimeout**: `number`
 
-Defined in: [index.d.ts:200](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L200)
+Defined in: [index.d.ts:198](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L198)
 
 ---
 
@@ -200,7 +200,7 @@ Defined in: [index.d.ts:200](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **retentionTime**: `number`
 
-Defined in: [index.d.ts:202](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L202)
+Defined in: [index.d.ts:200](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L200)
 
 ---
 
@@ -208,7 +208,7 @@ Defined in: [index.d.ts:202](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **sasl**: [`SASLConfig`](SASLConfig.md)
 
-Defined in: [index.d.ts:210](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L210)
+Defined in: [index.d.ts:208](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L208)
 
 ---
 
@@ -216,7 +216,7 @@ Defined in: [index.d.ts:210](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **sessionTimeout**: `number`
 
-Defined in: [index.d.ts:199](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L199)
+Defined in: [index.d.ts:197](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L197)
 
 ---
 
@@ -224,7 +224,7 @@ Defined in: [index.d.ts:199](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **startOffset**: [`START_OFFSETS`](../enumerations/START_OFFSETS.md)
 
-Defined in: [index.d.ts:203](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L203)
+Defined in: [index.d.ts:201](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L201)
 
 ---
 
@@ -232,7 +232,7 @@ Defined in: [index.d.ts:203](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **tls**: [`TLSConfig`](TLSConfig.md)
 
-Defined in: [index.d.ts:211](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L211)
+Defined in: [index.d.ts:209](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L209)
 
 ---
 
@@ -240,7 +240,7 @@ Defined in: [index.d.ts:211](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **topic**: `string`
 
-Defined in: [index.d.ts:186](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L186)
+Defined in: [index.d.ts:184](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L184)
 
 ---
 
@@ -248,4 +248,4 @@ Defined in: [index.d.ts:186](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **watchPartitionChanges**: `boolean`
 
-Defined in: [index.d.ts:198](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L198)
+Defined in: [index.d.ts:196](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L196)

--- a/api-docs/v2/docs/interfaces/Reference.md
+++ b/api-docs/v2/docs/interfaces/Reference.md
@@ -4,7 +4,7 @@
 
 # Interface: Reference
 
-Defined in: [index.d.ts:288](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L288)
+Defined in: [index.d.ts:286](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L286)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:288](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **name**: `string`
 
-Defined in: [index.d.ts:289](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L289)
+Defined in: [index.d.ts:287](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L287)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:289](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **subject**: `string`
 
-Defined in: [index.d.ts:290](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L290)
+Defined in: [index.d.ts:288](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L288)
 
 ---
 
@@ -28,4 +28,4 @@ Defined in: [index.d.ts:290](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **version**: `number`
 
-Defined in: [index.d.ts:291](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L291)
+Defined in: [index.d.ts:289](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L289)

--- a/api-docs/v2/docs/interfaces/ReplicaAssignment.md
+++ b/api-docs/v2/docs/interfaces/ReplicaAssignment.md
@@ -4,7 +4,7 @@
 
 # Interface: ReplicaAssignment
 
-Defined in: [index.d.ts:238](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L238)
+Defined in: [index.d.ts:236](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L236)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:238](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **partition**: `number`
 
-Defined in: [index.d.ts:239](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L239)
+Defined in: [index.d.ts:237](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L237)
 
 ---
 
@@ -20,4 +20,4 @@ Defined in: [index.d.ts:239](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **replicas**: `number`[]
 
-Defined in: [index.d.ts:240](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L240)
+Defined in: [index.d.ts:238](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L238)

--- a/api-docs/v2/docs/interfaces/SASLConfig.md
+++ b/api-docs/v2/docs/interfaces/SASLConfig.md
@@ -4,7 +4,7 @@
 
 # Interface: SASLConfig
 
-Defined in: [index.d.ts:109](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L109)
+Defined in: [index.d.ts:107](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L107)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:109](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **algorithm**: [`SASL_MECHANISMS`](../enumerations/SASL_MECHANISMS.md)
 
-Defined in: [index.d.ts:112](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L112)
+Defined in: [index.d.ts:110](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L110)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:112](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **awsProfile**: `string`
 
-Defined in: [index.d.ts:113](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L113)
+Defined in: [index.d.ts:111](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L111)
 
 ---
 
@@ -28,7 +28,7 @@ Defined in: [index.d.ts:113](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **password**: `string`
 
-Defined in: [index.d.ts:111](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L111)
+Defined in: [index.d.ts:109](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L109)
 
 ---
 
@@ -36,4 +36,4 @@ Defined in: [index.d.ts:111](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **username**: `string`
 
-Defined in: [index.d.ts:110](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L110)
+Defined in: [index.d.ts:108](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L108)

--- a/api-docs/v2/docs/interfaces/Schema.md
+++ b/api-docs/v2/docs/interfaces/Schema.md
@@ -4,15 +4,23 @@
 
 # Interface: Schema
 
-Defined in: [index.d.ts:295](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L295)
+Defined in: [index.d.ts:293](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L293)
 
 ## Properties
+
+### dependencies?
+
+> `optional` **dependencies?**: `Record`\<`string`, `string`\>
+
+Defined in: [index.d.ts:302](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L302)
+
+---
 
 ### enableCaching
 
 > **enableCaching**: `boolean`
 
-Defined in: [index.d.ts:296](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L296)
+Defined in: [index.d.ts:294](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L294)
 
 ---
 
@@ -20,7 +28,15 @@ Defined in: [index.d.ts:296](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **id**: `number`
 
-Defined in: [index.d.ts:297](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L297)
+Defined in: [index.d.ts:295](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L295)
+
+---
+
+### messageName?
+
+> `optional` **messageName?**: `string`
+
+Defined in: [index.d.ts:301](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L301)
 
 ---
 
@@ -28,7 +44,7 @@ Defined in: [index.d.ts:297](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **references**: [`Reference`](Reference.md)[]
 
-Defined in: [index.d.ts:301](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L301)
+Defined in: [index.d.ts:299](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L299)
 
 ---
 
@@ -36,7 +52,7 @@ Defined in: [index.d.ts:301](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **schema**: `string`
 
-Defined in: [index.d.ts:298](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L298)
+Defined in: [index.d.ts:296](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L296)
 
 ---
 
@@ -44,7 +60,7 @@ Defined in: [index.d.ts:298](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **schemaType**: [`SCHEMA_TYPES`](../enumerations/SCHEMA_TYPES.md)
 
-Defined in: [index.d.ts:299](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L299)
+Defined in: [index.d.ts:297](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L297)
 
 ---
 
@@ -52,7 +68,7 @@ Defined in: [index.d.ts:299](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **subject**: `string`
 
-Defined in: [index.d.ts:302](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L302)
+Defined in: [index.d.ts:300](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L300)
 
 ---
 
@@ -60,4 +76,4 @@ Defined in: [index.d.ts:302](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **version**: `number`
 
-Defined in: [index.d.ts:300](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L300)
+Defined in: [index.d.ts:298](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L298)

--- a/api-docs/v2/docs/interfaces/SchemaRegistryConfig.md
+++ b/api-docs/v2/docs/interfaces/SchemaRegistryConfig.md
@@ -4,7 +4,7 @@
 
 # Interface: SchemaRegistryConfig
 
-Defined in: [index.d.ts:167](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L167)
+Defined in: [index.d.ts:165](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L165)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:167](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **basicAuth**: [`BasicAuth`](BasicAuth.md)
 
-Defined in: [index.d.ts:170](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L170)
+Defined in: [index.d.ts:168](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L168)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:170](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **enableCaching**: `boolean`
 
-Defined in: [index.d.ts:169](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L169)
+Defined in: [index.d.ts:167](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L167)
 
 ---
 
@@ -28,7 +28,7 @@ Defined in: [index.d.ts:169](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **tls**: [`TLSConfig`](TLSConfig.md)
 
-Defined in: [index.d.ts:171](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L171)
+Defined in: [index.d.ts:169](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L169)
 
 ---
 
@@ -36,4 +36,4 @@ Defined in: [index.d.ts:171](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **url**: `string`
 
-Defined in: [index.d.ts:168](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L168)
+Defined in: [index.d.ts:166](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L166)

--- a/api-docs/v2/docs/interfaces/SubjectNameConfig.md
+++ b/api-docs/v2/docs/interfaces/SubjectNameConfig.md
@@ -16,6 +16,14 @@ Defined in: [index.d.ts:308](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 ---
 
+### messageName?
+
+> `optional` **messageName?**: `string`
+
+Defined in: [index.d.ts:310](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L310)
+
+---
+
 ### schema
 
 > **schema**: `string`

--- a/api-docs/v2/docs/interfaces/TLSConfig.md
+++ b/api-docs/v2/docs/interfaces/TLSConfig.md
@@ -4,7 +4,7 @@
 
 # Interface: TLSConfig
 
-Defined in: [index.d.ts:117](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L117)
+Defined in: [index.d.ts:115](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L115)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:117](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **clientCertPem**: `string`
 
-Defined in: [index.d.ts:121](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L121)
+Defined in: [index.d.ts:119](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L119)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:121](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **clientKeyPem**: `string`
 
-Defined in: [index.d.ts:122](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L122)
+Defined in: [index.d.ts:120](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L120)
 
 ---
 
@@ -28,7 +28,7 @@ Defined in: [index.d.ts:122](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **enableTls**: `boolean`
 
-Defined in: [index.d.ts:118](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L118)
+Defined in: [index.d.ts:116](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L116)
 
 ---
 
@@ -36,7 +36,7 @@ Defined in: [index.d.ts:118](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **insecureSkipTlsVerify**: `boolean`
 
-Defined in: [index.d.ts:119](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L119)
+Defined in: [index.d.ts:117](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L117)
 
 ---
 
@@ -44,7 +44,7 @@ Defined in: [index.d.ts:119](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **minVersion**: [`TLS_VERSIONS`](../enumerations/TLS_VERSIONS.md)
 
-Defined in: [index.d.ts:120](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L120)
+Defined in: [index.d.ts:118](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L118)
 
 ---
 
@@ -52,4 +52,4 @@ Defined in: [index.d.ts:120](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **serverCaPem**: `string`
 
-Defined in: [index.d.ts:123](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L123)
+Defined in: [index.d.ts:121](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L121)

--- a/api-docs/v2/docs/interfaces/TopicConfig.md
+++ b/api-docs/v2/docs/interfaces/TopicConfig.md
@@ -4,7 +4,7 @@
 
 # Interface: TopicConfig
 
-Defined in: [index.d.ts:250](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L250)
+Defined in: [index.d.ts:248](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L248)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:250](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **configEntries**: [`ConfigEntry`](ConfigEntry.md)[]
 
-Defined in: [index.d.ts:255](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L255)
+Defined in: [index.d.ts:253](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L253)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:255](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **numPartitions**: `number`
 
-Defined in: [index.d.ts:252](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L252)
+Defined in: [index.d.ts:250](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L250)
 
 ---
 
@@ -28,7 +28,7 @@ Defined in: [index.d.ts:252](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **replicaAssignments**: [`ReplicaAssignment`](ReplicaAssignment.md)[]
 
-Defined in: [index.d.ts:254](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L254)
+Defined in: [index.d.ts:252](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L252)
 
 ---
 
@@ -36,7 +36,7 @@ Defined in: [index.d.ts:254](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **replicationFactor**: `number`
 
-Defined in: [index.d.ts:253](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L253)
+Defined in: [index.d.ts:251](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L251)
 
 ---
 
@@ -44,4 +44,4 @@ Defined in: [index.d.ts:253](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **topic**: `string`
 
-Defined in: [index.d.ts:251](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L251)
+Defined in: [index.d.ts:249](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L249)

--- a/api-docs/v2/docs/interfaces/TopicInfo.md
+++ b/api-docs/v2/docs/interfaces/TopicInfo.md
@@ -4,7 +4,7 @@
 
 # Interface: TopicInfo
 
-Defined in: [index.d.ts:266](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L266)
+Defined in: [index.d.ts:264](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L264)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:266](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **error**: `any`
 
-Defined in: [index.d.ts:269](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L269)
+Defined in: [index.d.ts:267](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L267)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:269](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **partitions**: `number`
 
-Defined in: [index.d.ts:268](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L268)
+Defined in: [index.d.ts:266](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L266)
 
 ---
 
@@ -28,4 +28,4 @@ Defined in: [index.d.ts:268](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **topic**: `string`
 
-Defined in: [index.d.ts:267](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L267)
+Defined in: [index.d.ts:265](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L265)

--- a/api-docs/v2/docs/interfaces/TopicMetadata.md
+++ b/api-docs/v2/docs/interfaces/TopicMetadata.md
@@ -4,7 +4,7 @@
 
 # Interface: TopicMetadata
 
-Defined in: [index.d.ts:280](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L280)
+Defined in: [index.d.ts:278](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L278)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:280](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **error**: `any`
 
-Defined in: [index.d.ts:283](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L283)
+Defined in: [index.d.ts:281](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L281)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:283](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **partitions**: [`PartitionInfo`](PartitionInfo.md)[]
 
-Defined in: [index.d.ts:282](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L282)
+Defined in: [index.d.ts:280](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L280)
 
 ---
 
@@ -28,4 +28,4 @@ Defined in: [index.d.ts:282](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **topic**: `string`
 
-Defined in: [index.d.ts:281](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L281)
+Defined in: [index.d.ts:279](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L279)

--- a/api-docs/v2/docs/interfaces/WriterConfig.md
+++ b/api-docs/v2/docs/interfaces/WriterConfig.md
@@ -4,7 +4,7 @@
 
 # Interface: WriterConfig
 
-Defined in: [index.d.ts:127](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L127)
+Defined in: [index.d.ts:125](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L125)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:127](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **autoCreateTopic**: `boolean`
 
-Defined in: [index.d.ts:130](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L130)
+Defined in: [index.d.ts:128](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L128)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:130](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **balancer**: [`BALANCERS`](../enumerations/BALANCERS.md) \| [`BalancerFunction`](../type-aliases/BalancerFunction.md)
 
-Defined in: [index.d.ts:131](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L131)
+Defined in: [index.d.ts:129](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L129)
 
 ---
 
@@ -28,7 +28,7 @@ Defined in: [index.d.ts:131](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **batchBytes**: `number`
 
-Defined in: [index.d.ts:134](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L134)
+Defined in: [index.d.ts:132](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L132)
 
 ---
 
@@ -36,7 +36,7 @@ Defined in: [index.d.ts:134](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **batchSize**: `number`
 
-Defined in: [index.d.ts:133](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L133)
+Defined in: [index.d.ts:131](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L131)
 
 ---
 
@@ -44,7 +44,7 @@ Defined in: [index.d.ts:133](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **batchTimeout**: `number`
 
-Defined in: [index.d.ts:135](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L135)
+Defined in: [index.d.ts:133](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L133)
 
 ---
 
@@ -52,7 +52,7 @@ Defined in: [index.d.ts:135](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **brokers**: `string`[]
 
-Defined in: [index.d.ts:128](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L128)
+Defined in: [index.d.ts:126](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L126)
 
 ---
 
@@ -60,7 +60,7 @@ Defined in: [index.d.ts:128](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **compression**: [`COMPRESSION_CODECS`](../enumerations/COMPRESSION_CODECS.md)
 
-Defined in: [index.d.ts:139](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L139)
+Defined in: [index.d.ts:137](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L137)
 
 ---
 
@@ -68,7 +68,7 @@ Defined in: [index.d.ts:139](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **connectLogger**: `boolean`
 
-Defined in: [index.d.ts:142](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L142)
+Defined in: [index.d.ts:140](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L140)
 
 ---
 
@@ -76,7 +76,7 @@ Defined in: [index.d.ts:142](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **maxAttempts**: `number`
 
-Defined in: [index.d.ts:132](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L132)
+Defined in: [index.d.ts:130](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L130)
 
 ---
 
@@ -84,7 +84,7 @@ Defined in: [index.d.ts:132](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **readTimeout**: `number`
 
-Defined in: [index.d.ts:136](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L136)
+Defined in: [index.d.ts:134](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L134)
 
 ---
 
@@ -92,7 +92,7 @@ Defined in: [index.d.ts:136](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **requiredAcks**: `number`
 
-Defined in: [index.d.ts:137](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L137)
+Defined in: [index.d.ts:135](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L135)
 
 ---
 
@@ -100,7 +100,7 @@ Defined in: [index.d.ts:137](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **sasl**: [`SASLConfig`](SASLConfig.md)
 
-Defined in: [index.d.ts:140](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L140)
+Defined in: [index.d.ts:138](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L138)
 
 ---
 
@@ -108,7 +108,7 @@ Defined in: [index.d.ts:140](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **tls**: [`TLSConfig`](TLSConfig.md)
 
-Defined in: [index.d.ts:141](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L141)
+Defined in: [index.d.ts:139](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L139)
 
 ---
 
@@ -116,7 +116,7 @@ Defined in: [index.d.ts:141](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **topic**: `string`
 
-Defined in: [index.d.ts:129](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L129)
+Defined in: [index.d.ts:127](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L127)
 
 ---
 
@@ -124,4 +124,4 @@ Defined in: [index.d.ts:129](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **writeTimeout**: `number`
 
-Defined in: [index.d.ts:138](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L138)
+Defined in: [index.d.ts:136](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L136)

--- a/api-docs/v2/index.d.ts
+++ b/api-docs/v2/index.d.ts
@@ -84,9 +84,7 @@ export enum GROUP_BALANCERS {
   GROUP_BALANCER_RACK_AFFINITY = "group_balancer_rack_affinity",
 }
 
-/* Schema types used in identifying schema and data type in serdes.
-SCHEMA_TYPE_PROTOBUF remains exported, but Schema Registry Protobuf serdes
-are planned for v2.1 and are not available in v2.0.0. */
+/* Schema types used in identifying schema and data type in serdes. */
 export enum SCHEMA_TYPES {
   SCHEMA_TYPE_STRING = "STRING",
   SCHEMA_TYPE_BYTES = "BYTES",
@@ -300,6 +298,8 @@ export interface Schema {
   version: number;
   references: Reference[];
   subject: string;
+  messageName?: string;
+  dependencies?: Record<string, string>;
 }
 
 export interface SubjectNameConfig {
@@ -307,12 +307,14 @@ export interface SubjectNameConfig {
   topic: string;
   element: ELEMENT_TYPES;
   subjectNameStrategy: SUBJECT_NAME_STRATEGY;
+  messageName?: string;
 }
 
 export interface Container {
   data: any;
   schema: Schema;
   schemaType: SCHEMA_TYPES;
+  protobufFormat?: "object" | "bytes";
 }
 
 export interface JKSConfig {

--- a/docs/schema-registry.md
+++ b/docs/schema-registry.md
@@ -7,7 +7,7 @@ It ensures that the data produced and consumed by Kafka producers and consumers 
 It is highly recommended to use Schema Registry when working with Kafka, in order to ensure that your messages conform to the expected structure and types.
 
 > [!NOTE]
-> `xk6-kafka v2.0.0` supports Avro and JSON on the Schema Registry path. `SCHEMA_TYPE_PROTOBUF` remains exported for compatibility planning, but Protobuf Schema Registry serdes are not implemented in `v2.0.0` and are planned for `v2.1`.
+> `xk6-kafka v2.1.0` supports Avro, JSON, and Protobuf on both Schema Registry and standalone schema flows.
 
 ## How to Use Schema Registry with xk6-kafka
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/mostafa/xk6-kafka/v2
 go 1.26
 
 require (
+	github.com/bufbuild/protocompile v0.14.1
 	github.com/confluentinc/confluent-kafka-go/v2 v2.14.0
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/grafana/sobek v0.0.0-20260219184149-bdae4a158e94
@@ -12,6 +13,7 @@ require (
 	github.com/sirupsen/logrus v1.9.3
 	github.com/stretchr/testify v1.11.1
 	go.k6.io/k6 v1.7.1
+	google.golang.org/protobuf v1.36.11
 	gopkg.in/guregu/null.v3 v3.3.0
 )
 
@@ -61,13 +63,13 @@ require (
 	golang.org/x/crypto v0.50.0 // indirect
 	golang.org/x/net v0.52.0 // indirect
 	golang.org/x/oauth2 v0.34.0 // indirect
+	golang.org/x/sync v0.20.0 // indirect
 	golang.org/x/sys v0.43.0 // indirect
 	golang.org/x/text v0.36.0 // indirect
 	golang.org/x/time v0.14.0 // indirect
 	google.golang.org/genproto/googleapis/api v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20251202230838-ff82c1b0f217 // indirect
 	google.golang.org/grpc v1.79.3 // indirect
-	google.golang.org/protobuf v1.36.11 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/pkg/kafka/compatibility_test.go
+++ b/pkg/kafka/compatibility_test.go
@@ -43,8 +43,8 @@ func TestJSCompatibilityConstructorsWithMockCluster(t *testing.T) {
 		Arguments: []sobek.Value{
 			test.rt.ToValue(map[string]any{
 				"messages": []map[string]any{{
-					"key":   []byte("producer-key"),
-					"value": []byte("producer-value"),
+					"key":   "producer-key",
+					"value": "producer-value",
 				}},
 			}),
 		},
@@ -65,8 +65,8 @@ func TestJSCompatibilityConstructorsWithMockCluster(t *testing.T) {
 		Arguments: []sobek.Value{
 			test.rt.ToValue(map[string]any{
 				"messages": []map[string]any{{
-					"key":   []byte("writer-key"),
-					"value": []byte("writer-value"),
+					"key":   "writer-key",
+					"value": "writer-value",
 				}},
 			}),
 		},

--- a/pkg/kafka/error_codes.go
+++ b/pkg/kafka/error_codes.go
@@ -69,6 +69,13 @@ const (
 	failedParseReferencedSchema         errCode = 5005
 	failedResolveReferences             errCode = 5006
 	invalidSchemaID                     errCode = 5007
+	protobufSchemaCompileFailed         errCode = 5008
+	protobufMissingImport               errCode = 5009
+	protobufAmbiguousMessageName        errCode = 5010
+	protobufMissingMessageName          errCode = 5011
+	protobufInvalidMessageIndexPath     errCode = 5012
+	protobufObjectValidationFailed      errCode = 5013
+	protobufUnsupportedFormatInput      errCode = 5014
 
 	// topics.
 	failedGetController     errCode = 6000
@@ -83,10 +90,46 @@ var (
 	// ErrUnsupportedOperation is the error returned when the operation is not supported.
 	ErrUnsupportedOperation = NewXk6KafkaError(unsupportedOperation, "Operation not supported", nil)
 
-	// ErrProtobufSerdesPlanned is returned when Protobuf Schema Registry serdes are requested in v2.0.0.
-	ErrProtobufSerdesPlanned = NewXk6KafkaError(
-		unsupportedOperation,
-		"Protobuf Schema Registry serdes are planned for v2.1 and are not available in v2.0.0.",
+	// ErrProtobufSchemaCompileFailed is returned when compiling a protobuf schema fails.
+	ErrProtobufSchemaCompileFailed = NewXk6KafkaError(
+		protobufSchemaCompileFailed,
+		"Failed to compile protobuf schema",
+		nil,
+	)
+	// ErrProtobufMissingImport is returned when a protobuf import cannot be resolved.
+	ErrProtobufMissingImport = NewXk6KafkaError(
+		protobufMissingImport,
+		"Missing protobuf import or dependency",
+		nil,
+	)
+	// ErrProtobufAmbiguousMessageName is returned when schema has multiple top-level messages.
+	ErrProtobufAmbiguousMessageName = NewXk6KafkaError(
+		protobufAmbiguousMessageName,
+		"Ambiguous protobuf message name: set schema.messageName",
+		nil,
+	)
+	// ErrProtobufMissingMessageName is returned when the selected message doesn't exist.
+	ErrProtobufMissingMessageName = NewXk6KafkaError(
+		protobufMissingMessageName,
+		"Configured protobuf messageName was not found in schema",
+		nil,
+	)
+	// ErrProtobufInvalidMessageIndexPath is returned when protobuf framing indexes are invalid.
+	ErrProtobufInvalidMessageIndexPath = NewXk6KafkaError(
+		protobufInvalidMessageIndexPath,
+		"Invalid protobuf message-index path",
+		nil,
+	)
+	// ErrProtobufObjectValidationFailed is returned when object-mode payload is invalid.
+	ErrProtobufObjectValidationFailed = NewXk6KafkaError(
+		protobufObjectValidationFailed,
+		"Failed to validate object against protobuf schema",
+		nil,
+	)
+	// ErrProtobufUnsupportedFormatInput is returned when protobufFormat data type is unsupported.
+	ErrProtobufUnsupportedFormatInput = NewXk6KafkaError(
+		protobufUnsupportedFormatInput,
+		"Unsupported input type for protobufFormat",
 		nil,
 	)
 

--- a/pkg/kafka/hardening_test.go
+++ b/pkg/kafka/hardening_test.go
@@ -145,36 +145,61 @@ func TestDeserializeRejectsMissingMetadata(t *testing.T) {
 	}, "deserialize metadata is required")
 }
 
-func TestSerializeRejectsProtobufSerdesInV2(t *testing.T) {
+func TestSerializeSupportsProtobufBytesFormat(t *testing.T) {
 	test := getTestModuleInstance(t)
 
-	requireGoErrorMessage(t, func() {
-		test.module.serialize(&Container{
-			Data: []byte("value"),
-			Schema: &Schema{
-				ID:      1,
-				Schema:  `syntax = "proto3"; message Value { string field = 1; }`,
-				Subject: "test-subject",
-			},
-			SchemaType: Protobuf,
-		})
-	}, "Protobuf Schema Registry serdes are planned for v2.1 and are not available in v2.0.0.")
+	test.moveToVUCode()
+
+	rawPayload := []byte{10, 5, 'v', 'a', 'l', 'u', 'e'}
+	serialized := test.module.serialize(&Container{
+		Data: rawPayload,
+		Schema: &Schema{
+			ID:          1,
+			Schema:      `syntax = "proto3"; message Value { string field = 1; }`,
+			Subject:     "test-subject",
+			MessageName: "Value",
+		},
+		SchemaType:     Protobuf,
+		ProtobufFormat: "bytes",
+	})
+
+	require.NotNil(t, serialized)
+	assert.Greater(t, len(serialized), MagicPrefixSize)
 }
 
-func TestDeserializeRejectsProtobufSerdesInV2(t *testing.T) {
+func TestDeserializeSupportsProtobufBytesFormat(t *testing.T) {
 	test := getTestModuleInstance(t)
 
-	requireGoErrorMessage(t, func() {
-		test.module.deserialize(&Container{
-			Data: test.module.encodeWireFormat([]byte("value"), 1),
-			Schema: &Schema{
-				ID:      1,
-				Schema:  `syntax = "proto3"; message Value { string field = 1; }`,
-				Subject: "test-subject",
-			},
-			SchemaType: Protobuf,
-		})
-	}, "Protobuf Schema Registry serdes are planned for v2.1 and are not available in v2.0.0.")
+	test.moveToVUCode()
+
+	rawPayload := []byte{10, 5, 'v', 'a', 'l', 'u', 'e'}
+	serialized := test.module.serialize(&Container{
+		Data: rawPayload,
+		Schema: &Schema{
+			ID:          1,
+			Schema:      `syntax = "proto3"; message Value { string field = 1; }`,
+			Subject:     "test-subject",
+			MessageName: "Value",
+		},
+		SchemaType:     Protobuf,
+		ProtobufFormat: "bytes",
+	})
+
+	deserialized := test.module.deserialize(&Container{
+		Data: serialized,
+		Schema: &Schema{
+			ID:          1,
+			Schema:      `syntax = "proto3"; message Value { string field = 1; }`,
+			Subject:     "test-subject",
+			MessageName: "Value",
+		},
+		SchemaType:     Protobuf,
+		ProtobufFormat: "bytes",
+	})
+
+	decoded, ok := deserialized.([]byte)
+	require.True(t, ok)
+	assert.Equal(t, rawPayload, decoded)
 }
 
 func TestEncodeWireFormatRejectsOutOfRangeSchemaID(t *testing.T) {

--- a/pkg/kafka/interfaces.go
+++ b/pkg/kafka/interfaces.go
@@ -10,6 +10,7 @@ var TypesRegistry map[SchemaType]Serdes = map[SchemaType]Serdes{
 	Bytes:  &ByteArraySerde{},
 	Json:   &JSONSerde{},
 	Avro:   &AvroSerde{},
+	Protobuf: &ProtobufSerde{},
 }
 
 func GetSerdes(schemaType SchemaType) (Serdes, *Xk6KafkaError) {

--- a/pkg/kafka/interfaces.go
+++ b/pkg/kafka/interfaces.go
@@ -6,10 +6,10 @@ type Serdes interface {
 }
 
 var TypesRegistry map[SchemaType]Serdes = map[SchemaType]Serdes{
-	String: &StringSerde{},
-	Bytes:  &ByteArraySerde{},
-	Json:   &JSONSerde{},
-	Avro:   &AvroSerde{},
+	String:   &StringSerde{},
+	Bytes:    &ByteArraySerde{},
+	Json:     &JSONSerde{},
+	Avro:     &AvroSerde{},
 	Protobuf: &ProtobufSerde{},
 }
 

--- a/pkg/kafka/protobuf.go
+++ b/pkg/kafka/protobuf.go
@@ -1,0 +1,555 @@
+package kafka
+
+import (
+	"context"
+	"encoding/binary"
+	"fmt"
+	"strings"
+
+	"github.com/bufbuild/protocompile"
+	"go.k6.io/k6/js/common"
+	"google.golang.org/protobuf/encoding/protojson"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+	"google.golang.org/protobuf/types/dynamicpb"
+)
+
+type ProtobufSerde struct {
+	Serdes
+}
+
+type protobufRuntime struct {
+	fileDesc    protoreflect.FileDescriptor
+	messageDesc protoreflect.MessageDescriptor
+	indexes     []int
+}
+
+const (
+	protobufFormatObject = "object"
+	protobufFormatBytes  = "bytes"
+)
+
+func normalizeProtobufFormat(format string) string {
+	normalized := strings.ToLower(strings.TrimSpace(format))
+	if normalized == "" {
+		return protobufFormatObject
+	}
+	return normalized
+}
+
+func parseProtobufBytesInput(data any) ([]byte, *Xk6KafkaError) {
+	switch value := data.(type) {
+	case []byte:
+		return value, nil
+	case []any:
+		bytesData := make([]byte, len(value))
+		for i, element := range value {
+			converted, ok := element.(float64)
+			if !ok {
+				return nil, ErrProtobufUnsupportedFormatInput
+			}
+			bytesData[i] = byte(converted)
+		}
+		return bytesData, nil
+	case string:
+		if !isBase64Encoded(value) {
+			return nil, ErrProtobufUnsupportedFormatInput
+		}
+		decoded, err := base64ToBytes(value)
+		if err != nil {
+			return nil, err
+		}
+		return decoded, nil
+	default:
+		return nil, ErrProtobufUnsupportedFormatInput
+	}
+}
+
+func parseProtobufMessageIndexes(payload []byte) (int, []int, *Xk6KafkaError) {
+	arrayLen, bytesRead := binary.Varint(payload)
+	if bytesRead <= 0 || arrayLen < 0 {
+		return 0, nil, ErrProtobufInvalidMessageIndexPath
+	}
+
+	if arrayLen == 0 {
+		return bytesRead, []int{0}, nil
+	}
+
+	indexes := make([]int, arrayLen)
+	for i := 0; i < int(arrayLen); i++ {
+		index, read := binary.Varint(payload[bytesRead:])
+		if read <= 0 {
+			return 0, nil, ErrProtobufInvalidMessageIndexPath
+		}
+		bytesRead += read
+		indexes[i] = int(index)
+	}
+
+	return bytesRead, indexes, nil
+}
+
+func encodeProtobufMessageIndexes(indexes []int) []byte {
+	if len(indexes) == 1 && indexes[0] == 0 {
+		return []byte{0}
+	}
+
+	buffer := make([]byte, (1+len(indexes))*binary.MaxVarintLen64)
+	length := binary.PutVarint(buffer, int64(len(indexes)))
+	for _, index := range indexes {
+		length += binary.PutVarint(buffer[length:], int64(index))
+	}
+	return buffer[:length]
+}
+
+func (k *Kafka) encodeProtobufWireFormat(data []byte, schemaID int, messageIndexes []int) []byte {
+	schemaIDBytes := make([]byte, MagicPrefixSize-1)
+	if schemaID < 0 || schemaID > int(^uint32(0)) {
+		err := NewXk6KafkaError(
+			invalidSchemaID,
+			fmt.Sprintf("Invalid schema id %d: must be within uint32 range", schemaID),
+			nil,
+		)
+		common.Throw(k.vu.Runtime(), err)
+		return nil
+	}
+	binary.BigEndian.PutUint32(schemaIDBytes, uint32(schemaID))
+
+	payload := make([]byte, 0, 1+len(schemaIDBytes)+len(messageIndexes)+len(data))
+	payload = append(payload, 0)
+	payload = append(payload, schemaIDBytes...)
+	payload = append(payload, encodeProtobufMessageIndexes(messageIndexes)...)
+	payload = append(payload, data...)
+	return payload
+}
+
+func (k *Kafka) decodeProtobufWireFormat(message []byte) (int, []int, []byte, *Xk6KafkaError) {
+	if len(message) < MagicPrefixSize {
+		return 0, nil, nil, NewXk6KafkaError(
+			messageTooShort,
+			"Invalid message: message too short to contain schema id.",
+			nil,
+		)
+	}
+	if message[0] != 0 {
+		return 0, nil, nil, NewXk6KafkaError(
+			messageTooShort,
+			"Invalid message: invalid start byte.",
+			nil,
+		)
+	}
+
+	schemaID := int(binary.BigEndian.Uint32(message[1:5]))
+	bytesRead, indexes, err := parseProtobufMessageIndexes(message[5:])
+	if err != nil {
+		return 0, nil, nil, err
+	}
+
+	return schemaID, indexes, message[5+bytesRead:], nil
+}
+
+func toMessageIndexes(descriptor protoreflect.Descriptor, count int) []int {
+	index := descriptor.Index()
+	switch parent := descriptor.Parent().(type) {
+	case protoreflect.FileDescriptor:
+		msgIndexes := make([]int, count+1)
+		msgIndexes[0] = index
+		return msgIndexes[:1]
+	default:
+		msgIndexes := toMessageIndexes(parent, count+1)
+		return append(msgIndexes, index)
+	}
+}
+
+func toMessageIndexArray(messageDesc protoreflect.MessageDescriptor) []int {
+	if messageDesc.Index() == 0 {
+		switch messageDesc.Parent().(type) {
+		case protoreflect.FileDescriptor:
+			return []int{0}
+		}
+	}
+	return toMessageIndexes(messageDesc, 0)
+}
+
+func toMessageDescriptor(
+	descriptor protoreflect.Descriptor,
+	indexes []int,
+) (protoreflect.MessageDescriptor, *Xk6KafkaError) {
+	if len(indexes) == 0 {
+		return nil, ErrProtobufInvalidMessageIndexPath
+	}
+
+	index := indexes[0]
+	switch value := descriptor.(type) {
+	case protoreflect.FileDescriptor:
+		messages := value.Messages()
+		if index < 0 || index >= messages.Len() {
+			return nil, ErrProtobufInvalidMessageIndexPath
+		}
+		if len(indexes) == 1 {
+			return messages.Get(index), nil
+		}
+		return toMessageDescriptor(messages.Get(index), indexes[1:])
+	case protoreflect.MessageDescriptor:
+		messages := value.Messages()
+		if index < 0 || index >= messages.Len() {
+			return nil, ErrProtobufInvalidMessageIndexPath
+		}
+		if len(indexes) == 1 {
+			return messages.Get(index), nil
+		}
+		return toMessageDescriptor(messages.Get(index), indexes[1:])
+	default:
+		return nil, ErrProtobufInvalidMessageIndexPath
+	}
+}
+
+func findMessageByFullName(
+	messages protoreflect.MessageDescriptors,
+	fullName protoreflect.FullName,
+) protoreflect.MessageDescriptor {
+	for i := 0; i < messages.Len(); i++ {
+		message := messages.Get(i)
+		if message.FullName() == fullName {
+			return message
+		}
+		nested := findMessageByFullName(message.Messages(), fullName)
+		if nested != nil {
+			return nested
+		}
+	}
+	return nil
+}
+
+func resolveTargetProtobufMessage(
+	fileDesc protoreflect.FileDescriptor,
+	messageName string,
+) (protoreflect.MessageDescriptor, *Xk6KafkaError) {
+	if fileDesc == nil {
+		return nil, ErrProtobufSchemaCompileFailed
+	}
+
+	trimmed := strings.TrimSpace(messageName)
+	if trimmed != "" {
+		fullName := protoreflect.FullName(trimmed)
+		if message := findMessageByFullName(fileDesc.Messages(), fullName); message != nil {
+			return message, nil
+		}
+		return nil, ErrProtobufMissingMessageName
+	}
+
+	topLevel := fileDesc.Messages()
+	if topLevel.Len() != 1 {
+		return nil, ErrProtobufAmbiguousMessageName
+	}
+
+	return topLevel.Get(0), nil
+}
+
+func resolveReferenceByName(schema *Schema, name string) (*Schema, error) {
+	if schema == nil || schema.resolver == nil {
+		return nil, ErrReferenceNotFound
+	}
+
+	if resolved, err := schema.resolver(name); err == nil && resolved != nil {
+		return resolved, nil
+	}
+
+	for _, ref := range schema.References {
+		if ref.Name == name || ref.Subject == name {
+			if resolved, err := schema.resolver(ref.Subject); err == nil && resolved != nil {
+				return resolved, nil
+			}
+		}
+	}
+
+	return nil, ErrReferenceNotFound
+}
+
+func collectProtobufReferenceSchemas(
+	schema *Schema,
+	out map[string]string,
+	visited map[string]bool,
+) *Xk6KafkaError {
+	for _, ref := range schema.References {
+		if visited[ref.Name] {
+			continue
+		}
+
+		resolved, err := resolveReferenceByName(schema, ref.Name)
+		if err != nil {
+			return NewXk6KafkaError(failedResolveReferences, "Failed to resolve protobuf references", err)
+		}
+
+		visited[ref.Name] = true
+		out[ref.Name] = resolved.Schema
+		if collectErr := collectProtobufReferenceSchemas(resolved, out, visited); collectErr != nil {
+			return collectErr
+		}
+	}
+
+	return nil
+}
+
+func buildProtobufDependencyMap(schema *Schema) (map[string]string, *Xk6KafkaError) {
+	dependencies := make(map[string]string)
+	for key, value := range schema.Dependencies {
+		dependencies[key] = value
+	}
+
+	if len(schema.References) == 0 {
+		return dependencies, nil
+	}
+
+	if schema.resolver == nil {
+		return nil, NewXk6KafkaError(failedResolveReferences, "Failed to resolve protobuf references", ErrReferenceNotFound)
+	}
+
+	if err := collectProtobufReferenceSchemas(schema, dependencies, map[string]bool{}); err != nil {
+		return nil, err
+	}
+
+	return dependencies, nil
+}
+
+func parseProtobufFileDescriptor(schema *Schema) (protoreflect.FileDescriptor, *Xk6KafkaError) {
+	if schema == nil || strings.TrimSpace(schema.Schema) == "" {
+		return nil, ErrProtobufSchemaCompileFailed
+	}
+
+	dependencies, err := buildProtobufDependencyMap(schema)
+	if err != nil {
+		return nil, err
+	}
+
+	sources := map[string]string{
+		".": schema.Schema,
+	}
+	for filename, dependencySchema := range dependencies {
+		sources[filename] = dependencySchema
+	}
+
+	compiler := protocompile.Compiler{
+		Resolver: protocompile.WithStandardImports(&protocompile.SourceResolver{
+			Accessor: protocompile.SourceAccessorFromMap(sources),
+		}),
+	}
+
+	files, parseErr := compiler.Compile(context.Background(), ".")
+	if parseErr != nil {
+		if strings.Contains(parseErr.Error(), "file does not exist") ||
+			strings.Contains(parseErr.Error(), "not found") {
+			return nil, NewXk6KafkaError(
+				protobufMissingImport,
+				"Missing protobuf import or dependency",
+				parseErr,
+			)
+		}
+		return nil, NewXk6KafkaError(failedToEncode, "Failed to compile protobuf schema", parseErr)
+	}
+	if len(files) != 1 {
+		return nil, ErrProtobufSchemaCompileFailed
+	}
+
+	return files[0], nil
+}
+
+func buildProtobufRuntime(schema *Schema) (*protobufRuntime, *Xk6KafkaError) {
+	fileDesc, err := parseProtobufFileDescriptor(schema)
+	if err != nil {
+		return nil, err
+	}
+
+	messageDesc, err := resolveTargetProtobufMessage(fileDesc, schema.MessageName)
+	if err != nil {
+		return nil, err
+	}
+
+	return &protobufRuntime{
+		fileDesc:    fileDesc,
+		messageDesc: messageDesc,
+		indexes:     toMessageIndexArray(messageDesc),
+	}, nil
+}
+
+func (s *ProtobufSerde) Serialize(data any, schema *Schema) ([]byte, *Xk6KafkaError) {
+	runtime, err := buildProtobufRuntime(schema)
+	if err != nil {
+		return nil, err
+	}
+
+	message := dynamicpb.NewMessage(runtime.messageDesc)
+
+	jsonData, err := toJSONBytes(data)
+	if err != nil {
+		return nil, ErrProtobufObjectValidationFailed
+	}
+
+	if unmarshalErr := (protojson.UnmarshalOptions{DiscardUnknown: false}).Unmarshal(jsonData, message); unmarshalErr != nil {
+		return nil, NewXk6KafkaError(failedToEncode, "Failed to encode protobuf object data", unmarshalErr)
+	}
+
+	encoded, marshalErr := proto.Marshal(message)
+	if marshalErr != nil {
+		return nil, NewXk6KafkaError(failedToEncodeToBinary, "Failed to encode protobuf data into binary", marshalErr)
+	}
+
+	return encoded, nil
+}
+
+func (s *ProtobufSerde) Deserialize(data []byte, schema *Schema) (any, *Xk6KafkaError) {
+	runtime, err := buildProtobufRuntime(schema)
+	if err != nil {
+		return nil, err
+	}
+
+	message := dynamicpb.NewMessage(runtime.messageDesc)
+	if unmarshalErr := proto.Unmarshal(data, message); unmarshalErr != nil {
+		return nil, NewXk6KafkaError(failedToDecodeFromBinary, "Failed to decode protobuf data", unmarshalErr)
+	}
+
+	jsonData, marshalErr := protojson.MarshalOptions{
+		UseProtoNames: false,
+	}.Marshal(message)
+	if marshalErr != nil {
+		return nil, NewXk6KafkaError(failedToDecodeFromBinary, "Failed to convert protobuf data to JSON", marshalErr)
+	}
+
+	decoded, mapErr := toMap(jsonData)
+	if mapErr != nil {
+		return nil, mapErr
+	}
+	return decoded, nil
+}
+
+func (k *Kafka) serializeProtobuf(container *Container) []byte {
+	format := normalizeProtobufFormat(container.ProtobufFormat)
+	if format != protobufFormatObject && format != protobufFormatBytes {
+		common.Throw(k.vu.Runtime(), ErrProtobufUnsupportedFormatInput)
+		return nil
+	}
+
+	runtime, err := buildProtobufRuntime(container.Schema)
+	if err != nil {
+		common.Throw(k.vu.Runtime(), err)
+		return nil
+	}
+
+	var payload []byte
+	switch format {
+	case protobufFormatObject:
+		serde, serdesErr := GetSerdes(Protobuf)
+		if serdesErr != nil {
+			common.Throw(k.vu.Runtime(), serdesErr)
+			return nil
+		}
+		encoded, encodeErr := serde.Serialize(container.Data, container.Schema)
+		if encodeErr != nil {
+			common.Throw(k.vu.Runtime(), encodeErr)
+			return nil
+		}
+		payload = encoded
+	case protobufFormatBytes:
+		rawBytes, bytesErr := parseProtobufBytesInput(container.Data)
+		if bytesErr != nil {
+			common.Throw(k.vu.Runtime(), bytesErr)
+			return nil
+		}
+
+		validationMessage := dynamicpb.NewMessage(runtime.messageDesc)
+		if unmarshalErr := proto.Unmarshal(rawBytes, validationMessage); unmarshalErr != nil {
+			common.Throw(k.vu.Runtime(), NewXk6KafkaError(
+				failedToEncodeToBinary,
+				"Failed to validate protobuf binary input",
+				unmarshalErr,
+			))
+			return nil
+		}
+		payload = rawBytes
+	}
+
+	schemaID := container.Schema.ID
+	if schemaID == 0 {
+		schemaID = 0
+	}
+
+	return k.encodeProtobufWireFormat(payload, schemaID, runtime.indexes)
+}
+
+func (k *Kafka) deserializeProtobuf(container *Container) any {
+	format := normalizeProtobufFormat(container.ProtobufFormat)
+	if format != protobufFormatObject && format != protobufFormatBytes {
+		common.Throw(k.vu.Runtime(), ErrProtobufUnsupportedFormatInput)
+		return nil
+	}
+
+	var data []byte
+	switch payload := container.Data.(type) {
+	case []byte:
+		data = payload
+	case string:
+		if isBase64Encoded(payload) {
+			decoded, err := base64ToBytes(payload)
+			if err != nil {
+				common.Throw(k.vu.Runtime(), err)
+				return nil
+			}
+			data = decoded
+		} else {
+			data = []byte(payload)
+		}
+	default:
+		common.Throw(k.vu.Runtime(), ErrProtobufUnsupportedFormatInput)
+		return nil
+	}
+
+	_, indexes, payload, err := k.decodeProtobufWireFormat(data)
+	if err != nil {
+		common.Throw(k.vu.Runtime(), err)
+		return nil
+	}
+
+	if format == protobufFormatBytes {
+		return payload
+	}
+
+	fileDesc, parseErr := parseProtobufFileDescriptor(container.Schema)
+	if parseErr != nil {
+		common.Throw(k.vu.Runtime(), parseErr)
+		return nil
+	}
+
+	messageDesc, descErr := toMessageDescriptor(fileDesc, indexes)
+	if descErr != nil {
+		common.Throw(k.vu.Runtime(), descErr)
+		return nil
+	}
+
+	message := dynamicpb.NewMessage(messageDesc)
+	if unmarshalErr := proto.Unmarshal(payload, message); unmarshalErr != nil {
+		common.Throw(k.vu.Runtime(), NewXk6KafkaError(
+			failedToDecodeFromBinary,
+			"Failed to decode protobuf payload",
+			unmarshalErr,
+		))
+		return nil
+	}
+
+	jsonData, marshalErr := protojson.MarshalOptions{
+		UseProtoNames: false,
+	}.Marshal(message)
+	if marshalErr != nil {
+		common.Throw(k.vu.Runtime(), NewXk6KafkaError(
+			failedToDecodeFromBinary,
+			"Failed to convert protobuf payload to JSON object",
+			marshalErr,
+		))
+		return nil
+	}
+
+	decoded, mapErr := toMap(jsonData)
+	if mapErr != nil {
+		common.Throw(k.vu.Runtime(), mapErr)
+		return nil
+	}
+	return decoded
+}

--- a/pkg/kafka/protobuf.go
+++ b/pkg/kafka/protobuf.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"maps"
 	"strings"
 
 	"github.com/bufbuild/protocompile"
@@ -76,7 +77,7 @@ func parseProtobufMessageIndexes(payload []byte) (int, []int, *Xk6KafkaError) {
 	}
 
 	indexes := make([]int, arrayLen)
-	for i := 0; i < int(arrayLen); i++ {
+	for i := range int(arrayLen) {
 		index, read := binary.Varint(payload[bytesRead:])
 		if read <= 0 {
 			return 0, nil, ErrProtobufInvalidMessageIndexPath
@@ -162,8 +163,7 @@ func toMessageIndexes(descriptor protoreflect.Descriptor, count int) []int {
 
 func toMessageIndexArray(messageDesc protoreflect.MessageDescriptor) []int {
 	if messageDesc.Index() == 0 {
-		switch messageDesc.Parent().(type) {
-		case protoreflect.FileDescriptor:
+		if _, ok := messageDesc.Parent().(protoreflect.FileDescriptor); ok {
 			return []int{0}
 		}
 	}
@@ -207,7 +207,7 @@ func findMessageByFullName(
 	messages protoreflect.MessageDescriptors,
 	fullName protoreflect.FullName,
 ) protoreflect.MessageDescriptor {
-	for i := 0; i < messages.Len(); i++ {
+	for i := range messages.Len() {
 		message := messages.Get(i)
 		if message.FullName() == fullName {
 			return message
@@ -292,9 +292,7 @@ func collectProtobufReferenceSchemas(
 
 func buildProtobufDependencyMap(schema *Schema) (map[string]string, *Xk6KafkaError) {
 	dependencies := make(map[string]string)
-	for key, value := range schema.Dependencies {
-		dependencies[key] = value
-	}
+	maps.Copy(dependencies, schema.Dependencies)
 
 	if len(schema.References) == 0 {
 		return dependencies, nil
@@ -324,9 +322,7 @@ func parseProtobufFileDescriptor(schema *Schema) (protoreflect.FileDescriptor, *
 	sources := map[string]string{
 		".": schema.Schema,
 	}
-	for filename, dependencySchema := range dependencies {
-		sources[filename] = dependencySchema
-	}
+	maps.Copy(sources, dependencies)
 
 	compiler := protocompile.Compiler{
 		Resolver: protocompile.WithStandardImports(&protocompile.SourceResolver{
@@ -384,7 +380,8 @@ func (s *ProtobufSerde) Serialize(data any, schema *Schema) ([]byte, *Xk6KafkaEr
 		return nil, ErrProtobufObjectValidationFailed
 	}
 
-	if unmarshalErr := (protojson.UnmarshalOptions{DiscardUnknown: false}).Unmarshal(jsonData, message); unmarshalErr != nil {
+	unmarshalOptions := protojson.UnmarshalOptions{DiscardUnknown: false}
+	if unmarshalErr := unmarshalOptions.Unmarshal(jsonData, message); unmarshalErr != nil {
 		return nil, NewXk6KafkaError(failedToEncode, "Failed to encode protobuf object data", unmarshalErr)
 	}
 

--- a/pkg/kafka/protobuf_internal_test.go
+++ b/pkg/kafka/protobuf_internal_test.go
@@ -1,0 +1,430 @@
+package kafka
+
+import (
+	"encoding/base64"
+	"strings"
+	"testing"
+
+	"github.com/grafana/sobek"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+const depSubjectName = "dep-subject"
+
+func TestNormalizeProtobufFormat(t *testing.T) {
+	assert.Equal(t, "object", normalizeProtobufFormat(""))
+	assert.Equal(t, "object", normalizeProtobufFormat(" OBJECT "))
+	assert.Equal(t, "bytes", normalizeProtobufFormat("bytes"))
+}
+
+func TestParseProtobufBytesInput(t *testing.T) {
+	raw := []byte{1, 2, 3}
+	out, err := parseProtobufBytesInput(raw)
+	require.Nil(t, err)
+	assert.Equal(t, raw, out)
+
+	out, err = parseProtobufBytesInput([]any{1.0, 2.0, 3.0})
+	require.Nil(t, err)
+	assert.Equal(t, raw, out)
+
+	base64Data := base64.StdEncoding.EncodeToString(raw)
+	out, err = parseProtobufBytesInput(base64Data)
+	require.Nil(t, err)
+	assert.Equal(t, raw, out)
+
+	_, err = parseProtobufBytesInput("not-base64")
+	require.Error(t, err)
+	assert.Equal(t, ErrProtobufUnsupportedFormatInput, err)
+
+	_, err = parseProtobufBytesInput([]any{1.0, "x"})
+	require.Error(t, err)
+	assert.Equal(t, ErrProtobufUnsupportedFormatInput, err)
+}
+
+func TestEncodeDecodeMessageIndexes(t *testing.T) {
+	encoded := encodeProtobufMessageIndexes([]int{0})
+	assert.Equal(t, []byte{0}, encoded)
+
+	encoded = encodeProtobufMessageIndexes([]int{1, 2, 3})
+	read, indexes, err := parseProtobufMessageIndexes(encoded)
+	require.Nil(t, err)
+	assert.Equal(t, len(encoded), read)
+	assert.Equal(t, []int{1, 2, 3}, indexes)
+}
+
+func TestParseProtobufFileDescriptorAndMessageResolution(t *testing.T) {
+	schema := &Schema{
+		Schema: `syntax = "proto3"; package t; message A { string v = 1; }`,
+	}
+	fileDesc, err := parseProtobufFileDescriptor(schema)
+	require.Nil(t, err)
+	require.NotNil(t, fileDesc)
+
+	messageDesc, msgErr := resolveTargetProtobufMessage(fileDesc, "t.A")
+	require.Nil(t, msgErr)
+	require.NotNil(t, messageDesc)
+
+	_, msgErr = resolveTargetProtobufMessage(fileDesc, "t.Missing")
+	require.Error(t, msgErr)
+	assert.Equal(t, ErrProtobufMissingMessageName, msgErr)
+}
+
+func TestBuildProtobufRuntimeAmbiguousMessage(t *testing.T) {
+	schema := &Schema{
+		Schema: `syntax = "proto3"; message A { string v = 1; } message B { string v = 1; }`,
+	}
+	_, err := buildProtobufRuntime(schema)
+	require.Error(t, err)
+	assert.Equal(t, ErrProtobufAmbiguousMessageName, err)
+}
+
+func TestToMessageDescriptorInvalidIndexPath(t *testing.T) {
+	schema := &Schema{
+		Schema: `syntax = "proto3"; package t; message A { string v = 1; }`,
+	}
+	fileDesc, err := parseProtobufFileDescriptor(schema)
+	require.Nil(t, err)
+
+	_, descErr := toMessageDescriptor(fileDesc, []int{99})
+	require.Error(t, descErr)
+	assert.Equal(t, ErrProtobufInvalidMessageIndexPath, descErr)
+}
+
+func TestBuildProtobufDependencyMapWithReferences(t *testing.T) {
+	protobufType := Protobuf
+	referenced := &Schema{
+		Schema:       `syntax = "proto3"; package dep; message Dep { string value = 1; }`,
+		SchemaType:   &protobufType,
+		Subject:      depSubjectName,
+		References:   nil,
+		Dependencies: nil,
+	}
+	root := &Schema{
+		Schema: `syntax = "proto3"; import "dep.proto"; message Root { dep.Dep value = 1; }`,
+		References: []Reference{
+			{Name: "dep.proto", Subject: depSubjectName, Version: 1},
+		},
+		resolver: func(name string) (*Schema, error) {
+			if name == "dep.proto" || name == depSubjectName {
+				return referenced, nil
+			}
+			return nil, ErrReferenceNotFound
+		},
+	}
+
+	deps, err := buildProtobufDependencyMap(root)
+	require.Nil(t, err)
+	assert.Contains(t, deps, "dep.proto")
+}
+
+func TestBuildProtobufDependencyMapErrorWithoutResolver(t *testing.T) {
+	_, err := buildProtobufDependencyMap(&Schema{
+		Schema: `syntax = "proto3"; import "dep.proto"; message Root { string v = 1; }`,
+		References: []Reference{
+			{Name: "dep.proto", Subject: "dep-subject", Version: 1},
+		},
+	})
+	require.Error(t, err)
+	assert.Equal(t, failedResolveReferences, err.Code)
+}
+
+func TestCollectProtobufReferenceSchemasVisitedSkipsReprocessing(t *testing.T) {
+	ref := &Schema{Schema: `syntax = "proto3"; package dep; message Dep { string value = 1; }`}
+	root := &Schema{
+		References: []Reference{
+			{Name: "dep.proto", Subject: "dep-subject", Version: 1},
+		},
+		resolver: func(name string) (*Schema, error) {
+			if name == "dep.proto" || name == "dep-subject" {
+				return ref, nil
+			}
+			return nil, ErrReferenceNotFound
+		},
+	}
+
+	out := map[string]string{"dep.proto": "existing"}
+	visited := map[string]bool{"dep.proto": true}
+	err := collectProtobufReferenceSchemas(root, out, visited)
+	require.Nil(t, err)
+	assert.Equal(t, "existing", out["dep.proto"])
+}
+
+func TestParseProtobufFileDescriptorRejectsEmptySchema(t *testing.T) {
+	_, err := parseProtobufFileDescriptor(&Schema{Schema: " "})
+	require.Error(t, err)
+	assert.Equal(t, ErrProtobufSchemaCompileFailed, err)
+}
+
+func TestProtobufSerdeSerializeDeserialize(t *testing.T) {
+	serde := &ProtobufSerde{}
+	schema := &Schema{
+		Schema:      `syntax = "proto3"; package t; message A { string v = 1; }`,
+		MessageName: "t.A",
+	}
+
+	encoded, err := serde.Serialize(map[string]any{"v": "ok"}, schema)
+	require.Nil(t, err)
+	require.NotEmpty(t, encoded)
+
+	decoded, decodeErr := serde.Deserialize(encoded, schema)
+	require.Nil(t, decodeErr)
+	object, ok := decoded.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "ok", object["v"])
+}
+
+func TestProtobufSerdeSerializeErrorPaths(t *testing.T) {
+	serde := &ProtobufSerde{}
+	schema := &Schema{
+		Schema:      `syntax = "proto3"; package t; message A { string v = 1; }`,
+		MessageName: "t.A",
+	}
+
+	_, err := serde.Serialize(make(chan int), schema)
+	require.Error(t, err)
+	assert.Equal(t, ErrProtobufObjectValidationFailed, err)
+
+	_, err = serde.Serialize(map[string]any{"unknown": "x"}, schema)
+	require.Error(t, err)
+	assert.Equal(t, failedToEncode, err.Code)
+}
+
+func TestProtobufSerdeDeserializeErrorPaths(t *testing.T) {
+	serde := &ProtobufSerde{}
+	schema := &Schema{
+		Schema:      `syntax = "proto3"; package t; message A { string v = 1; }`,
+		MessageName: "t.A",
+	}
+
+	_, err := serde.Deserialize([]byte{255, 1, 2}, schema)
+	require.Error(t, err)
+	assert.Equal(t, failedToDecodeFromBinary, err.Code)
+}
+
+func TestToMessageIndexArrayAndDescriptorNestedPaths(t *testing.T) {
+	schema := &Schema{
+		Schema: `
+syntax = "proto3";
+package t;
+message A { string v = 1; }
+message B {
+  message C { string v = 1; }
+  C nested = 1;
+}
+`,
+	}
+	fileDesc, err := parseProtobufFileDescriptor(schema)
+	require.Nil(t, err)
+
+	// Second top-level message forces recursive toMessageIndexes path.
+	b := fileDesc.Messages().Get(1)
+	assert.Equal(t, []int{1}, toMessageIndexArray(b))
+
+	// Nested message exercises both file and message descriptor resolution branches.
+	c, descErr := toMessageDescriptor(fileDesc, []int{1, 0})
+	require.Nil(t, descErr)
+	assert.Equal(t, protoreflect.FullName("t.B.C"), c.FullName())
+
+	// Resolve from a message descriptor (not file descriptor) branch.
+	c2, descErr := toMessageDescriptor(b, []int{0})
+	require.Nil(t, descErr)
+	assert.Equal(t, protoreflect.FullName("t.B.C"), c2.FullName())
+
+	// Empty path on message descriptor is invalid for current traversal logic.
+	_, descErr = toMessageDescriptor(b, []int{})
+	require.Error(t, descErr)
+	assert.Equal(t, ErrProtobufInvalidMessageIndexPath, descErr)
+}
+
+func TestResolveReferenceByNameFallbackAndNotFound(t *testing.T) {
+	referenced := &Schema{Schema: `syntax = "proto3"; package dep; message Dep { string value = 1; }`}
+	schema := &Schema{
+		References: []Reference{
+			{Name: "dep.proto", Subject: "dep-subject", Version: 1},
+		},
+		resolver: func(name string) (*Schema, error) {
+			if name == "dep-subject" {
+				return referenced, nil
+			}
+			return nil, ErrReferenceNotFound
+		},
+	}
+
+	resolved, err := resolveReferenceByName(schema, "dep.proto")
+	require.Nil(t, err)
+	assert.Equal(t, referenced, resolved)
+
+	_, err = resolveReferenceByName(schema, "missing.proto")
+	require.Error(t, err)
+	assert.ErrorIs(t, err, ErrReferenceNotFound)
+}
+
+func TestSerializeDeserializeProtobufErrorPaths(t *testing.T) {
+	test := getTestModuleInstance(t)
+	test.moveToVUCode()
+
+	validSchema := &Schema{
+		ID:          1,
+		Schema:      `syntax = "proto3"; package t; message A { string v = 1; }`,
+		MessageName: "t.A",
+	}
+
+	requireGoErrorMessage(t, func() {
+		test.module.serializeProtobuf(&Container{
+			Data:           map[string]any{"v": "x"},
+			Schema:         validSchema,
+			SchemaType:     Protobuf,
+			ProtobufFormat: "invalid",
+		})
+	}, "Unsupported input type for protobufFormat")
+
+	requireGoErrorMessage(t, func() {
+		test.module.serializeProtobuf(&Container{
+			Data:           "not-base64",
+			Schema:         validSchema,
+			SchemaType:     Protobuf,
+			ProtobufFormat: "bytes",
+		})
+	}, "Unsupported input type for protobufFormat")
+
+	requireGoErrorMessage(t, func() {
+		test.module.deserializeProtobuf(&Container{
+			Data:           []byte{0, 0, 0, 0, 1},
+			Schema:         validSchema,
+			SchemaType:     Protobuf,
+			ProtobufFormat: "object",
+		})
+	}, "Invalid protobuf message-index path")
+}
+
+func TestDeserializeProtobufFormatsAndBranches(t *testing.T) {
+	test := getTestModuleInstance(t)
+	test.moveToVUCode()
+
+	validSchema := &Schema{
+		ID:          7,
+		Schema:      `syntax = "proto3"; package t; message A { string v = 1; }`,
+		MessageName: "t.A",
+	}
+
+	wire := test.module.serializeProtobuf(&Container{
+		Data:           map[string]any{"v": "ok"},
+		Schema:         validSchema,
+		SchemaType:     Protobuf,
+		ProtobufFormat: "object",
+	})
+	require.NotEmpty(t, wire)
+
+	// bytes mode should return raw protobuf payload for []byte input.
+	decodedBytes := test.module.deserializeProtobuf(&Container{
+		Data:           wire,
+		Schema:         validSchema,
+		SchemaType:     Protobuf,
+		ProtobufFormat: "bytes",
+	})
+	require.IsType(t, []byte{}, decodedBytes)
+
+	// object mode should decode from base64 input too.
+	decodedObject := test.module.deserializeProtobuf(&Container{
+		Data:           base64.StdEncoding.EncodeToString(wire),
+		Schema:         validSchema,
+		SchemaType:     Protobuf,
+		ProtobufFormat: "object",
+	})
+	asMap, ok := decodedObject.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "ok", asMap["v"])
+
+	requireGoErrorMessage(t, func() {
+		test.module.deserializeProtobuf(&Container{
+			Data:           123,
+			Schema:         validSchema,
+			SchemaType:     Protobuf,
+			ProtobufFormat: "object",
+		})
+	}, "Unsupported input type for protobufFormat")
+
+	requireGoErrorMessage(t, func() {
+		test.module.deserializeProtobuf(&Container{
+			Data:           "plain-text",
+			Schema:         validSchema,
+			SchemaType:     Protobuf,
+			ProtobufFormat: "object",
+		})
+	}, "Invalid message: invalid start byte.")
+}
+
+func TestDeserializeProtobufParseAndPayloadFailures(t *testing.T) {
+	test := getTestModuleInstance(t)
+	test.moveToVUCode()
+
+	validSchema := &Schema{
+		ID:          11,
+		Schema:      `syntax = "proto3"; package t; message A { string v = 1; }`,
+		MessageName: "t.A",
+	}
+
+	runtime, err := buildProtobufRuntime(validSchema)
+	require.Nil(t, err)
+
+	invalidPayloadWire := test.module.encodeProtobufWireFormat([]byte{255, 1, 2}, validSchema.ID, runtime.indexes)
+	requireGoErrorContains(t, func() {
+		test.module.deserializeProtobuf(&Container{
+			Data:           invalidPayloadWire,
+			Schema:         validSchema,
+			SchemaType:     Protobuf,
+			ProtobufFormat: "object",
+		})
+	}, "Failed to decode protobuf payload")
+
+	badSchema := &Schema{
+		Schema: `syntax = "proto3"; package t; import "missing.proto"; message A { string v = 1; }`,
+	}
+	expectedError := "Missing protobuf import or dependency, " +
+		"OriginalError: .:1:38: could not resolve path \"missing.proto\": file does not exist"
+	requireGoErrorMessage(t, func() {
+		test.module.deserializeProtobuf(&Container{
+			Data:           invalidPayloadWire,
+			Schema:         badSchema,
+			SchemaType:     Protobuf,
+			ProtobufFormat: "object",
+		})
+	}, expectedError)
+}
+
+func TestSerializeProtobufBytesValidationFailure(t *testing.T) {
+	test := getTestModuleInstance(t)
+	test.moveToVUCode()
+
+	validSchema := &Schema{
+		Schema:      `syntax = "proto3"; package t; message A { string v = 1; }`,
+		MessageName: "t.A",
+	}
+
+	requireGoErrorContains(t, func() {
+		test.module.serializeProtobuf(&Container{
+			Data:           []byte{255, 1, 2},
+			Schema:         validSchema,
+			SchemaType:     Protobuf,
+			ProtobufFormat: "bytes",
+		})
+	}, "Failed to validate protobuf binary input")
+}
+
+func requireGoErrorContains(t *testing.T, fn func(), expectedSubstring string) {
+	t.Helper()
+
+	defer func() {
+		err := recover()
+		require.NotNil(t, err)
+
+		errObj, ok := err.(*sobek.Object)
+		require.True(t, ok)
+		actual := errObj.ToString().String()
+		require.True(t, strings.Contains(actual, expectedSubstring), "expected %q to contain %q", actual, expectedSubstring)
+	}()
+
+	fn()
+}

--- a/pkg/kafka/schema_registry.go
+++ b/pkg/kafka/schema_registry.go
@@ -49,14 +49,14 @@ const (
 // Schema is a wrapper around the schema registry schema.
 // The Codec() and JsonSchema() methods will return the respective codecs (duck-typing).
 type Schema struct {
-	EnableCaching bool        `json:"enableCaching"`
-	ID            int         `json:"id"`
-	Schema        string      `json:"schema"`
-	SchemaType    *SchemaType `json:"schemaType"`
-	Version       int         `json:"version"`
-	References    []Reference `json:"references"`
-	Subject       string      `json:"subject"`
-	MessageName   string      `json:"messageName"`
+	EnableCaching bool              `json:"enableCaching"`
+	ID            int               `json:"id"`
+	Schema        string            `json:"schema"`
+	SchemaType    *SchemaType       `json:"schemaType"`
+	Version       int               `json:"version"`
+	References    []Reference       `json:"references"`
+	Subject       string            `json:"subject"`
+	MessageName   string            `json:"messageName"`
 	Dependencies  map[string]string `json:"dependencies"`
 	avroSchema    avro.Schema
 	jsonSchema    *jsonschema.Schema

--- a/pkg/kafka/schema_registry.go
+++ b/pkg/kafka/schema_registry.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"strings"
 
 	cschemaregistry "github.com/confluentinc/confluent-kafka-go/v2/schemaregistry"
 	"github.com/grafana/sobek"
@@ -55,6 +56,8 @@ type Schema struct {
 	Version       int         `json:"version"`
 	References    []Reference `json:"references"`
 	Subject       string      `json:"subject"`
+	MessageName   string      `json:"messageName"`
+	Dependencies  map[string]string `json:"dependencies"`
 	avroSchema    avro.Schema
 	jsonSchema    *jsonschema.Schema
 
@@ -67,6 +70,7 @@ type SubjectNameConfig struct {
 	Topic               string  `json:"topic"`
 	Element             Element `json:"element"`
 	SubjectNameStrategy string  `json:"subjectNameStrategy"`
+	MessageName         string  `json:"messageName"`
 }
 
 type WireFormat struct {
@@ -726,19 +730,25 @@ func (k *Kafka) getSubjectName(subjectNameConfig *SubjectNameConfig) string {
 	}
 
 	runtime := k.vu.Runtime()
-	var schemaMap map[string]any
-	err := json.Unmarshal([]byte(subjectNameConfig.Schema), &schemaMap)
-	if err != nil {
-		common.Throw(runtime, NewXk6KafkaError(
-			failedUnmarshalSchema, "Failed to unmarshal schema", err))
-	}
 	recordName := ""
-	if namespace, ok := schemaMap["namespace"]; ok {
-		if namespace, ok := namespace.(string); ok {
-			recordName = namespace + "."
-		} else {
-			err := NewXk6KafkaError(failedTypeCast, "Failed to cast to string", nil)
-			common.Throw(runtime, err)
+	var schemaMap map[string]any
+	if strings.TrimSpace(subjectNameConfig.MessageName) != "" {
+		recordName = strings.TrimSpace(subjectNameConfig.MessageName)
+	}
+
+	if recordName == "" {
+		err := json.Unmarshal([]byte(subjectNameConfig.Schema), &schemaMap)
+		if err != nil {
+			common.Throw(runtime, NewXk6KafkaError(
+				failedUnmarshalSchema, "Failed to unmarshal schema", err))
+		}
+		if namespace, ok := schemaMap["namespace"]; ok {
+			if namespace, ok := namespace.(string); ok {
+				recordName = namespace + "."
+			} else {
+				err := NewXk6KafkaError(failedTypeCast, "Failed to cast to string", nil)
+				common.Throw(runtime, err)
+			}
 		}
 	}
 	if name, ok := schemaMap["name"]; ok {
@@ -757,7 +767,7 @@ func (k *Kafka) getSubjectName(subjectNameConfig *SubjectNameConfig) string {
 		return subjectNameConfig.Topic + "-" + recordName
 	}
 
-	err = NewXk6KafkaError(failedToEncode, fmt.Sprintf(
+	err := NewXk6KafkaError(failedToEncode, fmt.Sprintf(
 		"Unknown subject name strategy: %v", subjectNameConfig.SubjectNameStrategy), nil)
 	common.Throw(runtime, err)
 	return ""

--- a/pkg/kafka/schema_registry_test.go
+++ b/pkg/kafka/schema_registry_test.go
@@ -299,6 +299,28 @@ func TestGetSubjectNameCanUseRecordNameStrategyWithNamespace(t *testing.T) {
 	assert.Equal(t, "com.example.person.Schema", subjectName)
 }
 
+func TestGetSubjectNameUsesMessageNameForProtobufStrategies(t *testing.T) {
+	test := getTestModuleInstance(t)
+
+	subject := test.module.getSubjectName(&SubjectNameConfig{
+		Schema:              `syntax = "proto3"; message User { string name = 1; }`,
+		Topic:               "test-topic",
+		SubjectNameStrategy: RecordNameStrategy,
+		Element:             Value,
+		MessageName:         "com.example.User",
+	})
+	assert.Equal(t, "com.example.User", subject)
+
+	subject = test.module.getSubjectName(&SubjectNameConfig{
+		Schema:              `syntax = "proto3"; message User { string name = 1; }`,
+		Topic:               "test-topic",
+		SubjectNameStrategy: TopicRecordNameStrategy,
+		Element:             Value,
+		MessageName:         "com.example.User",
+	})
+	assert.Equal(t, "test-topic-com.example.User", subject)
+}
+
 // TestSchemaRegistryClientClass tests the schema registry client class.
 func TestSchemaRegistryClientClass(t *testing.T) {
 	test := getTestModuleInstance(t)

--- a/pkg/kafka/serdes.go
+++ b/pkg/kafka/serdes.go
@@ -5,9 +5,10 @@ import (
 )
 
 type Container struct {
-	Data       any        `json:"data"`
-	Schema     *Schema    `json:"schema"`
-	SchemaType SchemaType `json:"schemaType"`
+	Data           any        `json:"data"`
+	Schema         *Schema    `json:"schema"`
+	SchemaType     SchemaType `json:"schemaType"`
+	ProtobufFormat string     `json:"protobufFormat"`
 }
 
 // serialize checks whether the incoming data has a schema or not.
@@ -28,7 +29,7 @@ func (k *Kafka) serializeWithRegistry(container *Container, registry *schemaRegi
 
 	if container.Schema == nil {
 		if container.SchemaType == Protobuf {
-			common.Throw(k.vu.Runtime(), ErrProtobufSerdesPlanned)
+			common.Throw(k.vu.Runtime(), newMissingConfigError("schema metadata"))
 			return nil
 		}
 
@@ -94,8 +95,7 @@ func (k *Kafka) serializeWithRegistry(container *Container, registry *schemaRegi
 		common.Throw(k.vu.Runtime(), ErrUnsupportedOperation)
 		return nil
 	case Protobuf:
-		common.Throw(k.vu.Runtime(), ErrProtobufSerdesPlanned)
-		return nil
+		return k.serializeProtobuf(container)
 	default:
 		common.Throw(k.vu.Runtime(), ErrUnsupportedOperation)
 		return nil
@@ -120,7 +120,7 @@ func (k *Kafka) deserializeWithRegistry(container *Container, registry *schemaRe
 
 	if container.Schema == nil {
 		if container.SchemaType == Protobuf {
-			common.Throw(k.vu.Runtime(), ErrProtobufSerdesPlanned)
+			common.Throw(k.vu.Runtime(), newMissingConfigError("schema metadata"))
 			return nil
 		}
 
@@ -246,8 +246,7 @@ func (k *Kafka) deserializeWithRegistry(container *Container, registry *schemaRe
 			common.Throw(runtime, ErrUnsupportedOperation)
 			return nil
 		case Protobuf:
-			common.Throw(runtime, ErrProtobufSerdesPlanned)
-			return nil
+			return k.deserializeProtobuf(container)
 		default:
 			common.Throw(runtime, ErrUnsupportedOperation)
 			return nil

--- a/pkg/kafka/serdes_test.go
+++ b/pkg/kafka/serdes_test.go
@@ -434,3 +434,67 @@ message User {
 	require.True(t, ok)
 	assert.Equal(t, "Mostafa", user["name"])
 }
+
+func TestDeserializeWithoutSchemaBranches(t *testing.T) {
+	test := getTestModuleInstance(t)
+	test.moveToVUCode()
+
+	t.Run("bytes to string", func(t *testing.T) {
+		out := test.module.deserialize(&Container{
+			Data:       []byte("hello"),
+			SchemaType: String,
+		})
+		assert.Equal(t, "hello", out)
+	})
+
+	t.Run("bytes passthrough", func(t *testing.T) {
+		out := test.module.deserialize(&Container{
+			Data:       []byte{1, 2, 3},
+			SchemaType: Bytes,
+		})
+		assert.Equal(t, []byte{1, 2, 3}, out)
+	})
+
+	t.Run("json bytes to map", func(t *testing.T) {
+		out := test.module.deserialize(&Container{
+			Data:       []byte(`{"key":"value"}`),
+			SchemaType: Json,
+		})
+		asMap, ok := out.(map[string]any)
+		require.True(t, ok)
+		assert.Equal(t, "value", asMap["key"])
+	})
+
+	t.Run("non-json bytes remain bytes", func(t *testing.T) {
+		out := test.module.deserialize(&Container{
+			Data:       []byte("not-json"),
+			SchemaType: Json,
+		})
+		assert.Equal(t, []byte("not-json"), out)
+	})
+
+	t.Run("plain string returns bytes", func(t *testing.T) {
+		out := test.module.deserialize(&Container{
+			Data:       "plain",
+			SchemaType: String,
+		})
+		assert.Equal(t, []byte("plain"), out)
+	})
+
+	t.Run("base64 string decodes via serde", func(t *testing.T) {
+		out := test.module.deserialize(&Container{
+			Data:       "aGVsbG8=",
+			SchemaType: String,
+		})
+		assert.Equal(t, "hello", out)
+	})
+
+	t.Run("protobuf without schema errors", func(t *testing.T) {
+		requireGoErrorMessage(t, func() {
+			test.module.deserialize(&Container{
+				Data:       []byte("abc"),
+				SchemaType: Protobuf,
+			})
+		}, "schema metadata is required")
+	})
+}

--- a/pkg/kafka/serdes_test.go
+++ b/pkg/kafka/serdes_test.go
@@ -352,3 +352,85 @@ func TestSerialize_AvroNestedUnionWithLogicalTypeIssue376(t *testing.T) {
 		})
 	}
 }
+
+func TestSerializeDeserialize_ProtobufObjectMode(t *testing.T) {
+	test := getTestModuleInstance(t)
+	test.moveToVUCode()
+
+	schema := &Schema{
+		ID:          9,
+		Schema:      `syntax = "proto3"; message User { string name = 1; int32 age = 2; }`,
+		Subject:     "test-user",
+		MessageName: "User",
+	}
+
+	serialized := test.module.serialize(&Container{
+		Data: map[string]any{
+			"name": "Mostafa",
+			"age":  33.0,
+		},
+		Schema:     schema,
+		SchemaType: Protobuf,
+	})
+	require.NotNil(t, serialized)
+
+	deserialized := test.module.deserialize(&Container{
+		Data:       serialized,
+		Schema:     schema,
+		SchemaType: Protobuf,
+	})
+
+	decoded, ok := deserialized.(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "Mostafa", decoded["name"])
+	assert.Equal(t, float64(33), decoded["age"])
+}
+
+func TestSerializeDeserialize_ProtobufStandaloneDependencies(t *testing.T) {
+	test := getTestModuleInstance(t)
+	test.moveToVUCode()
+
+	schema := &Schema{
+		ID: 0,
+		Schema: `
+syntax = "proto3";
+import "common.proto";
+message UserWrapper {
+  common.User user = 1;
+}`,
+		Dependencies: map[string]string{
+			"common.proto": `
+syntax = "proto3";
+package common;
+message User {
+  string name = 1;
+}
+`,
+		},
+		Subject:     "test-user-wrapper",
+		MessageName: "UserWrapper",
+	}
+
+	serialized := test.module.serialize(&Container{
+		Data: map[string]any{
+			"user": map[string]any{
+				"name": "Mostafa",
+			},
+		},
+		Schema:     schema,
+		SchemaType: Protobuf,
+	})
+	require.NotNil(t, serialized)
+
+	deserialized := test.module.deserialize(&Container{
+		Data:       serialized,
+		Schema:     schema,
+		SchemaType: Protobuf,
+	})
+
+	decoded, ok := deserialized.(map[string]any)
+	require.True(t, ok)
+	user, ok := decoded["user"].(map[string]any)
+	require.True(t, ok)
+	assert.Equal(t, "Mostafa", user["name"])
+}

--- a/pkg/kafka/writer.go
+++ b/pkg/kafka/writer.go
@@ -1,7 +1,9 @@
 package kafka
 
 import (
+	"errors"
 	"fmt"
+	"reflect"
 	"time"
 
 	"github.com/go-viper/mapstructure/v2"
@@ -22,6 +24,8 @@ var (
 	balancerHash       = "balancer_hash"
 	balancerCrc32      = "balancer_crc32"
 	balancerMurmur2    = "balancer_murmur2"
+
+	errExpectedNumericByte = errors.New("expected numeric byte")
 )
 
 var supportedBalancers = map[string]struct{}{
@@ -142,7 +146,10 @@ func (k *Kafka) compatProducerClass(call sobek.ConstructorCall) *sobek.Object {
 			common.Throw(runtime, ErrNotEnoughArguments)
 		}
 
-		decodeArgument(runtime, call.Argument(0), &producerConfig, "produce config")
+		producerConfig = decodeProduceConfig(runtime, call.Argument(0))
+		if producerConfig == nil {
+			return sobek.Undefined()
+		}
 
 		k.produceWithProducer(producer, producerConfig)
 		return sobek.Undefined()
@@ -192,6 +199,53 @@ func (k *Kafka) compatProducerClass(call sobek.ConstructorCall) *sobek.Object {
 	}
 
 	return runtime.ToValue(producerObject).ToObject(runtime)
+}
+
+func decodeProduceConfig(runtime *sobek.Runtime, value sobek.Value) *ProduceConfig {
+	params := exportArgumentMap(runtime, value, "produce config")
+	if params == nil {
+		return nil
+	}
+
+	var produceConfig ProduceConfig
+	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
+		Result: &produceConfig,
+		DecodeHook: func(from reflect.Type, to reflect.Type, data any) (any, error) {
+			if to == reflect.TypeFor[[]byte]() {
+				switch v := data.(type) {
+				case string:
+					return []byte(v), nil
+				case []any:
+					bytes := make([]byte, len(v))
+					for i, value := range v {
+						number, ok := value.(float64)
+						if !ok {
+							return nil, fmt.Errorf(
+								"%w at index %d, got %T",
+								errExpectedNumericByte,
+								i,
+								value,
+							)
+						}
+						bytes[i] = byte(number)
+					}
+					return bytes, nil
+				}
+			}
+			return data, nil
+		},
+	})
+	if err != nil {
+		throwConfigError(runtime, newInvalidConfigError("produce config", err))
+		return nil
+	}
+
+	if err := decoder.Decode(params); err != nil {
+		throwConfigError(runtime, newInvalidConfigError("produce config", err))
+		return nil
+	}
+
+	return &produceConfig
 }
 
 func validateConfluentWriterCompatibility(writerConfig *WriterConfig) *Xk6KafkaError {

--- a/scripts/test_protobuf_with_schema_registry.js
+++ b/scripts/test_protobuf_with_schema_registry.js
@@ -1,0 +1,116 @@
+/*
+This is a k6 test script that imports xk6-kafka and
+tests Kafka with Protobuf messages via Schema Registry.
+*/
+
+import { check, sleep } from "k6";
+import {
+  Writer,
+  Reader,
+  Connection,
+  SchemaRegistry,
+  VALUE,
+  RECORD_NAME_STRATEGY,
+  SCHEMA_TYPE_PROTOBUF,
+} from "k6/x/kafka";
+
+const brokers = ["localhost:9092"];
+const topic = "xk6_kafka_protobuf_topic";
+
+const writer = new Writer({
+  brokers: brokers,
+  topic: topic,
+});
+const reader = new Reader({
+  brokers: brokers,
+  topic: topic,
+});
+const schemaRegistry = new SchemaRegistry({
+  url: "http://localhost:8081",
+});
+
+export function setup() {
+  const connection = new Connection({
+    address: brokers[0],
+  });
+
+  connection.createTopic({ topic: topic });
+
+  const topics = connection.listTopics();
+  if (!topics.includes(topic)) {
+    throw new Error(`Topic ${topic} was not created successfully`);
+  }
+
+  connection.close();
+  sleep(2);
+}
+
+const valueSchema = `
+syntax = "proto3";
+package com.example.protobuf;
+
+message Person {
+  string first_name = 1;
+  string last_name = 2;
+  int32 age = 3;
+}
+`;
+
+const messageName = "com.example.protobuf.Person";
+
+const valueSubjectName = schemaRegistry.getSubjectName({
+  topic: topic,
+  element: VALUE,
+  subjectNameStrategy: RECORD_NAME_STRATEGY,
+  schema: valueSchema,
+  messageName: messageName,
+});
+
+const valueSchemaObject = schemaRegistry.createSchema({
+  subject: valueSubjectName,
+  schema: valueSchema,
+  schemaType: SCHEMA_TYPE_PROTOBUF,
+  messageName: messageName,
+});
+
+export default function () {
+  const messages = [
+    {
+      value: schemaRegistry.serialize({
+        data: {
+          firstName: "mostafa",
+          lastName: "moradian",
+          age: 33,
+        },
+        schema: valueSchemaObject,
+        schemaType: SCHEMA_TYPE_PROTOBUF,
+      }),
+    },
+  ];
+
+  writer.produce({ messages: messages });
+
+  const consumed = reader.consume({ limit: 1 });
+  check(consumed, {
+    "1 message returned": (msgs) => msgs.length === 1,
+    "protobuf payload is decoded": (msgs) => {
+      const value = schemaRegistry.deserialize({
+        data: msgs[0].value,
+        schema: valueSchemaObject,
+        schemaType: SCHEMA_TYPE_PROTOBUF,
+      });
+
+      return value.firstName === "mostafa" && value.lastName === "moradian" && value.age === 33;
+    },
+  });
+}
+
+export function teardown() {
+  const connection = new Connection({
+    address: brokers[0],
+  });
+  connection.deleteTopic(topic);
+  connection.close();
+  writer.close();
+  reader.close();
+}

--- a/scripts/test_protobuf_with_schema_registry.js
+++ b/scripts/test_protobuf_with_schema_registry.js
@@ -100,7 +100,11 @@ export default function () {
         schemaType: SCHEMA_TYPE_PROTOBUF,
       });
 
-      return value.firstName === "mostafa" && value.lastName === "moradian" && value.age === 33;
+      return (
+        value.firstName === "mostafa" &&
+        value.lastName === "moradian" &&
+        value.age === 33
+      );
     },
   });
 }


### PR DESCRIPTION
## Summary
- add dynamic `SCHEMA_TYPE_PROTOBUF` support to `SchemaRegistry.serialize()` and `SchemaRegistry.deserialize()` for object and bytes formats
- add protobuf-specific schema/container metadata (`messageName`, `dependencies`, `protobufFormat`) plus subject naming support for record-based strategies
- add protobuf-focused tests, a new schema-registry example script, and regenerate v2 API docs/declarations
- improve coverage with focused serde/branch tests to recover package baseline (`pkg/kafka` back to 80.0%)
- fix v2 compatibility `Producer.produce()` decoding so plain JS string `key`/`value` inputs are treated as raw bytes (not JSON base64), resolving smoke failures in `scripts/v2/smoke/basic.js`

## Test plan
- [x] `go test ./...`
- [x] `golangci-lint run ./...`
- [x] `./k6 run --quiet -d 2s scripts/v2/smoke/basic.js`
- [x] `./k6 run --quiet scripts/v2/integration/consumer_group.js`
- [x] `./k6 run --quiet scripts/v2/integration/avro_schema_registry.js`
- [x] `./k6 run --quiet scripts/v2/integration/json_schema_registry.js`
- [x] `yarn run generate-docs:v2` (from `api-docs/`)
- [x] `yarn run check-docs:v2`