### PR TITLE
fix(docker): use ubuntu:24.04 base to run glibc-linked binaries

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,15 @@
-FROM alpine:3.23
+FROM ubuntu:24.04
 
 ARG VERSION_TAG
 ARG TARGETOS
 ARG TARGETARCH
 
-RUN apk add --no-cache ca-certificates openssl && \
-    adduser -D -u 12345 -g 12345 k6
-COPY ./dist/xk6-kafka_${VERSION_TAG}_${TARGETOS}_${TARGETARCH} /usr/bin/k6
+RUN apt-get update && \
+    apt-get install -y --no-install-recommends ca-certificates librdkafka1 openssl && \
+    rm -rf /var/lib/apt/lists/* && \
+    groupadd -g 12345 k6 && \
+    useradd -u 12345 -g 12345 -m -s /bin/sh k6
+COPY --chmod=0755 ./dist/xk6-kafka_${VERSION_TAG}_${TARGETOS}_${TARGETARCH} /usr/bin/k6
 
 USER 12345
 WORKDIR /home/k6


### PR DESCRIPTION
## Summary

- Fix the container image so that `k6` actually runs. Currently it errors with `sh: k6: not found` because the published Linux binary is built against glibc but the image is based on `alpine:3.23` (musl), so the kernel can't load the requested ELF interpreter.
- Switch the base to `ubuntu:24.04` to match the build environment, pull in `librdkafka1` at runtime, and set `0755` on the copied binary so it remains executable under platforms that override `USER` with arbitrary UIDs (e.g. OpenShift `restricted-v2`).

Full diagnosis is in #395.

Fixes #395