### PR TITLE
perf(protobuf): cache compiled FileDescriptor by schema content

### DIFF
--- a/pkg/kafka/protobuf.go
+++ b/pkg/kafka/protobuf.go
@@ -372,7 +372,10 @@ func protobufCacheKey(schemaSource string, dependencies map[string]string) strin
 	return string(h.Sum(nil))
 }
 
-func compileProtobufFileDescriptor(schemaSource string, dependencies map[string]string) (protoreflect.FileDescriptor, *Xk6KafkaError) {
+func compileProtobufFileDescriptor(
+	schemaSource string,
+	dependencies map[string]string,
+) (protoreflect.FileDescriptor, *Xk6KafkaError) {
 	sources := map[string]string{
 		".": schemaSource,
 	}

--- a/pkg/kafka/protobuf.go
+++ b/pkg/kafka/protobuf.go
@@ -2,10 +2,13 @@ package kafka
 
 import (
 	"context"
+	"crypto/sha256"
 	"encoding/binary"
 	"fmt"
 	"maps"
+	"sort"
 	"strings"
+	"sync"
 
 	"github.com/bufbuild/protocompile"
 	"go.k6.io/k6/js/common"
@@ -309,6 +312,25 @@ func buildProtobufDependencyMap(schema *Schema) (map[string]string, *Xk6KafkaErr
 	return dependencies, nil
 }
 
+// protobufFileDescCache memoises protocompile.Compile results across the
+// process. The JS-facing serialize/deserialize handlers go through
+// decodeArgument, which json.Marshal/Unmarshal-round-trips the argument
+// and so produces a fresh *Schema on every call; a cache keyed on *Schema
+// pointer identity therefore cannot hit. Keys here are a SHA-256 hash of
+// the schema source plus sorted dependency map, so two distinct *Schema
+// instances with identical content share a compiled FileDescriptor.
+//
+// FileDescriptors are read-only once compiled and safe to share across
+// goroutines. The cache is unbounded by design — load tests typically use
+// a small fixed set of schemas, so growth is naturally constrained.
+var protobufFileDescCache sync.Map
+
+type protobufCachedDescriptor struct {
+	once     sync.Once
+	fileDesc protoreflect.FileDescriptor
+	err      *Xk6KafkaError
+}
+
 func parseProtobufFileDescriptor(schema *Schema) (protoreflect.FileDescriptor, *Xk6KafkaError) {
 	if schema == nil || strings.TrimSpace(schema.Schema) == "" {
 		return nil, ErrProtobufSchemaCompileFailed
@@ -319,8 +341,40 @@ func parseProtobufFileDescriptor(schema *Schema) (protoreflect.FileDescriptor, *
 		return nil, err
 	}
 
+	key := protobufCacheKey(schema.Schema, dependencies)
+	entry, _ := protobufFileDescCache.LoadOrStore(key, &protobufCachedDescriptor{})
+	cached := entry.(*protobufCachedDescriptor)
+	cached.once.Do(func() {
+		cached.fileDesc, cached.err = compileProtobufFileDescriptor(schema.Schema, dependencies)
+	})
+	return cached.fileDesc, cached.err
+}
+
+// protobufCacheKey returns a SHA-256 digest of the schema source and the
+// canonical (sorted) dependency map. NUL separators after every field
+// prevent boundary ambiguities between adjacent keys/values.
+func protobufCacheKey(schemaSource string, dependencies map[string]string) string {
+	h := sha256.New()
+	h.Write([]byte(schemaSource))
+	h.Write([]byte{0})
+
+	keys := make([]string, 0, len(dependencies))
+	for k := range dependencies {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		h.Write([]byte(k))
+		h.Write([]byte{0})
+		h.Write([]byte(dependencies[k]))
+		h.Write([]byte{0})
+	}
+	return string(h.Sum(nil))
+}
+
+func compileProtobufFileDescriptor(schemaSource string, dependencies map[string]string) (protoreflect.FileDescriptor, *Xk6KafkaError) {
 	sources := map[string]string{
-		".": schema.Schema,
+		".": schemaSource,
 	}
 	maps.Copy(sources, dependencies)
 

--- a/pkg/kafka/protobuf_internal_test.go
+++ b/pkg/kafka/protobuf_internal_test.go
@@ -455,6 +455,48 @@ message Inner {
 	}
 }
 
+// TestDecodeArgumentAllocatesFreshSchemaPerCall is the load-bearing proof
+// that a per-*Schema cache cannot hit across JS-facing serialize() calls:
+// decodeArgument round-trips the argument through json.Marshal/Unmarshal,
+// which fabricates a new *Schema on every call even when the JS-side value
+// is the identical object. Any descriptor cache that wants to amortise
+// protocompile.Compile across the JS hot path must key on schema content,
+// not on *Schema identity.
+func TestDecodeArgumentAllocatesFreshSchemaPerCall(t *testing.T) {
+	test := getTestModuleInstance(t)
+	test.moveToVUCode()
+
+	// Single sobek.Value representing the JS-side argument to
+	// schemaRegistry.serialize(). The reference is reused across both
+	// decodeArgument calls below — that is the JS-author's perspective of
+	// "passing the same schema object every iteration."
+	jsArg := test.rt.ToValue(map[string]any{
+		"data": "x",
+		"schema": map[string]any{
+			"schema":      `syntax = "proto3"; package t; message A { string v = 1; }`,
+			"messageName": "t.A",
+		},
+		"schemaType": string(Protobuf),
+	})
+
+	var first, second Container
+	decodeArgument(test.rt, jsArg, &first, "test")
+	decodeArgument(test.rt, jsArg, &second, "test")
+
+	require.NotNil(t, first.Schema)
+	require.NotNil(t, second.Schema)
+	// Different pointers despite the same JS-side input — this is the
+	// architectural reason any cache must key on schema content, not on
+	// *Schema identity.
+	assert.NotSame(t, first.Schema, second.Schema,
+		"decodeArgument must allocate a fresh *Schema per call; if this ever changes, per-instance caching becomes viable")
+
+	// The content fields, however, survive the round-trip intact — which is
+	// what makes a content-keyed cache feasible.
+	assert.Equal(t, first.Schema.Schema, second.Schema.Schema)
+	assert.Equal(t, first.Schema.MessageName, second.Schema.MessageName)
+}
+
 // BenchmarkBuildProtobufRuntime exercises the descriptor compilation path
 // invoked on every Serialize/Deserialize call. Each iteration calls
 // buildProtobufRuntime with the same *Schema instance, so a correct
@@ -464,13 +506,57 @@ func BenchmarkBuildProtobufRuntime(b *testing.B) {
 	schema := benchProtobufSchema()
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		runtime, err := buildProtobufRuntime(schema)
 		if err != nil {
 			b.Fatalf("buildProtobufRuntime returned error: %v", err)
 		}
 		if runtime == nil || runtime.messageDesc == nil {
 			b.Fatalf("buildProtobufRuntime returned empty runtime")
+		}
+	}
+}
+
+// BenchmarkProtobufSerdeSerializeViaDecodeArgument mirrors the JS-facing
+// hot path: each iteration runs decodeArgument (the json.Marshal/Unmarshal
+// round-trip the serialize handler performs on every call) before invoking
+// Serialize, so the *Schema is freshly allocated each time. Compared with
+// BenchmarkProtobufSerdeSerialize — which reuses one *Schema — this proves
+// that a cache keyed on *Schema pointer identity cannot hit the JS path.
+func BenchmarkProtobufSerdeSerializeViaDecodeArgument(b *testing.B) {
+	test := getTestModuleInstance(b)
+	test.moveToVUCode()
+	serde := &ProtobufSerde{}
+
+	schema := benchProtobufSchema()
+	jsArg := test.rt.ToValue(map[string]any{
+		"data": map[string]any{
+			"name": "load-test",
+			"ts":   "2026-01-01T00:00:00Z",
+			"inner": map[string]any{
+				"id":   "42",
+				"tags": []any{"a", "b"},
+			},
+		},
+		"schema": map[string]any{
+			"schema":       schema.Schema,
+			"messageName":  schema.MessageName,
+			"dependencies": schema.Dependencies,
+		},
+		"schemaType": string(Protobuf),
+	})
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for range b.N {
+		var c Container
+		decodeArgument(test.rt, jsArg, &c, "test")
+		encoded, err := serde.Serialize(c.Data, c.Schema)
+		if err != nil {
+			b.Fatalf("Serialize returned error: %v", err)
+		}
+		if len(encoded) == 0 {
+			b.Fatalf("Serialize returned empty payload")
 		}
 	}
 }
@@ -493,7 +579,7 @@ func BenchmarkProtobufSerdeSerialize(b *testing.B) {
 	}
 	b.ReportAllocs()
 	b.ResetTimer()
-	for i := 0; i < b.N; i++ {
+	for range b.N {
 		encoded, err := serde.Serialize(data, schema)
 		if err != nil {
 			b.Fatalf("Serialize returned error: %v", err)

--- a/pkg/kafka/protobuf_internal_test.go
+++ b/pkg/kafka/protobuf_internal_test.go
@@ -428,3 +428,78 @@ func requireGoErrorContains(t *testing.T, fn func(), expectedSubstring string) {
 
 	fn()
 }
+
+// benchProtobufSchema is a small but non-trivial schema covering a custom
+// dependency and a well-known import. It is shared across the protobuf
+// benchmarks below so they exercise the same compile cost.
+func benchProtobufSchema() *Schema {
+	return &Schema{
+		Schema: `syntax = "proto3";
+package bench;
+import "google/protobuf/timestamp.proto";
+import "bench/inner.proto";
+message Outer {
+  string name = 1;
+  google.protobuf.Timestamp ts = 2;
+  bench.Inner inner = 3;
+}`,
+		MessageName: "bench.Outer",
+		Dependencies: map[string]string{
+			"bench/inner.proto": `syntax = "proto3";
+package bench;
+message Inner {
+  int64 id = 1;
+  repeated string tags = 2;
+}`,
+		},
+	}
+}
+
+// BenchmarkBuildProtobufRuntime exercises the descriptor compilation path
+// invoked on every Serialize/Deserialize call. Each iteration calls
+// buildProtobufRuntime with the same *Schema instance, so a correct
+// implementation should not recompile the descriptor graph beyond the first
+// iteration. Run with `-benchmem` to surface the per-call allocations.
+func BenchmarkBuildProtobufRuntime(b *testing.B) {
+	schema := benchProtobufSchema()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		runtime, err := buildProtobufRuntime(schema)
+		if err != nil {
+			b.Fatalf("buildProtobufRuntime returned error: %v", err)
+		}
+		if runtime == nil || runtime.messageDesc == nil {
+			b.Fatalf("buildProtobufRuntime returned empty runtime")
+		}
+	}
+}
+
+// BenchmarkProtobufSerdeSerialize exercises the full Serialize hot path used
+// by xk6-kafka's JS-facing schemaRegistry.serialize. It is the same shape as
+// what an in-cluster k6 script calls on every produce() iteration; without a
+// descriptor cache the per-call cost grows in lockstep with descriptor graph
+// size.
+func BenchmarkProtobufSerdeSerialize(b *testing.B) {
+	serde := &ProtobufSerde{}
+	schema := benchProtobufSchema()
+	data := map[string]any{
+		"name": "load-test",
+		"ts":   "2026-01-01T00:00:00Z",
+		"inner": map[string]any{
+			"id":   "42",
+			"tags": []any{"a", "b"},
+		},
+	}
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		encoded, err := serde.Serialize(data, schema)
+		if err != nil {
+			b.Fatalf("Serialize returned error: %v", err)
+		}
+		if len(encoded) == 0 {
+			b.Fatalf("Serialize returned empty payload")
+		}
+	}
+}

--- a/pkg/kafka/protobuf_internal_test.go
+++ b/pkg/kafka/protobuf_internal_test.go
@@ -3,6 +3,7 @@ package kafka
 import (
 	"encoding/base64"
 	"strings"
+	"sync"
 	"testing"
 
 	"github.com/grafana/sobek"
@@ -452,6 +453,81 @@ message Inner {
   repeated string tags = 2;
 }`,
 		},
+	}
+}
+
+func TestParseProtobufFileDescriptorCachesByContent(t *testing.T) {
+	// Different *Schema pointers, identical content — mirrors the JS path,
+	// where decodeArgument allocates a fresh *Schema on every serialize()
+	// call (see TestDecodeArgumentAllocatesFreshSchemaPerCall).
+	src := `syntax = "proto3"; package cachebycontent; message M { string v = 1; }`
+	s1 := &Schema{Schema: src, MessageName: "cachebycontent.M"}
+	s2 := &Schema{Schema: src, MessageName: "cachebycontent.M"}
+	require.NotSame(t, s1, s2)
+
+	fd1, err := parseProtobufFileDescriptor(s1)
+	require.Nil(t, err)
+	fd2, err := parseProtobufFileDescriptor(s2)
+	require.Nil(t, err)
+	assert.Same(t, fd1, fd2, "identical schema content must yield the same cached FileDescriptor across *Schema instances")
+}
+
+func TestParseProtobufFileDescriptorDistinctContentDoesNotCollide(t *testing.T) {
+	a := &Schema{Schema: `syntax = "proto3"; package distinctcache; message A { string v = 1; }`}
+	b := &Schema{Schema: `syntax = "proto3"; package distinctcache; message B { int32 n = 1; }`}
+
+	fdA, err := parseProtobufFileDescriptor(a)
+	require.Nil(t, err)
+	fdB, err := parseProtobufFileDescriptor(b)
+	require.Nil(t, err)
+	assert.NotSame(t, fdA, fdB)
+}
+
+func TestParseProtobufFileDescriptorCachesCompileError(t *testing.T) {
+	// Unique import name so the cache enters from a known-miss state
+	// regardless of test ordering or parallel sibling-test pollution.
+	schema := &Schema{
+		Schema: `syntax = "proto3"; package errorcache; import "errorcache_missing_xK6.proto"; message A { string v = 1; }`,
+	}
+
+	_, firstErr := parseProtobufFileDescriptor(schema)
+	require.Error(t, firstErr)
+	_, secondErr := parseProtobufFileDescriptor(schema)
+	require.Error(t, secondErr)
+	// Failed compiles are cached so pathological schemas do not re-run
+	// protocompile.Compile on every retry.
+	assert.Same(t, firstErr, secondErr)
+}
+
+func TestParseProtobufFileDescriptorConcurrentInit(t *testing.T) {
+	src := `syntax = "proto3"; package concurrentinit; message Race { string v = 1; }`
+	const workers = 16
+
+	// Distinct *Schema instances with identical content — the JS-path shape
+	// under concurrent VUs.
+	schemas := make([]*Schema, workers)
+	for i := range schemas {
+		schemas[i] = &Schema{Schema: src, MessageName: "concurrentinit.Race"}
+	}
+
+	results := make([]protoreflect.FileDescriptor, workers)
+	var wg sync.WaitGroup
+	wg.Add(workers)
+	for i := range workers {
+		go func(idx int) {
+			defer wg.Done()
+			fd, err := parseProtobufFileDescriptor(schemas[idx])
+			if err != nil {
+				t.Errorf("worker %d: parseProtobufFileDescriptor returned error: %v", idx, err)
+				return
+			}
+			results[idx] = fd
+		}(i)
+	}
+	wg.Wait()
+
+	for i := 1; i < workers; i++ {
+		assert.Same(t, results[0], results[i])
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fixes #397
- cache compiled `protoreflect.FileDescriptor` results in a package-level `sync.Map` keyed by a SHA-256 hash of the schema source plus its sorted dependency map, so identical content across distinct `*Schema` instances shares a single compiled descriptor
- a pointer-keyed cache cannot help the JS hot path — `decodeArgument` (validation.go) round-trips every JS argument through `json.Marshal`/`json.Unmarshal`, fabricating a fresh `*Schema` per call. The proof test (`TestDecodeArgumentAllocatesFreshSchemaPerCall`) and benchmark (`BenchmarkProtobufSerdeSerializeViaDecodeArgument`) make this load-bearing fact directly observable
- per-key `sync.Once` gates initialisation so concurrent VUs share one compile pass; compile errors are cached so pathological schemas don't pay the descriptor-build cost on every retry
- adds benchmarks and focused tests covering content-keyed cache identity, distinct-content non-collision, error caching, and concurrent init

Without the cache, `protocompile.Compile` allocates ~75 KB / ~679 heap objects per `Serialize` call against a small schema with one dependency. A k6 load test calling `schemaRegistry.serialize()` at 100 msg/s OOMs a 4 GiB runner pod within 35s.

```
$ go test -run='^$' -bench='^Benchmark(BuildProtobufRuntime|ProtobufSerdeSerialize|ProtobufSerdeSerializeViaDecodeArgument)$' -benchmem -benchtime=2s ./pkg/kafka/

before
BenchmarkBuildProtobufRuntime-12                       45225     52964 ns/op    74423 B/op    605 allocs/op
BenchmarkProtobufSerdeSerialize-12                     39693     61197 ns/op    77500 B/op    679 allocs/op
BenchmarkProtobufSerdeSerializeViaDecodeArgument-12    35055     75255 ns/op    81651 B/op    751 allocs/op

after
BenchmarkBuildProtobufRuntime-12                     4543870       536 ns/op      840 B/op     10 allocs/op
BenchmarkProtobufSerdeSerialize-12                    507057      5450 ns/op     3820 B/op     84 allocs/op
BenchmarkProtobufSerdeSerializeViaDecodeArgument-12   190140     11750 ns/op     7774 B/op    155 allocs/op
```

The cache adds a fixed ~500 ns SHA-256 + `sync.Map.LoadOrStore` cost per call; on cache hit the dominant remaining work is per-message `protojson.Unmarshal` + `proto.Marshal`, which is intrinsic to encoding.

## Test plan

- [x] `go build ./...`
- [x] `go vet ./pkg/kafka/...`
- [x] `go test -race ./pkg/kafka/ -run='Schema|Protobuf|Codec|JSONSchema|Reference|Subject|WireFormat'`
- [x] `go test -bench=. -benchmem -benchtime=2s ./pkg/kafka/`