### PR TITLE
Check for signed commits on PR

### DIFF
--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -1,0 +1,13 @@
+name: Lint Pull Request
+on: pull_request_target
+
+jobs:
+  check-signed-commits:
+    name: Check Signed Commits in PR
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Check Signed Commits in PR
+        uses: 1Password/check-signed-commits-action@ed2885f3ed2577a4f5d3c3fe895432a557d23d52

--- a/.github/workflows/lint-pr.yaml
+++ b/.github/workflows/lint-pr.yaml
@@ -1,5 +1,5 @@
 name: Lint Pull Request
-on: pull_request_target
+on: pull_request
 
 jobs:
   check-signed-commits:


### PR DESCRIPTION
Check for signed commits on PRs, so contributors know to sign commits without the maintainer having to remind them :)

This is implemented as a PR linter workflow, so we can add in more steps for linting PRs that fall outside of the build and test workflows.