### PR TITLE
fix: clear TLSNextProto on schema registry transport when TLS is configured

### DIFF
--- a/pkg/kafka/schema_registry.go
+++ b/pkg/kafka/schema_registry.go
@@ -585,17 +585,23 @@ func (k *Kafka) schemaRegistryClient(config *SchemaRegistryConfig) SchemaRegistr
 }
 
 func newSchemaRegistryTransport(tlsConfig *tls.Config) http.RoundTripper {
+	if tlsConfig == nil {
+		return http.DefaultTransport
+	}
+
 	baseTransport, ok := http.DefaultTransport.(*http.Transport)
 	if !ok {
-		if tlsConfig == nil {
-			return http.DefaultTransport
-		}
-
 		return &http.Transport{TLSClientConfig: tlsConfig}
 	}
 
 	transport := baseTransport.Clone()
 	transport.TLSClientConfig = tlsConfig
+	// Cloning http.DefaultTransport copies TLSNextProto (the HTTP/2 protocol map).
+	// Setting TLSClientConfig on the clone without clearing TLSNextProto leaves the
+	// HTTP/2 connection pool in a broken state, causing EOF and gzip decoding failures
+	// on HTTPS schema registry endpoints. Clearing TLSNextProto forces HTTP/1.1, which
+	// is the same behaviour as the v1 fix (PR #363) that used a fresh http.Transport.
+	transport.TLSNextProto = make(map[string]func(authority string, c *tls.Conn) http.RoundTripper)
 	return transport
 }
 

--- a/pkg/kafka/schema_registry_test.go
+++ b/pkg/kafka/schema_registry_test.go
@@ -132,7 +132,9 @@ func TestNewSchemaRegistryTransportWithTLS(t *testing.T) {
 
 	httpTransport, ok := transport.(*http.Transport)
 	require.True(t, ok, "expected *http.Transport")
-	assert.Empty(t, httpTransport.TLSNextProto, "TLSNextProto must be empty to prevent HTTP/2 connection pool corruption when TLSClientConfig is set")
+	assert.Empty(t, httpTransport.TLSNextProto,
+		"TLSNextProto must be empty to prevent HTTP/2 negotiation "+
+			"which bypasses gzipTransport when TLSClientConfig is set")
 	assert.Equal(t, tlsConfig, httpTransport.TLSClientConfig)
 }
 

--- a/pkg/kafka/schema_registry_test.go
+++ b/pkg/kafka/schema_registry_test.go
@@ -1,6 +1,8 @@
 package kafka
 
 import (
+	"crypto/tls"
+	"net/http"
 	"testing"
 
 	"github.com/grafana/sobek"
@@ -117,6 +119,28 @@ func TestSchemaRegistryClientWithTLSConfig(t *testing.T) {
 	}
 	srClient := test.module.schemaRegistryClient(&srConfig)
 	assert.NotNil(t, srClient)
+}
+
+// TestNewSchemaRegistryTransportWithTLS verifies that the transport returned when a
+// TLSClientConfig is provided has TLSNextProto cleared. Cloning http.DefaultTransport
+// copies TLSNextProto (the HTTP/2 protocol map); without clearing it, setting
+// TLSClientConfig on the clone corrupts the HTTP/2 connection pool and causes EOF
+// and gzip decoding failures on HTTPS schema registry endpoints (regression in v2).
+func TestNewSchemaRegistryTransportWithTLS(t *testing.T) {
+	tlsConfig := &tls.Config{InsecureSkipVerify: true} //nolint:gosec // test only
+	transport := newSchemaRegistryTransport(tlsConfig)
+
+	httpTransport, ok := transport.(*http.Transport)
+	require.True(t, ok, "expected *http.Transport")
+	assert.Empty(t, httpTransport.TLSNextProto, "TLSNextProto must be empty to prevent HTTP/2 connection pool corruption when TLSClientConfig is set")
+	assert.Equal(t, tlsConfig, httpTransport.TLSClientConfig)
+}
+
+// TestNewSchemaRegistryTransportWithoutTLS verifies that http.DefaultTransport is
+// returned as-is when no TLSClientConfig is provided.
+func TestNewSchemaRegistryTransportWithoutTLS(t *testing.T) {
+	transport := newSchemaRegistryTransport(nil)
+	assert.Equal(t, http.DefaultTransport, transport)
 }
 
 // TestGetLatestSchemaFails tests getting the latest schema and fails because


### PR DESCRIPTION
Fixes #403

## What changed

One line added in `newSchemaRegistryTransport` (`pkg/kafka/schema_registry.go`):

```go
transport.TLSNextProto = make(map[string]func(authority string, c *tls.Conn) http.RoundTripper)
```

The `nil` check is also restructured to early-return before the `Clone()` path, so `http.DefaultTransport` is returned as-is when no TLS config is provided (avoids unnecessary cloning).

## Why

`http.DefaultTransport.Clone()` copies `TLSNextProto` — the HTTP/2 protocol handler map. Setting `TLSClientConfig` on the clone without clearing `TLSNextProto` causes HTTP/2 to be negotiated via ALPN. The cloned transport has no own h2 connection pool, so raw HTTP/2 frames are returned to `gzipTransport`, which mistakes the binary h2 framing for a gzip stream and fails with `invalid character '\x1f' looking for beginning of value`.

Clearing `TLSNextProto` forces HTTP/1.1, which is what `gzipTransport` was designed for.

This is a regression from v1.x where the TLS path used a fresh `&http.Transport{TLSClientConfig: tlsConfig}` (no `TLSNextProto` entries, always HTTP/1.1).

## Tests added

`pkg/kafka/schema_registry_test.go`:

- `TestNewSchemaRegistryTransportWithTLS` — verifies `TLSNextProto` is empty when a `TLSConfig` is provided
- `TestNewSchemaRegistryTransportWithoutTLS` — verifies `http.DefaultTransport` is returned as-is when no `TLSConfig` is provided

## Verification

- `CGO_ENABLED=1 go test ./...` passes
- `CGO_ENABLED=1 go test ./... -race` passes
- Fix validated end-to-end: schema registry lookup succeeds against an HTTPS endpoint with mTLS; no `\x1f` errors