### PR TITLE
Add scope override for Azure Entra OAuth SASL config

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,6 +724,19 @@ For v2.0.0+ examples using the new constructors (`Producer`, `Consumer`, `AdminC
 
     You can use the `AWS_PROFILE` environment variable to specify the profile name or use the `awsProfile` option in the `SASLConfig` [object](api-docs/v2/docs/interfaces/SASLConfig.md).
 
+17. My Azure Entra OAuth (or GCP OAuth) authentication fails because the token scope/audience doesn't match my broker. How can I fix that?
+
+    By default, the Azure Entra OAuth provider derives the scope from the broker's hostname, i.e. `https://<broker-host>/.default`. This doesn't work for every setup, for example, managed Kafka providers may expect a scope tied to an Azure App Registration's Application ID URI (e.g. `api://<app-id>/.default`) instead. You can override the derived scope with the `scope` option in the `SASLConfig` [object](api-docs/v2/docs/interfaces/SASLConfig.md):
+
+    ```javascript
+    const saslConfig = {
+      algorithm: SASL_AZURE_ENTRA,
+      scope: "api://<your-app-registration-id>/.default",
+    };
+    ```
+
+    If `scope` is left empty, the previous hostname-derived behavior is used.
+
 </details>
 
 ## Avro Union Types

--- a/README.md
+++ b/README.md
@@ -724,7 +724,7 @@ For v2.0.0+ examples using the new constructors (`Producer`, `Consumer`, `AdminC
 
     You can use the `AWS_PROFILE` environment variable to specify the profile name or use the `awsProfile` option in the `SASLConfig` [object](api-docs/v2/docs/interfaces/SASLConfig.md).
 
-17. My Azure Entra OAuth (or GCP OAuth) authentication fails because the token scope/audience doesn't match my broker. How can I fix that?
+17. My Azure Entra OAuth authentication fails because the token scope/audience doesn't match my broker. How can I fix that? (Note: custom scope override is only supported for Azure Entra OAuth at this point, not GCP OAuth.)
 
     By default, the Azure Entra OAuth provider derives the scope from the broker's hostname, i.e. `https://<broker-host>/.default`. This doesn't work for every setup, for example, managed Kafka providers may expect a scope tied to an Azure App Registration's Application ID URI (e.g. `api://<app-id>/.default`) instead. You can override the derived scope with the `scope` option in the `SASLConfig` [object](api-docs/v2/docs/interfaces/SASLConfig.md):
 

--- a/api-docs/index.d.ts
+++ b/api-docs/index.d.ts
@@ -112,6 +112,7 @@ export interface SASLConfig {
   password: string;
   algorithm: SASL_MECHANISMS;
   awsProfile: string;
+  scope?: string;
   kerberosConfig?: KerberosConfig;
 }
 

--- a/api-docs/v2/docs/classes/AdminClient.md
+++ b/api-docs/v2/docs/classes/AdminClient.md
@@ -4,7 +4,7 @@
 
 # Class: AdminClient
 
-Defined in: [index.d.ts:482](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L482)
+Defined in: [index.d.ts:483](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L483)
 
 ## Classdesc
 
@@ -31,7 +31,7 @@ adminClient.close();
 
 > **new AdminClient**(`connectionConfig`): `AdminClient`
 
-Defined in: [index.d.ts:483](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L483)
+Defined in: [index.d.ts:484](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L484)
 
 #### Parameters
 
@@ -49,7 +49,7 @@ Defined in: [index.d.ts:483](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **close**(): `void`
 
-Defined in: [index.d.ts:488](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L488)
+Defined in: [index.d.ts:489](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L489)
 
 #### Returns
 
@@ -61,7 +61,7 @@ Defined in: [index.d.ts:488](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **createTopic**(`topicConfig`): `void`
 
-Defined in: [index.d.ts:484](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L484)
+Defined in: [index.d.ts:485](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L485)
 
 #### Parameters
 
@@ -79,7 +79,7 @@ Defined in: [index.d.ts:484](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **deleteTopic**(`topic`): `void`
 
-Defined in: [index.d.ts:485](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L485)
+Defined in: [index.d.ts:486](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L486)
 
 #### Parameters
 
@@ -97,7 +97,7 @@ Defined in: [index.d.ts:485](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **getMetadata**(`topic`): [`TopicMetadata`](../interfaces/TopicMetadata.md)
 
-Defined in: [index.d.ts:487](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L487)
+Defined in: [index.d.ts:488](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L488)
 
 #### Parameters
 
@@ -115,7 +115,7 @@ Defined in: [index.d.ts:487](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **listTopics**(): [`TopicInfo`](../interfaces/TopicInfo.md)[]
 
-Defined in: [index.d.ts:486](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L486)
+Defined in: [index.d.ts:487](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L487)
 
 #### Returns
 

--- a/api-docs/v2/docs/classes/Connection.md
+++ b/api-docs/v2/docs/classes/Connection.md
@@ -4,7 +4,7 @@
 
 # ~~Class: Connection~~
 
-Defined in: [index.d.ts:494](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L494)
+Defined in: [index.d.ts:495](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L495)
 
 ## Deprecated
 
@@ -16,7 +16,7 @@ Use `AdminClient` instead. `Connection` remains as a compatibility alias in v2.x
 
 > **new Connection**(`connectionConfig`): `Connection`
 
-Defined in: [index.d.ts:501](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L501)
+Defined in: [index.d.ts:502](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L502)
 
 #### Parameters
 
@@ -38,7 +38,7 @@ Connection configuration.
 
 > **close**(): `void`
 
-Defined in: [index.d.ts:527](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L527)
+Defined in: [index.d.ts:528](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L528)
 
 #### Returns
 
@@ -58,7 +58,7 @@ Close the connection.
 
 > **createTopic**(`topicConfig`): `void`
 
-Defined in: [index.d.ts:508](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L508)
+Defined in: [index.d.ts:509](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L509)
 
 #### Parameters
 
@@ -84,7 +84,7 @@ Create a new topic.
 
 > **deleteTopic**(`topic`): `void`
 
-Defined in: [index.d.ts:515](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L515)
+Defined in: [index.d.ts:516](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L516)
 
 #### Parameters
 
@@ -110,7 +110,7 @@ Delete a topic.
 
 > **listTopics**(): `string`[]
 
-Defined in: [index.d.ts:521](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L521)
+Defined in: [index.d.ts:522](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L522)
 
 #### Returns
 

--- a/api-docs/v2/docs/classes/Consumer.md
+++ b/api-docs/v2/docs/classes/Consumer.md
@@ -4,7 +4,7 @@
 
 # Class: Consumer
 
-Defined in: [index.d.ts:428](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L428)
+Defined in: [index.d.ts:429](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L429)
 
 ## Classdesc
 
@@ -32,7 +32,7 @@ consumer.close();
 
 > **new Consumer**(`readerConfig`): `Consumer`
 
-Defined in: [index.d.ts:429](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L429)
+Defined in: [index.d.ts:430](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L430)
 
 #### Parameters
 
@@ -50,7 +50,7 @@ Defined in: [index.d.ts:429](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **close**(): `void`
 
-Defined in: [index.d.ts:435](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L435)
+Defined in: [index.d.ts:436](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L436)
 
 #### Returns
 
@@ -62,7 +62,7 @@ Defined in: [index.d.ts:435](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **commitOffsets**(): `void`
 
-Defined in: [index.d.ts:433](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L433)
+Defined in: [index.d.ts:434](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L434)
 
 #### Returns
 
@@ -74,7 +74,7 @@ Defined in: [index.d.ts:433](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **consume**(`consumeConfig`): [`Message`](../interfaces/Message.md)[]
 
-Defined in: [index.d.ts:430](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L430)
+Defined in: [index.d.ts:431](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L431)
 
 #### Parameters
 
@@ -92,7 +92,7 @@ Defined in: [index.d.ts:430](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **position**(`partition`): `number`
 
-Defined in: [index.d.ts:432](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L432)
+Defined in: [index.d.ts:433](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L433)
 
 #### Parameters
 
@@ -110,7 +110,7 @@ Defined in: [index.d.ts:432](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **seek**(`partition`, `offset`): `void`
 
-Defined in: [index.d.ts:431](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L431)
+Defined in: [index.d.ts:432](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L432)
 
 #### Parameters
 
@@ -132,7 +132,7 @@ Defined in: [index.d.ts:431](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **stats**(): [`ConsumerStats`](../interfaces/ConsumerStats.md)
 
-Defined in: [index.d.ts:434](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L434)
+Defined in: [index.d.ts:435](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L435)
 
 #### Returns
 

--- a/api-docs/v2/docs/classes/Producer.md
+++ b/api-docs/v2/docs/classes/Producer.md
@@ -4,7 +4,7 @@
 
 # Class: Producer
 
-Defined in: [index.d.ts:375](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L375)
+Defined in: [index.d.ts:376](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L376)
 
 ## Classdesc
 
@@ -40,7 +40,7 @@ producer.close();
 
 > **new Producer**(`writerConfig`): `Producer`
 
-Defined in: [index.d.ts:376](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L376)
+Defined in: [index.d.ts:377](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L377)
 
 #### Parameters
 
@@ -58,7 +58,7 @@ Defined in: [index.d.ts:376](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **close**(): `void`
 
-Defined in: [index.d.ts:380](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L380)
+Defined in: [index.d.ts:381](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L381)
 
 #### Returns
 
@@ -70,7 +70,7 @@ Defined in: [index.d.ts:380](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **flush**(): `void`
 
-Defined in: [index.d.ts:378](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L378)
+Defined in: [index.d.ts:379](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L379)
 
 #### Returns
 
@@ -82,7 +82,7 @@ Defined in: [index.d.ts:378](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **produce**(`produceConfig`): `void`
 
-Defined in: [index.d.ts:377](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L377)
+Defined in: [index.d.ts:378](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L378)
 
 #### Parameters
 
@@ -100,7 +100,7 @@ Defined in: [index.d.ts:377](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **stats**(): [`ProducerStats`](../interfaces/ProducerStats.md)
 
-Defined in: [index.d.ts:379](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L379)
+Defined in: [index.d.ts:380](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L380)
 
 #### Returns
 

--- a/api-docs/v2/docs/classes/Reader.md
+++ b/api-docs/v2/docs/classes/Reader.md
@@ -4,7 +4,7 @@
 
 # ~~Class: Reader~~
 
-Defined in: [index.d.ts:441](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L441)
+Defined in: [index.d.ts:442](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L442)
 
 ## Deprecated
 
@@ -16,7 +16,7 @@ Use `Consumer` instead. `Reader` remains as a compatibility alias in v2.x.
 
 > **new Reader**(`readerConfig`): `Reader`
 
-Defined in: [index.d.ts:448](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L448)
+Defined in: [index.d.ts:449](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L449)
 
 #### Parameters
 
@@ -38,7 +38,7 @@ Reader configuration.
 
 > **close**(): `void`
 
-Defined in: [index.d.ts:461](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L461)
+Defined in: [index.d.ts:462](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L462)
 
 #### Returns
 
@@ -58,7 +58,7 @@ Close the reader.
 
 > **consume**(`consumeConfig`): [`Message`](../interfaces/Message.md)[]
 
-Defined in: [index.d.ts:455](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L455)
+Defined in: [index.d.ts:456](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L456)
 
 #### Parameters
 

--- a/api-docs/v2/docs/classes/SchemaRegistry.md
+++ b/api-docs/v2/docs/classes/SchemaRegistry.md
@@ -4,7 +4,7 @@
 
 # Class: SchemaRegistry
 
-Defined in: [index.d.ts:582](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L582)
+Defined in: [index.d.ts:583](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L583)
 
 ## Classdesc
 
@@ -65,7 +65,7 @@ writer.produce({
 
 > **new SchemaRegistry**(`schemaRegistryConfig`): `SchemaRegistry`
 
-Defined in: [index.d.ts:589](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L589)
+Defined in: [index.d.ts:590](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L590)
 
 #### Parameters
 
@@ -87,7 +87,7 @@ Schema Registry configuration.
 
 > **createSchema**(`schema`): [`Schema`](../interfaces/Schema.md)
 
-Defined in: [index.d.ts:603](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L603)
+Defined in: [index.d.ts:604](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L604)
 
 #### Parameters
 
@@ -113,7 +113,7 @@ Create or update a schema on Schema Registry.
 
 > **deserialize**(`container`): `any`
 
-Defined in: [index.d.ts:624](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L624)
+Defined in: [index.d.ts:625](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L625)
 
 #### Parameters
 
@@ -139,7 +139,7 @@ Deserializes the given data and schema into its original form.
 
 > **getSchema**(`schema`): [`Schema`](../interfaces/Schema.md)
 
-Defined in: [index.d.ts:596](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L596)
+Defined in: [index.d.ts:597](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L597)
 
 #### Parameters
 
@@ -165,7 +165,7 @@ Get a schema from Schema Registry by version and subject.
 
 > **getSubjectName**(`subjectNameConfig`): `string`
 
-Defined in: [index.d.ts:610](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L610)
+Defined in: [index.d.ts:611](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L611)
 
 #### Parameters
 
@@ -191,7 +191,7 @@ Returns the subject name for the given SubjectNameConfig.
 
 > **serialize**(`container`): `Uint8Array`
 
-Defined in: [index.d.ts:617](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L617)
+Defined in: [index.d.ts:618](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L618)
 
 #### Parameters
 

--- a/api-docs/v2/docs/classes/Writer.md
+++ b/api-docs/v2/docs/classes/Writer.md
@@ -4,7 +4,7 @@
 
 # ~~Class: Writer~~
 
-Defined in: [index.d.ts:386](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L386)
+Defined in: [index.d.ts:387](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L387)
 
 ## Deprecated
 
@@ -16,7 +16,7 @@ Use `Producer` instead. `Writer` remains as a compatibility alias in v2.x.
 
 > **new Writer**(`writerConfig`): `Writer`
 
-Defined in: [index.d.ts:393](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L393)
+Defined in: [index.d.ts:394](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L394)
 
 #### Parameters
 
@@ -38,7 +38,7 @@ Writer configuration.
 
 > **close**(): `void`
 
-Defined in: [index.d.ts:406](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L406)
+Defined in: [index.d.ts:407](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L407)
 
 #### Returns
 
@@ -58,7 +58,7 @@ Close the writer.
 
 > **produce**(`produceConfig`): `void`
 
-Defined in: [index.d.ts:400](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L400)
+Defined in: [index.d.ts:401](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L401)
 
 #### Parameters
 

--- a/api-docs/v2/docs/functions/LoadJKS.md
+++ b/api-docs/v2/docs/functions/LoadJKS.md
@@ -6,7 +6,7 @@
 
 > **LoadJKS**(`jksConfig`): [`JKS`](../interfaces/JKS.md)
 
-Defined in: [index.d.ts:644](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L644)
+Defined in: [index.d.ts:645](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L645)
 
 **`Function`**
 

--- a/api-docs/v2/docs/interfaces/BasicAuth.md
+++ b/api-docs/v2/docs/interfaces/BasicAuth.md
@@ -4,7 +4,7 @@
 
 # Interface: BasicAuth
 
-Defined in: [index.d.ts:172](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L172)
+Defined in: [index.d.ts:173](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L173)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:172](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **password**: `string`
 
-Defined in: [index.d.ts:174](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L174)
+Defined in: [index.d.ts:175](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L175)
 
 ---
 
@@ -20,4 +20,4 @@ Defined in: [index.d.ts:174](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **username**: `string`
 
-Defined in: [index.d.ts:173](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L173)
+Defined in: [index.d.ts:174](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L174)

--- a/api-docs/v2/docs/interfaces/ConfigEntry.md
+++ b/api-docs/v2/docs/interfaces/ConfigEntry.md
@@ -4,7 +4,7 @@
 
 # Interface: ConfigEntry
 
-Defined in: [index.d.ts:255](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L255)
+Defined in: [index.d.ts:256](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L256)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:255](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **configName**: `string`
 
-Defined in: [index.d.ts:256](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L256)
+Defined in: [index.d.ts:257](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L257)
 
 ---
 
@@ -20,4 +20,4 @@ Defined in: [index.d.ts:256](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **configValue**: `string`
 
-Defined in: [index.d.ts:257](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L257)
+Defined in: [index.d.ts:258](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L258)

--- a/api-docs/v2/docs/interfaces/ConnectionConfig.md
+++ b/api-docs/v2/docs/interfaces/ConnectionConfig.md
@@ -4,7 +4,7 @@
 
 # Interface: ConnectionConfig
 
-Defined in: [index.d.ts:241](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L241)
+Defined in: [index.d.ts:242](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L242)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:241](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > `optional` **address?**: `string`
 
-Defined in: [index.d.ts:242](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L242)
+Defined in: [index.d.ts:243](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L243)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:242](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > `optional` **brokers?**: `string`[]
 
-Defined in: [index.d.ts:243](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L243)
+Defined in: [index.d.ts:244](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L244)
 
 ---
 
@@ -28,7 +28,7 @@ Defined in: [index.d.ts:243](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **sasl**: [`SASLConfig`](SASLConfig.md)
 
-Defined in: [index.d.ts:244](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L244)
+Defined in: [index.d.ts:245](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L245)
 
 ---
 
@@ -36,4 +36,4 @@ Defined in: [index.d.ts:244](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **tls**: [`TLSConfig`](TLSConfig.md)
 
-Defined in: [index.d.ts:245](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L245)
+Defined in: [index.d.ts:246](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L246)

--- a/api-docs/v2/docs/interfaces/ConsumeConfig.md
+++ b/api-docs/v2/docs/interfaces/ConsumeConfig.md
@@ -4,7 +4,7 @@
 
 # Interface: ConsumeConfig
 
-Defined in: [index.d.ts:226](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L226)
+Defined in: [index.d.ts:227](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L227)
 
 Configuration for Consume method.
 
@@ -14,7 +14,7 @@ Configuration for Consume method.
 
 > **expectTimeout**: `boolean`
 
-Defined in: [index.d.ts:237](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L237)
+Defined in: [index.d.ts:238](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L238)
 
 If true, return whatever messages have been collected when maxWait is
 passed.
@@ -25,7 +25,7 @@ passed.
 
 > `optional` **limit?**: `number`
 
-Defined in: [index.d.ts:228](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L228)
+Defined in: [index.d.ts:229](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L229)
 
 collect this many messages before returning.
 
@@ -35,7 +35,7 @@ collect this many messages before returning.
 
 > `optional` **maxMessages?**: `number`
 
-Defined in: [index.d.ts:230](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L230)
+Defined in: [index.d.ts:231](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L231)
 
 preferred v2 alias for limit.
 
@@ -45,6 +45,6 @@ preferred v2 alias for limit.
 
 > **nanoPrecision**: `boolean`
 
-Defined in: [index.d.ts:232](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L232)
+Defined in: [index.d.ts:233](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L233)
 
 If true, returned message RFC3339 timestamps carry nanosecond precision.

--- a/api-docs/v2/docs/interfaces/ConsumerStats.md
+++ b/api-docs/v2/docs/interfaces/ConsumerStats.md
@@ -4,7 +4,7 @@
 
 # Interface: ConsumerStats
 
-Defined in: [index.d.ts:273](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L273)
+Defined in: [index.d.ts:274](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L274)
 
 ## Properties
 
@@ -12,4 +12,4 @@ Defined in: [index.d.ts:273](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **assignments**: `number`
 
-Defined in: [index.d.ts:274](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L274)
+Defined in: [index.d.ts:275](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L275)

--- a/api-docs/v2/docs/interfaces/Container.md
+++ b/api-docs/v2/docs/interfaces/Container.md
@@ -4,7 +4,7 @@
 
 # Interface: Container
 
-Defined in: [index.d.ts:326](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L326)
+Defined in: [index.d.ts:327](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L327)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:326](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **data**: `any`
 
-Defined in: [index.d.ts:327](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L327)
+Defined in: [index.d.ts:328](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L328)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:327](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > `optional` **protobufFormat?**: `"object"` \| `"bytes"`
 
-Defined in: [index.d.ts:330](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L330)
+Defined in: [index.d.ts:331](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L331)
 
 ---
 
@@ -28,7 +28,7 @@ Defined in: [index.d.ts:330](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **schema**: [`Schema`](Schema.md)
 
-Defined in: [index.d.ts:328](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L328)
+Defined in: [index.d.ts:329](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L329)
 
 ---
 
@@ -36,4 +36,4 @@ Defined in: [index.d.ts:328](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **schemaType**: [`SCHEMA_TYPES`](../enumerations/SCHEMA_TYPES.md)
 
-Defined in: [index.d.ts:329](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L329)
+Defined in: [index.d.ts:330](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L330)

--- a/api-docs/v2/docs/interfaces/JKS.md
+++ b/api-docs/v2/docs/interfaces/JKS.md
@@ -4,7 +4,7 @@
 
 # Interface: JKS
 
-Defined in: [index.d.ts:342](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L342)
+Defined in: [index.d.ts:343](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L343)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:342](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **clientCertsPem**: `string`[]
 
-Defined in: [index.d.ts:343](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L343)
+Defined in: [index.d.ts:344](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L344)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:343](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **clientKeyPem**: `string`
 
-Defined in: [index.d.ts:344](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L344)
+Defined in: [index.d.ts:345](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L345)
 
 ---
 
@@ -28,4 +28,4 @@ Defined in: [index.d.ts:344](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **serverCaPem**: `string`
 
-Defined in: [index.d.ts:345](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L345)
+Defined in: [index.d.ts:346](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L346)

--- a/api-docs/v2/docs/interfaces/JKSConfig.md
+++ b/api-docs/v2/docs/interfaces/JKSConfig.md
@@ -4,7 +4,7 @@
 
 # Interface: JKSConfig
 
-Defined in: [index.d.ts:333](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L333)
+Defined in: [index.d.ts:334](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L334)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:333](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **clientCertAlias**: `string`
 
-Defined in: [index.d.ts:336](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L336)
+Defined in: [index.d.ts:337](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L337)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:336](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **clientKeyAlias**: `string`
 
-Defined in: [index.d.ts:337](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L337)
+Defined in: [index.d.ts:338](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L338)
 
 ---
 
@@ -28,7 +28,7 @@ Defined in: [index.d.ts:337](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **clientKeyPassword**: `string`
 
-Defined in: [index.d.ts:338](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L338)
+Defined in: [index.d.ts:339](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L339)
 
 ---
 
@@ -36,7 +36,7 @@ Defined in: [index.d.ts:338](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **password**: `string`
 
-Defined in: [index.d.ts:335](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L335)
+Defined in: [index.d.ts:336](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L336)
 
 ---
 
@@ -44,7 +44,7 @@ Defined in: [index.d.ts:335](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **path**: `string`
 
-Defined in: [index.d.ts:334](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L334)
+Defined in: [index.d.ts:335](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L335)
 
 ---
 
@@ -52,4 +52,4 @@ Defined in: [index.d.ts:334](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **serverCaAlias**: `string`
 
-Defined in: [index.d.ts:339](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L339)
+Defined in: [index.d.ts:340](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L340)

--- a/api-docs/v2/docs/interfaces/KerberosConfig.md
+++ b/api-docs/v2/docs/interfaces/KerberosConfig.md
@@ -4,7 +4,7 @@
 
 # Interface: KerberosConfig
 
-Defined in: [index.d.ts:119](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L119)
+Defined in: [index.d.ts:120](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L120)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:119](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > `optional` **keyTab?**: `string`
 
-Defined in: [index.d.ts:123](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L123)
+Defined in: [index.d.ts:124](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L124)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:123](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > `optional` **kInitCmd?**: `string`
 
-Defined in: [index.d.ts:122](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L122)
+Defined in: [index.d.ts:123](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L123)
 
 ---
 
@@ -28,7 +28,7 @@ Defined in: [index.d.ts:122](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > `optional` **minTimeBeforeRelogin?**: `number`
 
-Defined in: [index.d.ts:124](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L124)
+Defined in: [index.d.ts:125](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L125)
 
 ---
 
@@ -36,7 +36,7 @@ Defined in: [index.d.ts:124](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > `optional` **principal?**: `string`
 
-Defined in: [index.d.ts:121](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L121)
+Defined in: [index.d.ts:122](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L122)
 
 ---
 
@@ -44,4 +44,4 @@ Defined in: [index.d.ts:121](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > `optional` **serviceName?**: `string`
 
-Defined in: [index.d.ts:120](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L120)
+Defined in: [index.d.ts:121](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L121)

--- a/api-docs/v2/docs/interfaces/Message.md
+++ b/api-docs/v2/docs/interfaces/Message.md
@@ -4,7 +4,7 @@
 
 # Interface: Message
 
-Defined in: [index.d.ts:160](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L160)
+Defined in: [index.d.ts:161](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L161)
 
 Message format for producing messages to a topic.
 @note: The message format will be adopted by the reader at some point.
@@ -15,7 +15,7 @@ Message format for producing messages to a topic.
 
 > **headers**: `Map`\<`string`, `any`\>
 
-Defined in: [index.d.ts:167](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L167)
+Defined in: [index.d.ts:168](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L168)
 
 ---
 
@@ -23,7 +23,7 @@ Defined in: [index.d.ts:167](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **highwaterMark**: `number`
 
-Defined in: [index.d.ts:164](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L164)
+Defined in: [index.d.ts:165](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L165)
 
 ---
 
@@ -31,7 +31,7 @@ Defined in: [index.d.ts:164](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **key**: `Uint8Array`
 
-Defined in: [index.d.ts:165](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L165)
+Defined in: [index.d.ts:166](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L166)
 
 ---
 
@@ -39,7 +39,7 @@ Defined in: [index.d.ts:165](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **offset**: `number`
 
-Defined in: [index.d.ts:163](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L163)
+Defined in: [index.d.ts:164](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L164)
 
 ---
 
@@ -47,7 +47,7 @@ Defined in: [index.d.ts:163](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **partition**: `number`
 
-Defined in: [index.d.ts:162](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L162)
+Defined in: [index.d.ts:163](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L163)
 
 ---
 
@@ -55,7 +55,7 @@ Defined in: [index.d.ts:162](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **time**: `Date`
 
-Defined in: [index.d.ts:168](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L168)
+Defined in: [index.d.ts:169](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L169)
 
 ---
 
@@ -63,7 +63,7 @@ Defined in: [index.d.ts:168](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **topic**: `string`
 
-Defined in: [index.d.ts:161](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L161)
+Defined in: [index.d.ts:162](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L162)
 
 ---
 
@@ -71,4 +71,4 @@ Defined in: [index.d.ts:161](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **value**: `Uint8Array`
 
-Defined in: [index.d.ts:166](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L166)
+Defined in: [index.d.ts:167](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L167)

--- a/api-docs/v2/docs/interfaces/PartitionInfo.md
+++ b/api-docs/v2/docs/interfaces/PartitionInfo.md
@@ -4,7 +4,7 @@
 
 # Interface: PartitionInfo
 
-Defined in: [index.d.ts:283](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L283)
+Defined in: [index.d.ts:284](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L284)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:283](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **error**: `any`
 
-Defined in: [index.d.ts:288](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L288)
+Defined in: [index.d.ts:289](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L289)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:288](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **id**: `number`
 
-Defined in: [index.d.ts:284](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L284)
+Defined in: [index.d.ts:285](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L285)
 
 ---
 
@@ -28,7 +28,7 @@ Defined in: [index.d.ts:284](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **isrs**: `number`[]
 
-Defined in: [index.d.ts:287](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L287)
+Defined in: [index.d.ts:288](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L288)
 
 ---
 
@@ -36,7 +36,7 @@ Defined in: [index.d.ts:287](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **leader**: `number`
 
-Defined in: [index.d.ts:285](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L285)
+Defined in: [index.d.ts:286](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L286)
 
 ---
 
@@ -44,4 +44,4 @@ Defined in: [index.d.ts:285](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **replicas**: `number`[]
 
-Defined in: [index.d.ts:286](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L286)
+Defined in: [index.d.ts:287](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L287)

--- a/api-docs/v2/docs/interfaces/ProduceConfig.md
+++ b/api-docs/v2/docs/interfaces/ProduceConfig.md
@@ -4,7 +4,7 @@
 
 # Interface: ProduceConfig
 
-Defined in: [index.d.ts:186](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L186)
+Defined in: [index.d.ts:187](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L187)
 
 ## Properties
 
@@ -12,4 +12,4 @@ Defined in: [index.d.ts:186](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **messages**: [`Message`](Message.md)[]
 
-Defined in: [index.d.ts:187](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L187)
+Defined in: [index.d.ts:188](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L188)

--- a/api-docs/v2/docs/interfaces/ProducerStats.md
+++ b/api-docs/v2/docs/interfaces/ProducerStats.md
@@ -4,7 +4,7 @@
 
 # Interface: ProducerStats
 
-Defined in: [index.d.ts:269](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L269)
+Defined in: [index.d.ts:270](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L270)
 
 ## Properties
 
@@ -12,4 +12,4 @@ Defined in: [index.d.ts:269](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **pending**: `number`
 
-Defined in: [index.d.ts:270](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L270)
+Defined in: [index.d.ts:271](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L271)

--- a/api-docs/v2/docs/interfaces/ReaderConfig.md
+++ b/api-docs/v2/docs/interfaces/ReaderConfig.md
@@ -4,7 +4,7 @@
 
 # Interface: ReaderConfig
 
-Defined in: [index.d.ts:191](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L191)
+Defined in: [index.d.ts:192](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L192)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:191](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **brokers**: `string`[]
 
-Defined in: [index.d.ts:192](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L192)
+Defined in: [index.d.ts:193](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L193)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:192](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **commitInterval**: `number`
 
-Defined in: [index.d.ts:207](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L207)
+Defined in: [index.d.ts:208](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L208)
 
 ---
 
@@ -28,7 +28,7 @@ Defined in: [index.d.ts:207](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **connectLogger**: `boolean`
 
-Defined in: [index.d.ts:217](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L217)
+Defined in: [index.d.ts:218](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L218)
 
 ---
 
@@ -36,7 +36,7 @@ Defined in: [index.d.ts:217](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **groupBalancers**: [`GROUP_BALANCERS`](../enumerations/GROUP_BALANCERS.md)[]
 
-Defined in: [index.d.ts:205](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L205)
+Defined in: [index.d.ts:206](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L206)
 
 ---
 
@@ -44,7 +44,7 @@ Defined in: [index.d.ts:205](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **groupId**: `string`
 
-Defined in: [index.d.ts:193](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L193)
+Defined in: [index.d.ts:194](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L194)
 
 ---
 
@@ -52,7 +52,7 @@ Defined in: [index.d.ts:193](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > `optional` **groupID?**: `string`
 
-Defined in: [index.d.ts:195](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L195)
+Defined in: [index.d.ts:196](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L196)
 
 #### Deprecated
 
@@ -64,7 +64,7 @@ Use `groupId` instead.
 
 > **groupTopics**: `string`[]
 
-Defined in: [index.d.ts:196](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L196)
+Defined in: [index.d.ts:197](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L197)
 
 ---
 
@@ -72,7 +72,7 @@ Defined in: [index.d.ts:196](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **heartbeatInterval**: `number`
 
-Defined in: [index.d.ts:206](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L206)
+Defined in: [index.d.ts:207](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L207)
 
 ---
 
@@ -80,7 +80,7 @@ Defined in: [index.d.ts:206](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **isolationLevel**: [`ISOLATION_LEVEL`](../enumerations/ISOLATION_LEVEL.md)
 
-Defined in: [index.d.ts:219](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L219)
+Defined in: [index.d.ts:220](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L220)
 
 ---
 
@@ -88,7 +88,7 @@ Defined in: [index.d.ts:219](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **joinGroupBackoff**: `number`
 
-Defined in: [index.d.ts:212](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L212)
+Defined in: [index.d.ts:213](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L213)
 
 ---
 
@@ -96,7 +96,7 @@ Defined in: [index.d.ts:212](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **maxAttempts**: `number`
 
-Defined in: [index.d.ts:218](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L218)
+Defined in: [index.d.ts:219](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L219)
 
 ---
 
@@ -104,7 +104,7 @@ Defined in: [index.d.ts:218](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **maxBytes**: `number`
 
-Defined in: [index.d.ts:201](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L201)
+Defined in: [index.d.ts:202](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L202)
 
 ---
 
@@ -112,7 +112,7 @@ Defined in: [index.d.ts:201](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **maxWait**: `string`
 
-Defined in: [index.d.ts:203](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L203)
+Defined in: [index.d.ts:204](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L204)
 
 ---
 
@@ -120,7 +120,7 @@ Defined in: [index.d.ts:203](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **minBytes**: `number`
 
-Defined in: [index.d.ts:200](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L200)
+Defined in: [index.d.ts:201](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L201)
 
 ---
 
@@ -128,7 +128,7 @@ Defined in: [index.d.ts:200](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **offset**: `number`
 
-Defined in: [index.d.ts:220](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L220)
+Defined in: [index.d.ts:221](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L221)
 
 ---
 
@@ -136,7 +136,7 @@ Defined in: [index.d.ts:220](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **partition**: `number`
 
-Defined in: [index.d.ts:198](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L198)
+Defined in: [index.d.ts:199](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L199)
 
 ---
 
@@ -144,7 +144,7 @@ Defined in: [index.d.ts:198](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **partitionWatchInterval**: `number`
 
-Defined in: [index.d.ts:208](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L208)
+Defined in: [index.d.ts:209](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L209)
 
 ---
 
@@ -152,7 +152,7 @@ Defined in: [index.d.ts:208](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **queueCapacity**: `number`
 
-Defined in: [index.d.ts:199](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L199)
+Defined in: [index.d.ts:200](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L200)
 
 ---
 
@@ -160,7 +160,7 @@ Defined in: [index.d.ts:199](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **readBackoffMax**: `number`
 
-Defined in: [index.d.ts:216](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L216)
+Defined in: [index.d.ts:217](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L217)
 
 ---
 
@@ -168,7 +168,7 @@ Defined in: [index.d.ts:216](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **readBackoffMin**: `number`
 
-Defined in: [index.d.ts:215](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L215)
+Defined in: [index.d.ts:216](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L216)
 
 ---
 
@@ -176,7 +176,7 @@ Defined in: [index.d.ts:215](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **readBatchTimeout**: `number`
 
-Defined in: [index.d.ts:202](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L202)
+Defined in: [index.d.ts:203](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L203)
 
 ---
 
@@ -184,7 +184,7 @@ Defined in: [index.d.ts:202](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **readLagInterval**: `number`
 
-Defined in: [index.d.ts:204](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L204)
+Defined in: [index.d.ts:205](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L205)
 
 ---
 
@@ -192,7 +192,7 @@ Defined in: [index.d.ts:204](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **rebalanceTimeout**: `number`
 
-Defined in: [index.d.ts:211](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L211)
+Defined in: [index.d.ts:212](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L212)
 
 ---
 
@@ -200,7 +200,7 @@ Defined in: [index.d.ts:211](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **retentionTime**: `number`
 
-Defined in: [index.d.ts:213](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L213)
+Defined in: [index.d.ts:214](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L214)
 
 ---
 
@@ -208,7 +208,7 @@ Defined in: [index.d.ts:213](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **sasl**: [`SASLConfig`](SASLConfig.md)
 
-Defined in: [index.d.ts:221](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L221)
+Defined in: [index.d.ts:222](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L222)
 
 ---
 
@@ -216,7 +216,7 @@ Defined in: [index.d.ts:221](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **sessionTimeout**: `number`
 
-Defined in: [index.d.ts:210](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L210)
+Defined in: [index.d.ts:211](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L211)
 
 ---
 
@@ -224,7 +224,7 @@ Defined in: [index.d.ts:210](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **startOffset**: [`START_OFFSETS`](../enumerations/START_OFFSETS.md)
 
-Defined in: [index.d.ts:214](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L214)
+Defined in: [index.d.ts:215](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L215)
 
 ---
 
@@ -232,7 +232,7 @@ Defined in: [index.d.ts:214](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **tls**: [`TLSConfig`](TLSConfig.md)
 
-Defined in: [index.d.ts:222](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L222)
+Defined in: [index.d.ts:223](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L223)
 
 ---
 
@@ -240,7 +240,7 @@ Defined in: [index.d.ts:222](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **topic**: `string`
 
-Defined in: [index.d.ts:197](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L197)
+Defined in: [index.d.ts:198](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L198)
 
 ---
 
@@ -248,4 +248,4 @@ Defined in: [index.d.ts:197](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **watchPartitionChanges**: `boolean`
 
-Defined in: [index.d.ts:209](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L209)
+Defined in: [index.d.ts:210](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L210)

--- a/api-docs/v2/docs/interfaces/Reference.md
+++ b/api-docs/v2/docs/interfaces/Reference.md
@@ -4,7 +4,7 @@
 
 # Interface: Reference
 
-Defined in: [index.d.ts:299](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L299)
+Defined in: [index.d.ts:300](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L300)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:299](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **name**: `string`
 
-Defined in: [index.d.ts:300](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L300)
+Defined in: [index.d.ts:301](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L301)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:300](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **subject**: `string`
 
-Defined in: [index.d.ts:301](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L301)
+Defined in: [index.d.ts:302](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L302)
 
 ---
 
@@ -28,4 +28,4 @@ Defined in: [index.d.ts:301](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **version**: `number`
 
-Defined in: [index.d.ts:302](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L302)
+Defined in: [index.d.ts:303](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L303)

--- a/api-docs/v2/docs/interfaces/ReplicaAssignment.md
+++ b/api-docs/v2/docs/interfaces/ReplicaAssignment.md
@@ -4,7 +4,7 @@
 
 # Interface: ReplicaAssignment
 
-Defined in: [index.d.ts:249](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L249)
+Defined in: [index.d.ts:250](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L250)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:249](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **partition**: `number`
 
-Defined in: [index.d.ts:250](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L250)
+Defined in: [index.d.ts:251](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L251)
 
 ---
 
@@ -20,4 +20,4 @@ Defined in: [index.d.ts:250](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **replicas**: `number`[]
 
-Defined in: [index.d.ts:251](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L251)
+Defined in: [index.d.ts:252](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L252)

--- a/api-docs/v2/docs/interfaces/SASLConfig.md
+++ b/api-docs/v2/docs/interfaces/SASLConfig.md
@@ -28,7 +28,7 @@ Defined in: [index.d.ts:114](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > `optional` **kerberosConfig?**: [`KerberosConfig`](KerberosConfig.md)
 
-Defined in: [index.d.ts:115](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L115)
+Defined in: [index.d.ts:116](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L116)
 
 ---
 
@@ -37,6 +37,14 @@ Defined in: [index.d.ts:115](https://github.com/mostafa/xk6-kafka/blob/main/api-
 > **password**: `string`
 
 Defined in: [index.d.ts:112](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L112)
+
+---
+
+### scope?
+
+> `optional` **scope?**: `string`
+
+Defined in: [index.d.ts:115](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L115)
 
 ---
 

--- a/api-docs/v2/docs/interfaces/Schema.md
+++ b/api-docs/v2/docs/interfaces/Schema.md
@@ -4,7 +4,7 @@
 
 # Interface: Schema
 
-Defined in: [index.d.ts:306](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L306)
+Defined in: [index.d.ts:307](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L307)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:306](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > `optional` **dependencies?**: `Record`\<`string`, `string`\>
 
-Defined in: [index.d.ts:315](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L315)
+Defined in: [index.d.ts:316](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L316)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:315](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **enableCaching**: `boolean`
 
-Defined in: [index.d.ts:307](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L307)
+Defined in: [index.d.ts:308](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L308)
 
 ---
 
@@ -28,7 +28,7 @@ Defined in: [index.d.ts:307](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **id**: `number`
 
-Defined in: [index.d.ts:308](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L308)
+Defined in: [index.d.ts:309](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L309)
 
 ---
 
@@ -36,7 +36,7 @@ Defined in: [index.d.ts:308](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > `optional` **messageName?**: `string`
 
-Defined in: [index.d.ts:314](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L314)
+Defined in: [index.d.ts:315](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L315)
 
 ---
 
@@ -44,7 +44,7 @@ Defined in: [index.d.ts:314](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **references**: [`Reference`](Reference.md)[]
 
-Defined in: [index.d.ts:312](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L312)
+Defined in: [index.d.ts:313](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L313)
 
 ---
 
@@ -52,7 +52,7 @@ Defined in: [index.d.ts:312](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **schema**: `string`
 
-Defined in: [index.d.ts:309](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L309)
+Defined in: [index.d.ts:310](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L310)
 
 ---
 
@@ -60,7 +60,7 @@ Defined in: [index.d.ts:309](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **schemaType**: [`SCHEMA_TYPES`](../enumerations/SCHEMA_TYPES.md)
 
-Defined in: [index.d.ts:310](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L310)
+Defined in: [index.d.ts:311](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L311)
 
 ---
 
@@ -68,7 +68,7 @@ Defined in: [index.d.ts:310](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **subject**: `string`
 
-Defined in: [index.d.ts:313](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L313)
+Defined in: [index.d.ts:314](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L314)
 
 ---
 
@@ -76,4 +76,4 @@ Defined in: [index.d.ts:313](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **version**: `number`
 
-Defined in: [index.d.ts:311](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L311)
+Defined in: [index.d.ts:312](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L312)

--- a/api-docs/v2/docs/interfaces/SchemaRegistryConfig.md
+++ b/api-docs/v2/docs/interfaces/SchemaRegistryConfig.md
@@ -4,7 +4,7 @@
 
 # Interface: SchemaRegistryConfig
 
-Defined in: [index.d.ts:178](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L178)
+Defined in: [index.d.ts:179](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L179)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:178](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **basicAuth**: [`BasicAuth`](BasicAuth.md)
 
-Defined in: [index.d.ts:181](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L181)
+Defined in: [index.d.ts:182](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L182)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:181](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **enableCaching**: `boolean`
 
-Defined in: [index.d.ts:180](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L180)
+Defined in: [index.d.ts:181](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L181)
 
 ---
 
@@ -28,7 +28,7 @@ Defined in: [index.d.ts:180](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **tls**: [`TLSConfig`](TLSConfig.md)
 
-Defined in: [index.d.ts:182](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L182)
+Defined in: [index.d.ts:183](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L183)
 
 ---
 
@@ -36,4 +36,4 @@ Defined in: [index.d.ts:182](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **url**: `string`
 
-Defined in: [index.d.ts:179](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L179)
+Defined in: [index.d.ts:180](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L180)

--- a/api-docs/v2/docs/interfaces/SubjectNameConfig.md
+++ b/api-docs/v2/docs/interfaces/SubjectNameConfig.md
@@ -4,7 +4,7 @@
 
 # Interface: SubjectNameConfig
 
-Defined in: [index.d.ts:318](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L318)
+Defined in: [index.d.ts:319](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L319)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:318](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **element**: [`ELEMENT_TYPES`](../enumerations/ELEMENT_TYPES.md)
 
-Defined in: [index.d.ts:321](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L321)
+Defined in: [index.d.ts:322](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L322)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:321](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > `optional` **messageName?**: `string`
 
-Defined in: [index.d.ts:323](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L323)
+Defined in: [index.d.ts:324](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L324)
 
 ---
 
@@ -28,7 +28,7 @@ Defined in: [index.d.ts:323](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **schema**: `string`
 
-Defined in: [index.d.ts:319](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L319)
+Defined in: [index.d.ts:320](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L320)
 
 ---
 
@@ -36,7 +36,7 @@ Defined in: [index.d.ts:319](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **subjectNameStrategy**: [`SUBJECT_NAME_STRATEGY`](../enumerations/SUBJECT_NAME_STRATEGY.md)
 
-Defined in: [index.d.ts:322](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L322)
+Defined in: [index.d.ts:323](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L323)
 
 ---
 
@@ -44,4 +44,4 @@ Defined in: [index.d.ts:322](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **topic**: `string`
 
-Defined in: [index.d.ts:320](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L320)
+Defined in: [index.d.ts:321](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L321)

--- a/api-docs/v2/docs/interfaces/TLSConfig.md
+++ b/api-docs/v2/docs/interfaces/TLSConfig.md
@@ -4,7 +4,7 @@
 
 # Interface: TLSConfig
 
-Defined in: [index.d.ts:128](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L128)
+Defined in: [index.d.ts:129](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L129)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:128](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **clientCertPem**: `string`
 
-Defined in: [index.d.ts:132](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L132)
+Defined in: [index.d.ts:133](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L133)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:132](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **clientKeyPem**: `string`
 
-Defined in: [index.d.ts:133](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L133)
+Defined in: [index.d.ts:134](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L134)
 
 ---
 
@@ -28,7 +28,7 @@ Defined in: [index.d.ts:133](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **enableTls**: `boolean`
 
-Defined in: [index.d.ts:129](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L129)
+Defined in: [index.d.ts:130](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L130)
 
 ---
 
@@ -36,7 +36,7 @@ Defined in: [index.d.ts:129](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **insecureSkipTlsVerify**: `boolean`
 
-Defined in: [index.d.ts:130](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L130)
+Defined in: [index.d.ts:131](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L131)
 
 ---
 
@@ -44,7 +44,7 @@ Defined in: [index.d.ts:130](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **minVersion**: [`TLS_VERSIONS`](../enumerations/TLS_VERSIONS.md)
 
-Defined in: [index.d.ts:131](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L131)
+Defined in: [index.d.ts:132](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L132)
 
 ---
 
@@ -52,4 +52,4 @@ Defined in: [index.d.ts:131](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **serverCaPem**: `string`
 
-Defined in: [index.d.ts:134](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L134)
+Defined in: [index.d.ts:135](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L135)

--- a/api-docs/v2/docs/interfaces/TopicConfig.md
+++ b/api-docs/v2/docs/interfaces/TopicConfig.md
@@ -4,7 +4,7 @@
 
 # Interface: TopicConfig
 
-Defined in: [index.d.ts:261](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L261)
+Defined in: [index.d.ts:262](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L262)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:261](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **configEntries**: [`ConfigEntry`](ConfigEntry.md)[]
 
-Defined in: [index.d.ts:266](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L266)
+Defined in: [index.d.ts:267](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L267)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:266](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **numPartitions**: `number`
 
-Defined in: [index.d.ts:263](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L263)
+Defined in: [index.d.ts:264](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L264)
 
 ---
 
@@ -28,7 +28,7 @@ Defined in: [index.d.ts:263](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **replicaAssignments**: [`ReplicaAssignment`](ReplicaAssignment.md)[]
 
-Defined in: [index.d.ts:265](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L265)
+Defined in: [index.d.ts:266](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L266)
 
 ---
 
@@ -36,7 +36,7 @@ Defined in: [index.d.ts:265](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **replicationFactor**: `number`
 
-Defined in: [index.d.ts:264](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L264)
+Defined in: [index.d.ts:265](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L265)
 
 ---
 
@@ -44,4 +44,4 @@ Defined in: [index.d.ts:264](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **topic**: `string`
 
-Defined in: [index.d.ts:262](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L262)
+Defined in: [index.d.ts:263](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L263)

--- a/api-docs/v2/docs/interfaces/TopicInfo.md
+++ b/api-docs/v2/docs/interfaces/TopicInfo.md
@@ -4,7 +4,7 @@
 
 # Interface: TopicInfo
 
-Defined in: [index.d.ts:277](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L277)
+Defined in: [index.d.ts:278](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L278)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:277](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **error**: `any`
 
-Defined in: [index.d.ts:280](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L280)
+Defined in: [index.d.ts:281](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L281)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:280](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **partitions**: `number`
 
-Defined in: [index.d.ts:279](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L279)
+Defined in: [index.d.ts:280](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L280)
 
 ---
 
@@ -28,4 +28,4 @@ Defined in: [index.d.ts:279](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **topic**: `string`
 
-Defined in: [index.d.ts:278](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L278)
+Defined in: [index.d.ts:279](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L279)

--- a/api-docs/v2/docs/interfaces/TopicMetadata.md
+++ b/api-docs/v2/docs/interfaces/TopicMetadata.md
@@ -4,7 +4,7 @@
 
 # Interface: TopicMetadata
 
-Defined in: [index.d.ts:291](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L291)
+Defined in: [index.d.ts:292](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L292)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:291](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **error**: `any`
 
-Defined in: [index.d.ts:294](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L294)
+Defined in: [index.d.ts:295](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L295)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:294](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **partitions**: [`PartitionInfo`](PartitionInfo.md)[]
 
-Defined in: [index.d.ts:293](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L293)
+Defined in: [index.d.ts:294](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L294)
 
 ---
 
@@ -28,4 +28,4 @@ Defined in: [index.d.ts:293](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **topic**: `string`
 
-Defined in: [index.d.ts:292](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L292)
+Defined in: [index.d.ts:293](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L293)

--- a/api-docs/v2/docs/interfaces/WriterConfig.md
+++ b/api-docs/v2/docs/interfaces/WriterConfig.md
@@ -4,7 +4,7 @@
 
 # Interface: WriterConfig
 
-Defined in: [index.d.ts:138](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L138)
+Defined in: [index.d.ts:139](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L139)
 
 ## Properties
 
@@ -12,7 +12,7 @@ Defined in: [index.d.ts:138](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **autoCreateTopic**: `boolean`
 
-Defined in: [index.d.ts:141](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L141)
+Defined in: [index.d.ts:142](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L142)
 
 ---
 
@@ -20,7 +20,7 @@ Defined in: [index.d.ts:141](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **balancer**: [`BALANCERS`](../enumerations/BALANCERS.md) \| [`BalancerFunction`](../type-aliases/BalancerFunction.md)
 
-Defined in: [index.d.ts:142](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L142)
+Defined in: [index.d.ts:143](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L143)
 
 ---
 
@@ -28,7 +28,7 @@ Defined in: [index.d.ts:142](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **batchBytes**: `number`
 
-Defined in: [index.d.ts:145](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L145)
+Defined in: [index.d.ts:146](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L146)
 
 ---
 
@@ -36,7 +36,7 @@ Defined in: [index.d.ts:145](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **batchSize**: `number`
 
-Defined in: [index.d.ts:144](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L144)
+Defined in: [index.d.ts:145](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L145)
 
 ---
 
@@ -44,7 +44,7 @@ Defined in: [index.d.ts:144](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **batchTimeout**: `number`
 
-Defined in: [index.d.ts:146](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L146)
+Defined in: [index.d.ts:147](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L147)
 
 ---
 
@@ -52,7 +52,7 @@ Defined in: [index.d.ts:146](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **brokers**: `string`[]
 
-Defined in: [index.d.ts:139](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L139)
+Defined in: [index.d.ts:140](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L140)
 
 ---
 
@@ -60,7 +60,7 @@ Defined in: [index.d.ts:139](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **compression**: [`COMPRESSION_CODECS`](../enumerations/COMPRESSION_CODECS.md)
 
-Defined in: [index.d.ts:150](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L150)
+Defined in: [index.d.ts:151](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L151)
 
 ---
 
@@ -68,7 +68,7 @@ Defined in: [index.d.ts:150](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **connectLogger**: `boolean`
 
-Defined in: [index.d.ts:153](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L153)
+Defined in: [index.d.ts:154](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L154)
 
 ---
 
@@ -76,7 +76,7 @@ Defined in: [index.d.ts:153](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **maxAttempts**: `number`
 
-Defined in: [index.d.ts:143](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L143)
+Defined in: [index.d.ts:144](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L144)
 
 ---
 
@@ -84,7 +84,7 @@ Defined in: [index.d.ts:143](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **readTimeout**: `number`
 
-Defined in: [index.d.ts:147](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L147)
+Defined in: [index.d.ts:148](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L148)
 
 ---
 
@@ -92,7 +92,7 @@ Defined in: [index.d.ts:147](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **requiredAcks**: `number`
 
-Defined in: [index.d.ts:148](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L148)
+Defined in: [index.d.ts:149](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L149)
 
 ---
 
@@ -100,7 +100,7 @@ Defined in: [index.d.ts:148](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **sasl**: [`SASLConfig`](SASLConfig.md)
 
-Defined in: [index.d.ts:151](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L151)
+Defined in: [index.d.ts:152](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L152)
 
 ---
 
@@ -108,7 +108,7 @@ Defined in: [index.d.ts:151](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **tls**: [`TLSConfig`](TLSConfig.md)
 
-Defined in: [index.d.ts:152](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L152)
+Defined in: [index.d.ts:153](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L153)
 
 ---
 
@@ -116,7 +116,7 @@ Defined in: [index.d.ts:152](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **topic**: `string`
 
-Defined in: [index.d.ts:140](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L140)
+Defined in: [index.d.ts:141](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L141)
 
 ---
 
@@ -124,4 +124,4 @@ Defined in: [index.d.ts:140](https://github.com/mostafa/xk6-kafka/blob/main/api-
 
 > **writeTimeout**: `number`
 
-Defined in: [index.d.ts:149](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L149)
+Defined in: [index.d.ts:150](https://github.com/mostafa/xk6-kafka/blob/main/api-docs/v2/index.d.ts#L150)

--- a/api-docs/v2/index.d.ts
+++ b/api-docs/v2/index.d.ts
@@ -112,6 +112,7 @@ export interface SASLConfig {
   password: string;
   algorithm: SASL_MECHANISMS;
   awsProfile: string;
+  scope?: string;
   kerberosConfig?: KerberosConfig;
 }
 

--- a/pkg/kafka/auth.go
+++ b/pkg/kafka/auth.go
@@ -28,6 +28,7 @@ type SASLConfig struct {
 	Algorithm      string         `json:"algorithm"`
 	AWSProfile     string         `json:"awsProfile"`
 	KerberosConfig KerberosConfig `json:"kerberosConfig"`
+	Scope          string         `json:"scope"`
 }
 
 type KerberosConfig struct {
@@ -51,7 +52,7 @@ func NewSaslContext(saslConfig SASLConfig, brokers []string, opts SASLContextOpt
 
 	switch saslConfig.Algorithm {
 	case saslAzureEntra, saslGcpOauth:
-		oauthProvider, err := NewOAuthProvider(saslConfig.Algorithm, brokers, opts.OAuthProviderOpts)
+		oauthProvider, err := NewOAuthProvider(saslConfig.Algorithm, saslConfig.Scope, brokers, opts.OAuthProviderOpts)
 		if err != nil {
 			return SASLContext{}, err
 		}

--- a/pkg/kafka/auth_test.go
+++ b/pkg/kafka/auth_test.go
@@ -38,6 +38,28 @@ func TestSASLContext(t *testing.T) {
 		require.NotNil(t, context.OAuthProvider)
 	})
 
+	t.Run("azure entra algorithm with custom oauth scope", func(t *testing.T) {
+		fakeToken := azcoreFake.TokenCredential{}
+
+		opts := SASLContextOpts{
+			OAuthProviderOpts: OAuthProviderOpts{
+				azureTokenCredential: &fakeToken,
+			},
+		}
+
+		context, err := NewSaslContext(SASLConfig{
+			Algorithm: saslAzureEntra,
+			Scope:     "api://custom-scope/.default",
+		}, []string{"broker1:9093"}, opts)
+
+		require.NoError(t, err)
+		require.NotNil(t, context.OAuthProvider)
+
+		provider, ok := (*context.OAuthProvider).(*AzureEntraOAuthTokenProvider)
+		require.True(t, ok, "expected *AzureEntraOAuthTokenProvider")
+		require.Equal(t, []string{"api://custom-scope/.default"}, provider.requestOpts.Scopes)
+	})
+
 	t.Run("gcp oauth algorithm with oauth context", func(t *testing.T) {
 		opts := SASLContextOpts{
 			OAuthProviderOpts: OAuthProviderOpts{

--- a/pkg/kafka/oauth.go
+++ b/pkg/kafka/oauth.go
@@ -49,9 +49,9 @@ type OAuthTokenHandler interface {
 	SetOAuthBearerTokenFailure(errstr string) error
 }
 
-func NewOAuthProvider(saslAlgorithm string, brokers []string, opts OAuthProviderOpts) (OAuthTokenProvider, error) {
+func NewOAuthProvider(saslAlgorithm string, scope string, brokers []string, opts OAuthProviderOpts) (OAuthTokenProvider, error) {
 	if saslAlgorithm == saslAzureEntra {
-		return newAzureEntraOAuthTokenProvider(brokers, opts.azureTokenCredential)
+		return newAzureEntraOAuthTokenProvider(brokers, scope, opts.azureTokenCredential)
 	}
 
 	if saslAlgorithm == saslGcpOauth {
@@ -69,7 +69,7 @@ type AzureEntraOAuthTokenProvider struct {
 var _ OAuthTokenProvider = (*AzureEntraOAuthTokenProvider)(nil)
 
 func newAzureEntraOAuthTokenProvider(
-	brokers []string, tokenCredential azcore.TokenCredential,
+	brokers []string, scope string, tokenCredential azcore.TokenCredential,
 ) (*AzureEntraOAuthTokenProvider, error) {
 	var cred azcore.TokenCredential
 	var err error
@@ -87,7 +87,9 @@ func newAzureEntraOAuthTokenProvider(
 		return nil, NewXk6KafkaError(failedGetOAuthToken, "Azure Entra OAuth requires a valid host:port for the broker.", err)
 	}
 
-	scope := fmt.Sprintf("https://%s/.default", host)
+	if scope == "" {
+		scope = fmt.Sprintf("https://%s/.default", host)
+	}
 
 	if tokenCredential == nil {
 		cred, err = azidentity.NewDefaultAzureCredential(nil)

--- a/pkg/kafka/oauth.go
+++ b/pkg/kafka/oauth.go
@@ -49,7 +49,9 @@ type OAuthTokenHandler interface {
 	SetOAuthBearerTokenFailure(errstr string) error
 }
 
-func NewOAuthProvider(saslAlgorithm string, scope string, brokers []string, opts OAuthProviderOpts) (OAuthTokenProvider, error) {
+func NewOAuthProvider(
+	saslAlgorithm string, scope string, brokers []string, opts OAuthProviderOpts,
+) (OAuthTokenProvider, error) {
 	if saslAlgorithm == saslAzureEntra {
 		return newAzureEntraOAuthTokenProvider(brokers, scope, opts.azureTokenCredential)
 	}

--- a/pkg/kafka/oauth_test.go
+++ b/pkg/kafka/oauth_test.go
@@ -123,7 +123,7 @@ func TestGetOAuthTokenSuccess(t *testing.T) {
 
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
-			provider, err := NewOAuthProvider(test.saslAlgorithm, []string{"broker1:9093"}, test.opts)
+			provider, err := NewOAuthProvider(test.saslAlgorithm, "", []string{"broker1:9093"}, test.opts)
 			require.NoError(t, err)
 
 			token, err := provider.GetToken(t.Context())
@@ -212,7 +212,7 @@ func TestGetOAuthTokenFailure(t *testing.T) {
 
 	for name, test := range testCases {
 		t.Run(name, func(t *testing.T) {
-			provider, err := NewOAuthProvider(test.saslAlgorithm, []string{"broker1:9093"}, test.opts)
+			provider, err := NewOAuthProvider(test.saslAlgorithm, "", []string{"broker1:9093"}, test.opts)
 			require.NoError(t, err)
 
 			_, err = provider.GetToken(t.Context())
@@ -227,6 +227,30 @@ func TestGetOAuthTokenFailure(t *testing.T) {
 }
 
 func TestUnsupportedOAuthProvider(t *testing.T) {
-	_, err := NewOAuthProvider(saslPlain, []string{"broker1"}, OAuthProviderOpts{})
+	_, err := NewOAuthProvider(saslPlain, "", []string{"broker1"}, OAuthProviderOpts{})
 	require.ErrorContains(t, err, "sasl_plain is not a supported OAuth Provider.")
+}
+
+func TestAzureEntraOAuthScopeOverride(t *testing.T) {
+	t.Run("derives scope from broker host when scope is empty", func(t *testing.T) {
+		provider, err := newAzureEntraOAuthTokenProvider(
+			[]string{"broker1.example.com:9093"},
+			"",
+			&testAzureEntraTokenCredential{Subject: "test-sub"},
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, []string{"https://broker1.example.com/.default"}, provider.requestOpts.Scopes)
+	})
+
+	t.Run("uses the explicit scope override when provided", func(t *testing.T) {
+		provider, err := newAzureEntraOAuthTokenProvider(
+			[]string{"broker1.example.com:9093"},
+			"api://custom-scope/.default",
+			&testAzureEntraTokenCredential{Subject: "test-sub"},
+		)
+
+		require.NoError(t, err)
+		require.Equal(t, []string{"api://custom-scope/.default"}, provider.requestOpts.Scopes)
+	})
 }


### PR DESCRIPTION
## Summary

Hi @mostafa, hope you're doing well! 

I've added an optional `scope` field to `SASLConfig` so we can override the OAuth scope/audience requested for `sasl_azure_entra`. Currently the scope is always derived from the broker hostname `https://<broker-host>/.default`, which doesn't work for setups where the token is tied to an Azure App ID e.g. `api://<app-id>/.default` rather than the broker's connection endpoint. Hence, auth fails with no workaround.

When `scope` is left empty, the existing hostname-derived behaviour is unchanged.

---

We've tested my fork with Azure & it worked with our custom scope. 

---

**Note:** I haven't regenerated `api-docs/` to keep this diff focused, happy to generate docs if you'd like that included in this PR.