### PR TITLE
chore: replace archived hamba/avro with confluent-avro-go

### DIFF
--- a/README.md
+++ b/README.md
@@ -745,7 +745,7 @@ For v2.0.0+ examples using the new constructors (`Producer`, `Consumer`, `AdminC
 
 ## Avro Union Types
 
-xk6-kafka uses `hamba/avro` for Avro serialization/deserialization. When working with Avro union types, you can usually provide union values directly without wrapping them in type-specific objects. For nullable fields, you can use `null` directly. For logical primitive unions (for example `int` with `logicalType: "date"`), direct values and wrapped values like `{ "int": 20474 }` or `{ "int.date": 20474 }` are supported and normalized before encoding. See the [Schema Registry documentation](./docs/schema-registry.md#complex-schemas--manage-union-types) for detailed examples and best practices.
+xk6-kafka uses [`confluent-avro-go`](https://github.com/confluentinc/confluent-avro-go) (Confluent's maintained fork of the archived `hamba/avro`) for Avro serialization/deserialization. When working with Avro union types, you can usually provide union values directly without wrapping them in type-specific objects. For nullable fields, you can use `null` directly. For logical primitive unions (for example `int` with `logicalType: "date"`), direct values and wrapped values like `{ "int": 20474 }` or `{ "int.date": 20474 }` are supported and normalized before encoding. See the [Schema Registry documentation](./docs/schema-registry.md#complex-schemas--manage-union-types) for detailed examples and best practices.
 
 ## Contributions, Issues and Feedback
 

--- a/docs/schema-registry.md
+++ b/docs/schema-registry.md
@@ -190,7 +190,7 @@ For example, if you have a union type schema like this:
 }
 ```
 
-Here `myField` can either be a string or null. When serializing data for this schema with hamba/avro, you can provide the value directly:
+Here `myField` can either be a string or null. When serializing data for this schema with confluent-avro-go, you can provide the value directly:
 
 ```javascript
 export const productionOrder = {
@@ -200,7 +200,7 @@ export const productionOrder = {
 };
 ```
 
-With hamba/avro, you usually don't need to wrap union values in a type-specific object. Simply provide the value that matches one of the union types. For nullable fields, you can use `null` directly.
+With confluent-avro-go, you usually don't need to wrap union values in a type-specific object. Simply provide the value that matches one of the union types. For nullable fields, you can use `null` directly.
 
 For unions with logical primitive types (for example `["null", {"type":"int","logicalType":"date"}]`), xk6-kafka accepts:
 
@@ -208,9 +208,9 @@ For unions with logical primitive types (for example `["null", {"type":"int","lo
 - wrapped primitive values (for example `documentValidTo: { "int": 20474 }`)
 - wrapped logical discriminator values (for example `documentValidTo: { "int.date": 20474 }`)
 
-xk6-kafka normalizes these inputs before Avro encoding so they match the discriminator format expected by `hamba/avro`.
+xk6-kafka normalizes these inputs before Avro encoding so they match the discriminator format expected by `confluent-avro-go`.
 
-**Note**: In your schema, you should define the `null` value first in the union type (e.g., `["null", "string"]` rather than `["string", "null"]`) to follow Avro best practices, though hamba/avro will handle both cases.
+**Note**: In your schema, you should define the `null` value first in the union type (e.g., `["null", "string"]` rather than `["string", "null"]`) to follow Avro best practices, though confluent-avro-go will handle both cases.
 
 In order to help you with complex schemas, you can use the [nested-avro-schema](https://github.com/mostafa/nested-avro-schema) project, which provides a way to define complex Avro schemas in a more structured way.
 

--- a/docs/v2.2.0-subcommand.md
+++ b/docs/v2.2.0-subcommand.md
@@ -39,7 +39,7 @@
 - Validation behavior:
   - Avro:
     - Compile and resolve the schema first.
-    - Validate by running the actual Avro serialize path with `hamba/avro` against the candidate JSON payload.
+    - Validate by running the actual Avro serialize path with `confluent-avro-go` against the candidate JSON payload.
     - Success means the payload serializes successfully with the resolved schema.
   - JSON Schema:
     - Compile and resolve the schema first.

--- a/go.mod
+++ b/go.mod
@@ -7,11 +7,11 @@ require (
 	github.com/Azure/azure-sdk-for-go/sdk/azcore v1.21.0
 	github.com/Azure/azure-sdk-for-go/sdk/azidentity v1.13.1
 	github.com/bufbuild/protocompile v0.14.1
+	github.com/confluentinc/confluent-avro-go/v2 v2.32.0
 	github.com/confluentinc/confluent-kafka-go/v2 v2.14.0
 	github.com/go-viper/mapstructure/v2 v2.5.0
 	github.com/golang-jwt/jwt/v5 v5.3.1
 	github.com/grafana/sobek v0.0.0-20260727154728-7781506a890f
-	github.com/hamba/avro/v2 v2.31.0
 	github.com/pavlo-v-chernykh/keystore-go/v4 v4.5.0
 	github.com/santhosh-tekuri/jsonschema/v5 v5.3.1
 	github.com/sirupsen/logrus v1.9.3

--- a/go.sum
+++ b/go.sum
@@ -92,6 +92,8 @@ github.com/chromedp/sysutil v1.1.0 h1:PUFNv5EcprjqXZD9nJb9b/c9ibAbxiYo4exNWZyipw
 github.com/chromedp/sysutil v1.1.0/go.mod h1:WiThHUdltqCNKGc4gaU50XgYjwjYIhKWoHGPTUfWTJ8=
 github.com/compose-spec/compose-go/v2 v2.1.3 h1:bD67uqLuL/XgkAK6ir3xZvNLFPxPScEi1KW7R5esrLE=
 github.com/compose-spec/compose-go/v2 v2.1.3/go.mod h1:lFN0DrMxIncJGYAXTfWuajfwj5haBJqrBkarHcnjJKc=
+github.com/confluentinc/confluent-avro-go/v2 v2.32.0 h1:PQjdGEaxCGrvdNtXsoMJsfY39WQyfrekEdOsh0e6bT0=
+github.com/confluentinc/confluent-avro-go/v2 v2.32.0/go.mod h1:WfNwYNykGDKOM3WrEqhHDNokB+PBRno5DJqS/cTtAko=
 github.com/confluentinc/confluent-kafka-go/v2 v2.14.0 h1:SCeCsGTKuWwnxTNltvh6fmj1lueTT5J2zvh9s2KYphg=
 github.com/confluentinc/confluent-kafka-go/v2 v2.14.0/go.mod h1:aR1aciwbULyLhKkv9eq88JhS4XmGOusEnHZx1R93XZI=
 github.com/containerd/console v1.0.4 h1:F2g4+oChYvBTsASRTz8NP6iIAi97J3TtSAsLbIFn4ro=
@@ -223,8 +225,6 @@ github.com/grpc-ecosystem/go-grpc-middleware v1.4.0 h1:UH//fgunKIs4JdUbpDl1VZCDa
 github.com/grpc-ecosystem/go-grpc-middleware v1.4.0/go.mod h1:g5qyo/la0ALbONm6Vbp88Yd8NsDy6rZz+RcrMPxvld8=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 h1:5VipnvEpbqr2gA2VbM+nYVbkIF28c5ZQfqCBQ5g2xfk=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0/go.mod h1:Hyl3n6Twe1hvtd9XUXDec4pTvgMSEixRuQKPTMH2bNs=
-github.com/hamba/avro/v2 v2.31.0 h1:wv3nmua7lCEIwWsb6vqsTS3pXktTxcKg5eoyNu0VhrU=
-github.com/hamba/avro/v2 v2.31.0/go.mod h1:t6lJYAGE5Mswfn17zjtyQsssRQgnqO6TXLBCHHWRqrw=
 github.com/hashicorp/errwrap v1.1.0 h1:OxrOeh75EUXMY8TBjag2fzXGZ40LB6IKw45YeGUDY2I=
 github.com/hashicorp/errwrap v1.1.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=

--- a/pkg/kafka/avro.go
+++ b/pkg/kafka/avro.go
@@ -8,7 +8,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/hamba/avro/v2"
+	avro "github.com/confluentinc/confluent-avro-go/v2"
 )
 
 var (
@@ -149,7 +149,7 @@ func getPrimitiveTypeName(schemaType avro.Type) string {
 	}
 }
 
-// getPrimitiveUnionDiscriminator returns the discriminator key expected by hamba/avro
+// getPrimitiveUnionDiscriminator returns the discriminator key expected by confluent-avro-go
 // for a primitive union branch. For logical primitive types, this is typically
 // "<primitive>.<logicalType>" (for example: "int.date").
 func getPrimitiveUnionDiscriminator(schema avro.Schema) string {
@@ -373,9 +373,9 @@ func convertUnionField(fieldValue any, unionSchema *avro.UnionSchema) (any, erro
 			if err != nil {
 				continue
 			}
-			// Arrays are returned unwrapped: hamba/avro encodes a bare slice
+			// Arrays are returned unwrapped: confluent-avro-go encodes a bare slice
 			// with the non-null branch of a nullable union. Maps must be
-			// wrapped by type name: hamba/avro only encodes map[string]any
+			// wrapped by type name: confluent-avro-go only encodes map[string]any
 			// union values in the {"map": value} form.
 			if actualType.Type() == avro.Map {
 				return map[string]any{string(avro.Map): converted}, nil
@@ -546,7 +546,7 @@ func (*AvroSerde) Serialize(data any, schema *Schema) ([]byte, *Xk6KafkaError) {
 			convertErr)
 	}
 
-	// Marshal to binary using hamba/avro
+	// Marshal to binary using confluent-avro-go
 	bytesData, originalErr := avro.Marshal(avroSchema, convertedData)
 	if originalErr != nil {
 		return nil, NewXk6KafkaError(failedToEncodeToBinary,
@@ -558,7 +558,7 @@ func (*AvroSerde) Serialize(data any, schema *Schema) ([]byte, *Xk6KafkaError) {
 }
 
 // unwrapUnionValues recursively unwraps union values that are wrapped in the
-// {"typeName": value} format returned by hamba/avro for named types in unions.
+// {"typeName": value} format returned by confluent-avro-go for named types in unions.
 func unwrapUnionValues(data any, schema avro.Schema) (any, error) {
 	if data == nil {
 		//nolint: nilnil // nil is a valid value

--- a/pkg/kafka/avro_conversion_test.go
+++ b/pkg/kafka/avro_conversion_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/hamba/avro/v2"
+	avro "github.com/confluentinc/confluent-avro-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -455,7 +455,7 @@ func TestConvertUnionField_UnknownWrappedPrimitiveKey(t *testing.T) {
 // shape: a union whose non-null branch is an array of records containing a
 // plain ["null", "int"] union field. The array branch must be recursed into
 // so the nested float64 values become int32, and the value must be returned
-// unwrapped (hamba/avro resolves unnamed composite branches by Go type).
+// unwrapped (confluent-avro-go resolves unnamed composite branches by Go type).
 func TestConvertUnionField_ArrayBranchWithIntUnionItems(t *testing.T) {
 	schemaJSON := `["null", {
 		"type": "array",
@@ -518,7 +518,7 @@ func TestConvertUnionField_ArrayBranchWithIntUnionItems(t *testing.T) {
 // TestConvertUnionField_MapBranch covers unions whose non-null branch is a
 // map: the map branch must be recursed into so nested float64 values become
 // int32/int64, and the value must be returned wrapped as {"map": value}
-// (hamba/avro only encodes map[string]any union values in that form).
+// (confluent-avro-go only encodes map[string]any union values in that form).
 func TestConvertUnionField_MapBranch(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -1147,7 +1147,7 @@ func TestSerializeDeserializeRoundTrip_UnionArrayBranch(t *testing.T) {
 				return
 			}
 
-			// hamba/avro decodes unnamed composite union branches (array/map)
+			// confluent-avro-go decodes unnamed composite union branches (array/map)
 			// into a type-name-wrapped map; accept that form until decode-side
 			// unwrapping is addressed separately.
 			linesValue := result["lines"]
@@ -1212,7 +1212,7 @@ func TestSerializeDeserializeRoundTrip_UnionMapBranch(t *testing.T) {
 	require.NotNil(t, deserialized, "Deserialized data should not be nil")
 
 	result := deserialized.(map[string]any)
-	// hamba/avro decodes unnamed composite union branches (array/map) into a
+	// confluent-avro-go decodes unnamed composite union branches (array/map) into a
 	// type-name-wrapped map; accept that form until decode-side unwrapping is
 	// addressed separately.
 	countsValue := result["counts"]
@@ -1241,7 +1241,7 @@ func TestAvroMarshal_UnionLogicalTypeDateAcceptedShapes(t *testing.T) {
 	schema, err := avro.Parse(testDocumentLogicalDateSchemaJSON)
 	require.NoError(t, err)
 
-	// Direct int32 value is rejected by hamba/avro for this logical union shape.
+	// Direct int32 value is rejected by confluent-avro-go for this logical union shape.
 	_, err = avro.Marshal(schema, map[string]any{"documentValidTo": int32(20474)})
 	assert.Error(t, err)
 

--- a/pkg/kafka/avro_edge_test.go
+++ b/pkg/kafka/avro_edge_test.go
@@ -3,7 +3,7 @@ package kafka
 import (
 	"testing"
 
-	"github.com/hamba/avro/v2"
+	avro "github.com/confluentinc/confluent-avro-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/pkg/kafka/schema_registry.go
+++ b/pkg/kafka/schema_registry.go
@@ -11,9 +11,9 @@ import (
 	"net/http"
 	"strings"
 
+	avro "github.com/confluentinc/confluent-avro-go/v2"
 	cschemaregistry "github.com/confluentinc/confluent-kafka-go/v2/schemaregistry"
 	"github.com/grafana/sobek"
-	"github.com/hamba/avro/v2"
 	"github.com/santhosh-tekuri/jsonschema/v5"
 	"github.com/sirupsen/logrus"
 	"go.k6.io/k6/v2/js/common"

--- a/pkg/kafka/schema_registry_resolver_test.go
+++ b/pkg/kafka/schema_registry_resolver_test.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/hamba/avro/v2"
+	avro "github.com/confluentinc/confluent-avro-go/v2"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/scripts/test_avro_complex_schema.js
+++ b/scripts/test_avro_complex_schema.js
@@ -1,7 +1,7 @@
 /*
  * This is a comprehensive k6 test script that tests Kafka with complex Avro schemas
  * including nested records, unions, arrays, maps, enums, fixed types, and combinations thereof.
- * This script demonstrates the full capabilities of the hamba/avro library.
+ * This script demonstrates the full capabilities of the confluent-avro-go library.
  *
  * NESTED SCHEMA REFERENCES:
  * This script uses Schema Registry references to demonstrate nested schemas. Instead of
@@ -532,7 +532,7 @@ export default function (data) {
           ? null
           : {
               // Union type: null or Order record
-              // Pass the Order record directly - hamba/avro will match it to the union type
+              // Pass the Order record directly - confluent-avro-go will match it to the union type
               orderId: `order-${index}`,
               items: [
                 {
@@ -571,7 +571,7 @@ export default function (data) {
           ? null
           : {
               // Union type: null or Coordinates record
-              // Pass the Coordinates record directly - hamba/avro will match it to the union type
+              // Pass the Coordinates record directly - confluent-avro-go will match it to the union type
               latitude: 40.7128 + index * 0.001,
               longitude: -74.006 + index * 0.001,
             },


### PR DESCRIPTION
## Summary

hamba/avro is archived and unmaintained. This PR swaps it for [confluent-avro-go](https://github.com/confluentinc/confluent-avro-go) (v2.32.0), Confluent's maintained fork that continues the hamba v2 line and powers confluent-kafka-go's own Schema Registry Avro serde — the same Kafka client library xk6-kafka ships, so our wire behavior stays aligned with Confluent's serde by construction.

## Due diligence: fork vs hamba v2.31.0 (our pinned version)

File-by-file diff of the two modules:

| File | Delta |
| --- | --- |
| `codec_union.go`, `resolver.go`, `config.go`, `decoder.go`, `encoder.go` | **byte-identical** — every behavior we depend on is preserved |
| `schema.go` | import-path rename only |
| `reader.go` | endianness-safety fix (unsafe pointer cast → `binary.LittleEndian`) |
| rest | test import renames, CI/metadata |

Our Avro test suite encodes the full behavioral contract (wrapped union maps, `int.date` discriminators, nullable-union bare slices, resolver decode envelopes, logical types, bytes/fixed conversion) and passes unchanged.

## Alternatives considered

[twmb/avro](https://github.com/twmb/avro) (v1.9.0, actively maintained): a modern rewrite with schema evolution (`Resolve`/`CheckCompatibility`), OCF, single-object encoding, schema-aware JSON, and native `float64`→`int32` coercion that could eventually replace our `convertFloat64ToIntForIntegerFields` layer. However, it has a completely different API (`SchemaNode` introspection, different union defaults and branch naming), so adopting it means rewriting and re-verifying the entire conversion layer for features xk6-kafka does not use today. It also started in Jan 2026 with a single maintainer, whereas the fork is battle-tested hamba code under corporate maintenance.

## Changes

- `go.mod`: `github.com/hamba/avro/v2 v2.31.0` → `github.com/confluentinc/confluent-avro-go/v2 v2.32.0`
- Import path swap in `avro.go`, `schema_registry.go` and the three Avro test files (package name is `avro` in both — no code changes)
- Doc/comment reference updates (README, schema-registry.md, v2.2.0-subcommand.md, complex-schema script)

## Verification

- `go build ./...`, `go vet`, gofmt/goimports clean, `golangci-lint run`: 0 issues
- Full `CGO_ENABLED=1 go test ./... -race` against a live Kafka + Schema Registry: pass

No behavior changes; not a breaking change.
