### PR TITLE
perf: restore producer throughput in compat produce config decode

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you want to learn more about the extension, read the [article](https://grafan
 
 ## Supported Features
 
-- **v2.0.0 Performance**: Up to ~383,000 msgs/sec (unacked) with 50 VUs using new `Producer`/`Consumer` constructors with `confluentinc/confluent-kafka-go` (**~3.3x faster than the current v1.x.x/main branch**, which reaches ~115,637 msgs/sec on the same `scripts/test_json.js` benchmark and machine)
+- **Performance**: Up to ~382,000 msgs/sec (unacked) with 50 VUs using the `Producer`/`Consumer` constructors backed by `confluentinc/confluent-kafka-go` (**~3.3x faster than the `v1.x.x` branch**, which reaches ~115,637 msgs/sec on the same `scripts/test_json.js` benchmark and machine)
 - Produce/consume messages as [String](https://github.com/mostafa/xk6-kafka/blob/main/scripts/test_string.js), [JSON](https://github.com/mostafa/xk6-kafka/blob/main/scripts/test_json.js), [ByteArray](https://github.com/mostafa/xk6-kafka/blob/main/scripts/test_bytes.js), [Avro](https://github.com/mostafa/xk6-kafka/blob/main/scripts/test_avro_with_schema_registry.js), [JSON Schema](https://github.com/mostafa/xk6-kafka/blob/main/scripts/test_jsonschema_with_schema_registry.js), and [Protobuf](https://github.com/mostafa/xk6-kafka/blob/main/scripts/test_protobuf_with_schema_registry.js) formats
 - Support for user-provided [Avro](https://github.com/mostafa/xk6-kafka/blob/main/scripts/test_avro_no_schema_registry.js) and JSON Schema key and value schemas in the script
 - Authentication with [SASL PLAIN, SCRAM, SSL and AWS IAM](https://github.com/mostafa/xk6-kafka/blob/main/scripts/test_sasl_auth.js), plus [Azure Entra OAuth for Event Hub](https://github.com/mostafa/xk6-kafka/blob/main/scripts/test_azure_event_hub.js) and [GCP OAuth for GCP Kafka](https://github.com/mostafa/xk6-kafka/blob/main/scripts/test_gcp_kafka.js)
@@ -398,16 +398,17 @@ For v2.0.0+ examples using the new constructors (`Producer`, `Consumer`, `AdminC
    ./k6 run --vus 50 --duration 60s scripts/test_json.js
    ```
 
-6. On the same machine and with the same `scripts/test_json.js` workload, the current `v1.x.x/main` branch reaches `115,637.233495 msg/s`, while `v2.0.0` reaches `383,331.650997 msg/s`, which is about `3.3x` higher throughput.
+6. On the same machine and with the same `scripts/test_json.js` workload, the `v1.x.x` branch reaches `115,637.233495 msg/s`, while the current version reaches `372,484.757665 msg/s`, which is about `3.2x` higher throughput.
 
-7. And here's the `v2.0.0` test result output:
+7. And here's the test result output on `main` (with the v2.1.0 throughput fix):
 
    ```bash
-               /\      Grafana   /‾‾/
-          /\  /  \     |\  __   /  /
-         /  \/    \    | |/ /  /   ‾‾\
-        /          \   |   (  |  (‾)  |
-       / __________ \  |_|\_\  \_____/
+
+            /\      Grafana   /‾‾/
+       /\  /  \     |\  __   /  /
+      /  \/    \    | |/ /  /   ‾‾\
+     /          \   |   (  |  (‾)  |
+    / __________ \  |_|\_\  \_____/
 
 
         execution: local
@@ -419,75 +420,75 @@ For v2.0.0+ examples using the new constructors (`Producer`, `Consumer`, `AdminC
 
 
 
-      █ THRESHOLDS
+     █ THRESHOLDS
 
-        kafka_reader_error_count
-        ✓ 'count == 0' count=0
+       kafka_reader_error_count
+       ✓ 'count == 0' count=0
 
-        kafka_writer_error_count
-        ✓ 'count == 0' count=0
+       kafka_writer_error_count
+       ✓ 'count == 0' count=0
 
 
-      █ TOTAL RESULTS 
+     █ TOTAL RESULTS
 
-      checks_total.......: 1073889 17249.924295/s
-      checks_succeeded...: 100.00% 1073889 out of 1073889
-      checks_failed......: 0.00%   0 out of 1073889
+       checks_total.......: 1045215 16761.814095/s
+       checks_succeeded...: 100.00% 1045215 out of 1045215
+       checks_failed......: 0.00%   0 out of 1045215
 
-      ✓ 10 messages are received
-      ✓ Topic equals to xk6_kafka_json_topic
-      ✓ Key contains key/value and is JSON
-      ✓ Value contains key/value and is JSON
-      ✓ Header equals {'mykey': 'myvalue'}
-      ✓ Time is past
-      ✓ Partition is zero
-      ✓ Offset is gte zero
-      ✓ High watermark is gte zero
+       ✓ 10 messages are received
+       ✓ Topic equals to xk6_kafka_json_topic
+       ✓ Key contains key/value and is JSON
+       ✓ Value contains key/value and is JSON
+       ✓ Header equals {'mykey': 'myvalue'}
+       ✓ Time is past
+       ✓ Partition is zero
+       ✓ Offset is gte zero
+       ✓ High watermark is gte zero
 
-      CUSTOM
-      kafka_reader_dial_count............: 119321   1916.658255/s
-      kafka_reader_dial_seconds..........: avg=0s      min=0s      med=0s      max=0s       p(90)=0s      p(95)=0s     
-      kafka_reader_error_count...........: 0        0/s
-      kafka_reader_fetch_bytes...........: 274 MB   4.4 MB/s
-      kafka_reader_fetch_bytes_max.......: 0        min=0             max=0    
-      kafka_reader_fetch_bytes_min.......: 0        min=0             max=0    
-      kafka_reader_fetch_size............: 1193210  19166.58255/s
-      kafka_reader_fetch_wait_max........: 0s       min=0s            max=0s   
-      kafka_reader_fetches_count.........: 1312531  21083.240805/s
-      kafka_reader_lag...................: 0        min=0             max=0    
-      kafka_reader_message_bytes.........: 274 MB   4.4 MB/s
-      kafka_reader_message_count.........: 1193210  19166.58255/s
-      kafka_reader_offset................: 23779    min=9             max=24819
-      kafka_reader_queue_capacity........: 0        min=0             max=0    
-      kafka_reader_queue_length..........: 0        min=0             max=0    
-      kafka_reader_read_seconds..........: avg=43.03µs min=11.08µs med=18.45µs max=81.67ms  p(90)=41.12µs p(95)=58.08µs
-      kafka_reader_rebalance_count.......: 0        0/s
-      kafka_reader_timeouts_count........: 0        0/s
-      kafka_reader_wait_seconds..........: avg=0s      min=0s      med=0s      max=0s       p(90)=0s      p(95)=0s     
-      kafka_writer_acks_required.........: 0        min=0             max=0    
-      kafka_writer_async.................: 0.00%    0 out of 11932100
-      kafka_writer_attempts_max..........: 0        min=0             max=0    
-      kafka_writer_batch_bytes...........: 2.8 GB   44 MB/s
-      kafka_writer_batch_max.............: 0        min=0             max=0    
-      kafka_writer_batch_queue_seconds...: avg=0s      min=0s      med=0s      max=0s       p(90)=0s      p(95)=0s     
-      kafka_writer_batch_seconds.........: avg=2.67µs  min=437ns   med=729ns   max=30.61ms  p(90)=1.6µs   p(95)=2.04µs 
-      kafka_writer_batch_size............: 11932100 191665.825499/s
-      kafka_writer_batch_timeout.........: 0s       min=0s            max=0s   
-      kafka_writer_error_count...........: 0        0/s
-      kafka_writer_message_bytes.........: 5.5 GB   89 MB/s
-      kafka_writer_message_count.........: 23864200 383331.650997/s
-      kafka_writer_read_timeout..........: 0s       min=0s            max=0s   
-      kafka_writer_retries_count.........: 0        0/s
-      kafka_writer_wait_seconds..........: avg=0s      min=0s      med=0s      max=0s       p(90)=0s      p(95)=0s     
-      kafka_writer_write_count...........: 23864200 383331.650997/s
-      kafka_writer_write_seconds.........: avg=5.35µs  min=875ns   med=1.45µs  max=61.23ms  p(90)=3.2µs   p(95)=4.08µs 
-      kafka_writer_write_timeout.........: 0s       min=0s            max=0s   
+       CUSTOM
+       kafka_reader_dial_count............: 116135   1862.423788/s
+       kafka_reader_dial_seconds..........: avg=0s      min=0s     med=0s      max=0s      p(90)=0s      p(95)=0s
+       kafka_reader_error_count...........: 0        0/s
+       kafka_reader_fetch_bytes...........: 267 MB   4.3 MB/s
+       kafka_reader_fetch_bytes_max.......: 0        min=0             max=0
+       kafka_reader_fetch_bytes_min.......: 0        min=0             max=0
+       kafka_reader_fetch_size............: 1161350  18624.237883/s
+       kafka_reader_fetch_wait_max........: 0s       min=0s            max=0s
+       kafka_reader_fetches_count.........: 1277485  20486.661672/s
+       kafka_reader_lag...................: 0        min=0             max=0
+       kafka_reader_message_bytes.........: 267 MB   4.3 MB/s
+       kafka_reader_message_count.........: 1161350  18624.237883/s
+       kafka_reader_offset................: 22989    min=9             max=24219
+       kafka_reader_queue_capacity........: 0        min=0             max=0
+       kafka_reader_queue_length..........: 0        min=0             max=0
+       kafka_reader_read_seconds..........: avg=46.92µs min=11.5µs med=20.29µs max=82.09ms p(90)=46.16µs p(95)=65.29µs
+       kafka_reader_rebalance_count.......: 0        0/s
+       kafka_reader_timeouts_count........: 0        0/s
+       kafka_reader_wait_seconds..........: avg=0s      min=0s     med=0s      max=0s      p(90)=0s      p(95)=0s
+       kafka_writer_acks_required.........: 0        min=0             max=0
+       kafka_writer_async.................: 0.00%    0 out of 11613500
+       kafka_writer_attempts_max..........: 0        min=0             max=0
+       kafka_writer_batch_bytes...........: 2.7 GB   43 MB/s
+       kafka_writer_batch_max.............: 0        min=0             max=0
+       kafka_writer_batch_queue_seconds...: avg=0s      min=0s     med=0s      max=0s      p(90)=0s      p(95)=0s
+       kafka_writer_batch_seconds.........: avg=2.93µs  min=458ns  med=895ns   max=27.75ms p(90)=1.68µs  p(95)=2.16µs
+       kafka_writer_batch_size............: 11613500 186242.378832/s
+       kafka_writer_batch_timeout.........: 0s       min=0s            max=0s
+       kafka_writer_error_count...........: 0        0/s
+       kafka_writer_message_bytes.........: 5.4 GB   86 MB/s
+       kafka_writer_message_count.........: 23227000 372484.757665/s
+       kafka_writer_read_timeout..........: 0s       min=0s            max=0s
+       kafka_writer_retries_count.........: 0        0/s
+       kafka_writer_wait_seconds..........: avg=0s      min=0s     med=0s      max=0s      p(90)=0s      p(95)=0s
+       kafka_writer_write_count...........: 23227000 372484.757665/s
+       kafka_writer_write_seconds.........: avg=5.87µs  min=916ns  med=1.79µs  max=55.5ms  p(90)=3.37µs  p(95)=4.33µs
+       kafka_writer_write_timeout.........: 0s       min=0s            max=0s
 
-      EXECUTION
-      iteration_duration.................: avg=25.07ms min=2.49ms  med=14.17ms max=446.15ms p(90)=61.86ms p(95)=85.65ms
-      iterations.........................: 119321   1916.658255/s
-      vus................................: 50       min=0             max=50   
-      vus_max............................: 50       min=50            max=50
+       EXECUTION
+       iteration_duration.................: avg=25.76ms min=2.42ms med=14.69ms max=355.7ms p(90)=63.5ms  p(95)=87.31ms
+       iterations.........................: 116135   1862.423788/s
+       vus................................: 50       min=0             max=50
+       vus_max............................: 50       min=50            max=50
 
        NETWORK
        data_received......................: 0 B      0 B/s
@@ -496,9 +497,14 @@ For v2.0.0+ examples using the new constructors (`Producer`, `Consumer`, `AdminC
 
 
 
-   running (1m02.1s), 00/50 VUs, 117079 complete and 0 interrupted iterations
-   default ✓ [======================================] 50 VUs  1m0s
+   running (1m02.4s), 00/50 VUs, 116135 complete and 0 interrupted iterations
+   default ✓ [ 100% ] 50 VUs  1m0s
    ```
+
+   > [!NOTE]
+   > The `v2.1.0` release shipped with a producer throughput regression that roughly
+   > halved the throughput shown above (produce-config decode path). It is fixed on
+   > `main` and in the upcoming release.
 
 </details>
 

--- a/pkg/kafka/writer.go
+++ b/pkg/kafka/writer.go
@@ -3,7 +3,6 @@ package kafka
 import (
 	"errors"
 	"fmt"
-	"reflect"
 	"time"
 
 	"github.com/go-viper/mapstructure/v2"
@@ -201,51 +200,80 @@ func (k *Kafka) compatProducerClass(call sobek.ConstructorCall) *sobek.Object {
 	return runtime.ToValue(producerObject).ToObject(runtime)
 }
 
+// decodeProduceConfig decodes a produce config from JS. It uses the fast
+// JSON round-trip path (decodeArgumentMap) after normalizing message key/value
+// payloads in the exported map: plain strings and number arrays are converted
+// to []byte first, so they survive the base64 semantics encoding/json applies
+// to []byte fields. A previous implementation used a mapstructure decoder with
+// a per-field reflection hook, which roughly halved producer throughput.
 func decodeProduceConfig(runtime *sobek.Runtime, value sobek.Value) *ProduceConfig {
 	params := exportArgumentMap(runtime, value, "produce config")
 	if params == nil {
 		return nil
 	}
 
+	normalizeProduceMessagePayloads(runtime, params)
+
 	var produceConfig ProduceConfig
-	decoder, err := mapstructure.NewDecoder(&mapstructure.DecoderConfig{
-		Result: &produceConfig,
-		DecodeHook: func(from reflect.Type, to reflect.Type, data any) (any, error) {
-			if to == reflect.TypeFor[[]byte]() {
-				switch v := data.(type) {
-				case string:
-					return []byte(v), nil
-				case []any:
-					bytes := make([]byte, len(v))
-					for i, value := range v {
-						number, ok := value.(float64)
-						if !ok {
-							return nil, fmt.Errorf(
-								"%w at index %d, got %T",
-								errExpectedNumericByte,
-								i,
-								value,
-							)
-						}
-						bytes[i] = byte(number)
-					}
-					return bytes, nil
-				}
-			}
-			return data, nil
-		},
-	})
-	if err != nil {
-		throwConfigError(runtime, newInvalidConfigError("produce config", err))
-		return nil
-	}
-
-	if err := decoder.Decode(params); err != nil {
-		throwConfigError(runtime, newInvalidConfigError("produce config", err))
-		return nil
-	}
-
+	decodeArgumentMap(runtime, params, &produceConfig, "produce config")
 	return &produceConfig
+}
+
+// normalizeProduceMessagePayloads converts JS string and number-array
+// key/value payloads in an exported produce config map to []byte in place.
+// The exported messages are []any for script-created values and
+// []map[string]any for Go-created ones (for example tests using ToValue).
+func normalizeProduceMessagePayloads(runtime *sobek.Runtime, params map[string]any) {
+	switch messages := params["messages"].(type) {
+	case []any:
+		for _, message := range messages {
+			if messageMap, ok := message.(map[string]any); ok {
+				normalizeProduceMessagePayload(runtime, messageMap)
+			}
+		}
+	case []map[string]any:
+		for _, messageMap := range messages {
+			normalizeProduceMessagePayload(runtime, messageMap)
+		}
+	}
+}
+
+// normalizeProduceMessagePayload normalizes the key and value of a single
+// exported message map in place.
+func normalizeProduceMessagePayload(runtime *sobek.Runtime, messageMap map[string]any) {
+	for _, field := range []string{"key", "value"} {
+		payload, exists := messageMap[field]
+		if !exists {
+			continue
+		}
+		converted, err := toRawBytes(payload)
+		if err != nil {
+			throwConfigError(runtime, newInvalidConfigError("produce config", err))
+			return
+		}
+		messageMap[field] = converted
+	}
+}
+
+// toRawBytes converts string and []any payloads to raw bytes; anything else
+// (including []byte and nil) passes through unchanged.
+func toRawBytes(payload any) (any, error) {
+	switch v := payload.(type) {
+	case string:
+		return []byte(v), nil
+	case []any:
+		bytes := make([]byte, len(v))
+		for i, value := range v {
+			number, ok := value.(float64)
+			if !ok {
+				return nil, fmt.Errorf("%w at index %d, got %T", errExpectedNumericByte, i, value)
+			}
+			bytes[i] = byte(number)
+		}
+		return bytes, nil
+	default:
+		return payload, nil
+	}
 }
 
 func validateConfluentWriterCompatibility(writerConfig *WriterConfig) *Xk6KafkaError {


### PR DESCRIPTION
## Summary

The README benchmark (`scripts/test_json.js`, 50 VUs, 60s, unacked) dropped from **~373k msg/s** (v2.0.0 tag) to **~208k msg/s** on current main — a ~45% producer throughput regression. `git bisect` with an automated build+benchmark script identified #389 (the v2 protobuf serde PR) as the culprit: it replaced the produce-config decode with a `mapstructure` decoder using a per-field reflection hook. That double reflection walk (JS export to untyped map, then mapstructure decode) runs on **every** `produce()` call.

This PR restores the fast JSON round-trip decode while keeping #389's plain-string-payload fix, and refreshes the README benchmark numbers.

## Root cause

Per `produce()` call, the old path did `value.Export()` → `json.Marshal` → `json.Unmarshal` (fast, optimized stdlib paths). #389 replaced it with `value.Export()` → `mapstructure.NewDecoder` + `DecodeHook` firing per field — roughly 2× slower per call, which at 100 calls/iteration halved benchmark throughput.

## Fix

`decodeProduceConfig` now:

1. Exports the JS value once (`exportArgumentMap`, as before).
2. Normalizes message `key`/`value` payloads **in place**: JS strings and number arrays become `[]byte` (`normalizeProduceMessagePayloads` / `toRawBytes`), so they survive the base64 semantics `encoding/json` applies to `[]byte` fields — this preserves #389's fix for plain string payloads.
3. Decodes via the proven JSON round-trip (`decodeArgumentMap`).

Both export shapes are handled: `[]any` (script-created values) and `[]map[string]any` (Go-created values, e.g. tests using `ToValue`) — the latter is covered by `TestJSCompatibilityConstructorsWithMockCluster`.

## Measurements (same machine, same container, same script)

| Build | Throughput |
| --- | --- |
| `v2.0.0` tag | 373,346 msg/s |
| `main` before this fix (3 runs) | 205,826 – 210,907 msg/s |
| k6 v1.7.1 vs v2.2.0 A/B (#393 exonerated) | 207,967 / 203,078 msg/s |
| `main` + this fix | 296k–382k msg/s (hot vs cool machine); final captured run **372,485 msg/s** |

The regression shipped in **v2.1.0** only (v2.0.0 is clean; verified via `git merge-base --is-ancestor`).

## README refresh

- Benchmark figures re-measured today (372,485 msg/s in the captured run; up to ~382k observed), sample output block replaced with today's run
- Fixed stale framing (`v1.x.x/main` branch → `v1.x.x` branch; `main` is v2 now)
- Added a note documenting the v2.1.0 regression

## Verification

- Full `CGO_ENABLED=1 go test ./... -race` against a live broker: pass
- `golangci-lint run`: 0 issues; gofmt/goimports clean
- Compat tests covering plain-string produce payloads: pass
